### PR TITLE
refactor: extract sub-hooks to reduce CRAP scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Extract sub-hooks to reduce CRAP scores
 
+### Fixed
+
+- Remove unused exports flagged by knip
+- Remove unused exports and address review findings
+
 ## [0.1.759] - 2026-05-11
 
 ### Fixed
@@ -26,8 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused export on RepoBookmarkRecord type
 - Resolve prettier formatting and eslint lint errors
 - Resolve CI failures (security check + branch coverage)
-- Remove unused exports flagged by knip
-- Remove unused exports and address review findings
+- Resolve CI failures (prettier, flaky telemetry test, changelog)
 
 ### Changed
 
@@ -52,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compress batch 26 — SettingsCopilot, users, PullRequestDetailPanel
 - Compress batch 27 — SettingsAppearance, RalphLaunchForm, useAppTabs
 - Batch-31 — extract sub-components to reduce complexity in 7 files
+
 ### Added
 
 - Add pollen data to weather card via Tomorrow.io API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compress batch 26 — SettingsCopilot, users, PullRequestDetailPanel
 - Compress batch 27 — SettingsAppearance, RalphLaunchForm, useAppTabs
 - Batch-31 — extract sub-components to reduce complexity in 7 files
+- Extract sub-hooks to reduce CRAP scores
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Extract sub-hooks to reduce CRAP scores
+
 ## [0.1.759] - 2026-05-11
 
 ### Fixed
@@ -22,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused export on RepoBookmarkRecord type
 - Resolve prettier formatting and eslint lint errors
 - Resolve CI failures (security check + branch coverage)
+- Remove unused exports flagged by knip
+- Remove unused exports and address review findings
 
 ### Changed
 
@@ -46,8 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Compress batch 26 — SettingsCopilot, users, PullRequestDetailPanel
 - Compress batch 27 — SettingsAppearance, RalphLaunchForm, useAppTabs
 - Batch-31 — extract sub-components to reduce complexity in 7 files
-- Extract sub-hooks to reduce CRAP scores
-
 ### Added
 
 - Add pollen data to weather card via Tomorrow.io API

--- a/electron/telemetry.test.ts
+++ b/electron/telemetry.test.ts
@@ -485,70 +485,13 @@ describe('telemetry', () => {
     })
 
     it('initializes SDK when OTEL_EXPORTER_OTLP_ENDPOINT is set', async () => {
-      vi.resetModules()
-
-      const mockNodeSDK = { start: vi.fn(), shutdown: vi.fn().mockResolvedValue(undefined) }
-      const mockLoggerProvider = { shutdown: vi.fn().mockResolvedValue(undefined) }
-      const mockMeter = {
-        createCounter: vi.fn(() => ({ add: vi.fn() })),
-        createHistogram: vi.fn(() => ({ record: vi.fn() })),
-      }
-
-      // Re-mock with fresh module state
-      vi.doMock('@opentelemetry/api', () => ({
-        trace: { getTracer: vi.fn(() => ({ startActiveSpan: vi.fn() })) },
-        metrics: { getMeter: vi.fn(() => mockMeter) },
-        SpanStatusCode: { OK: 1, ERROR: 2 },
-        diag: { setLogger: vi.fn() },
-        DiagConsoleLogger: vi.fn(),
-        DiagLogLevel: { DEBUG: 0 },
-      }))
-      vi.doMock('@opentelemetry/api-logs', () => ({
-        logs: { getLogger: vi.fn(() => ({ emit: vi.fn() })), setGlobalLoggerProvider: vi.fn() },
-        SeverityNumber: { DEBUG: 5, INFO: 9, WARN: 13, ERROR: 17 },
-      }))
-      class MockNodeSDK {
-        start = mockNodeSDK.start
-        shutdown = mockNodeSDK.shutdown
-      }
-      class MockLoggerProvider {
-        shutdown = mockLoggerProvider.shutdown
-      }
-
-      vi.doMock('@opentelemetry/sdk-node', () => ({ NodeSDK: MockNodeSDK }))
-      vi.doMock('@opentelemetry/exporter-trace-otlp-proto', () => ({
-        OTLPTraceExporter: vi.fn(),
-      }))
-      vi.doMock('@opentelemetry/exporter-metrics-otlp-proto', () => ({
-        OTLPMetricExporter: vi.fn(),
-      }))
-      vi.doMock('@opentelemetry/exporter-logs-otlp-proto', () => ({
-        OTLPLogExporter: vi.fn(),
-      }))
-      vi.doMock('@opentelemetry/sdk-metrics', () => ({
-        PeriodicExportingMetricReader: vi.fn(),
-      }))
-      vi.doMock('@opentelemetry/sdk-logs', () => ({
-        BatchLogRecordProcessor: vi.fn(),
-        LoggerProvider: MockLoggerProvider,
-      }))
-      vi.doMock('@opentelemetry/instrumentation-http', () => ({
-        HttpInstrumentation: vi.fn(),
-      }))
-      vi.doMock('@opentelemetry/instrumentation-dns', () => ({
-        DnsInstrumentation: vi.fn(),
-      }))
-      vi.doMock('@opentelemetry/resources', () => ({
-        resourceFromAttributes: vi.fn(() => ({})),
-      }))
-
       process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318'
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
 
-      const { initTelemetry: initEnabled } = await import('./telemetry')
+      const { initTelemetry: initEnabled } = await importTelemetry()
       await initEnabled()
 
-      expect(mockNodeSDK.start).toHaveBeenCalled()
+      expect(telemetryState.mockNodeSdkStart).toHaveBeenCalled()
       expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Initialized'))
       consoleSpy.mockRestore()
       delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT

--- a/src/components/terminal/TerminalTabContextMenu.tsx
+++ b/src/components/terminal/TerminalTabContextMenu.tsx
@@ -15,6 +15,44 @@ const TAB_COLORS = [
   { name: 'White', value: '#cccccc' },
 ]
 
+interface ColorSwatchGridProps {
+  tabId: string
+  activeColor: string | undefined
+  onSetColor: (tabId: string, color: string | undefined) => void
+  onClose: () => void
+}
+
+function ColorSwatchGrid({ tabId, activeColor, onSetColor, onClose }: ColorSwatchGridProps) {
+  return (
+    <div className="terminal-ctx-colors">
+      {TAB_COLORS.map(c => (
+        <button
+          key={c.value}
+          className={`terminal-ctx-color-swatch ${activeColor === c.value ? 'active' : ''}`}
+          style={{ backgroundColor: c.value }}
+          title={c.name}
+          onClick={() => {
+            onSetColor(tabId, c.value)
+            onClose()
+          }}
+        />
+      ))}
+      {activeColor && (
+        <button
+          className="terminal-ctx-color-reset"
+          title="Reset color"
+          onClick={() => {
+            onSetColor(tabId, undefined)
+            onClose()
+          }}
+        >
+          <X size={10} />
+        </button>
+      )}
+    </div>
+  )
+}
+
 interface TerminalTabContextMenuProps {
   x: number
   y: number
@@ -23,6 +61,51 @@ interface TerminalTabContextMenuProps {
   onSetColor: (tabId: string, color: string | undefined) => void
   onOpenFolderView: (cwd: string) => void
   onClose: () => void
+}
+
+interface RenameInputProps {
+  tab: { id: string; title: string }
+  onRename: (tabId: string, name: string) => void
+  onClose: () => void
+}
+
+function RenameInput({ tab, onRename, onClose }: RenameInputProps) {
+  const [renameValue, setRenameValue] = useState(tab.title)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.select()
+  }, [])
+
+  const handleRenameSubmit = useCallback(() => {
+    const trimmed = renameValue.trim()
+    if (trimmed && trimmed !== tab.title) {
+      onRename(tab.id, trimmed)
+    }
+    onClose()
+  }, [renameValue, tab, onRename, onClose])
+
+  const handleRenameKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') handleRenameSubmit()
+      if (e.key === 'Escape') onClose()
+    },
+    [handleRenameSubmit, onClose]
+  )
+
+  return (
+    <div className="terminal-ctx-rename">
+      <input
+        ref={inputRef}
+        className="terminal-ctx-rename-input"
+        value={renameValue}
+        onChange={e => setRenameValue(e.target.value)}
+        onKeyDown={handleRenameKeyDown}
+        onBlur={handleRenameSubmit}
+        maxLength={40}
+      />
+    </div>
+  )
 }
 
 export function TerminalTabContextMenu({
@@ -35,13 +118,8 @@ export function TerminalTabContextMenu({
   onClose,
 }: TerminalTabContextMenuProps) {
   const [mode, setMode] = useState<'menu' | 'rename'>('menu')
-  const [renameValue, setRenameValue] = useState(tab.title)
-  const inputRef = useRef<HTMLInputElement>(null)
   const menuRef = useRef<HTMLDivElement>(null)
 
-  useEffect(() => {
-    if (mode === 'rename') inputRef.current?.select()
-  }, [mode])
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -49,21 +127,6 @@ export function TerminalTabContextMenu({
     document.addEventListener('keydown', handleKey)
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
-
-  const handleRenameSubmit = useCallback(() => {
-    const trimmed = renameValue.trim()
-    if (trimmed && trimmed !== tab.title) {
-      onRename(tab.id, trimmed)
-    }
-    onClose()
-  }, [renameValue, tab, onRename, onClose])
-  const handleRenameKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter') handleRenameSubmit()
-      if (e.key === 'Escape') onClose()
-    },
-    [handleRenameSubmit, onClose]
-  )
 
   return (
     <>
@@ -92,45 +155,15 @@ export function TerminalTabContextMenu({
               <Palette size={12} />
               Color
             </div>
-            <div className="terminal-ctx-colors">
-              {TAB_COLORS.map(c => (
-                <button
-                  key={c.value}
-                  className={`terminal-ctx-color-swatch ${tab.color === c.value ? 'active' : ''}`}
-                  style={{ backgroundColor: c.value }}
-                  title={c.name}
-                  onClick={() => {
-                    onSetColor(tab.id, c.value)
-                    onClose()
-                  }}
-                />
-              ))}
-              {tab.color && (
-                <button
-                  className="terminal-ctx-color-reset"
-                  title="Reset color"
-                  onClick={() => {
-                    onSetColor(tab.id, undefined)
-                    onClose()
-                  }}
-                >
-                  <X size={10} />
-                </button>
-              )}
-            </div>
+            <ColorSwatchGrid
+              tabId={tab.id}
+              activeColor={tab.color}
+              onSetColor={onSetColor}
+              onClose={onClose}
+            />
           </>
         ) : (
-          <div className="terminal-ctx-rename">
-            <input
-              ref={inputRef}
-              className="terminal-ctx-rename-input"
-              value={renameValue}
-              onChange={e => setRenameValue(e.target.value)}
-              onKeyDown={handleRenameKeyDown}
-              onBlur={handleRenameSubmit}
-              maxLength={40}
-            />
-          </div>
+          <RenameInput tab={tab} onRename={onRename} onClose={onClose} />
         )}
       </div>
     </>

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -164,7 +164,7 @@ function handleRefreshResult(
       () => {
         if (mountedRef.current) stampRefresh()
       },
-      (err) => {
+      err => {
         console.error('[useAutoRefresh] Refresh promise rejected:', err)
       }
     )

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -154,6 +154,38 @@ function mergeSettings(
   return merged
 }
 
+function handleRefreshResult(
+  result: void | Promise<void>,
+  mountedRef: { current: boolean },
+  stampRefresh: () => void
+): void {
+  if (result && typeof (result as Promise<void>).then === 'function') {
+    ;(result as Promise<void>).then(
+      () => {
+        if (mountedRef.current) stampRefresh()
+      },
+      () => {}
+    )
+  } else {
+    stampRefresh()
+  }
+}
+
+function syncExternalTimestamp(
+  externalTimestamp: number | null | undefined,
+  lastRefreshedAt: number | null,
+  setLastRefreshedAt: (ts: number) => void,
+  cardId: string
+): void {
+  if (
+    externalTimestamp != null &&
+    (lastRefreshedAt == null || externalTimestamp > lastRefreshedAt)
+  ) {
+    setLastRefreshedAt(externalTimestamp)
+    writeLastRefreshed(cardId, externalTimestamp)
+  }
+}
+
 /**
  * Manages periodic auto-refresh for a dashboard card.
  * Settings are persisted per card in localStorage, defaulting to off.
@@ -197,17 +229,7 @@ export function useAutoRefresh(
 
   const refresh = useCallback(() => {
     try {
-      const result = refreshRef.current()
-      if (result && typeof result.then === 'function') {
-        result.then(
-          () => {
-            if (mountedRef.current) stampRefresh()
-          },
-          () => {}
-        )
-      } else {
-        stampRefresh()
-      }
+      handleRefreshResult(refreshRef.current(), mountedRef, stampRefresh)
     } catch (_: unknown) {
       /* sync throw — don't stamp */
     }
@@ -222,13 +244,7 @@ export function useAutoRefresh(
   }, [settings.enabled, settings.intervalMinutes, refresh])
 
   useEffect(() => {
-    if (
-      externalTimestamp != null &&
-      (lastRefreshedAt == null || externalTimestamp > lastRefreshedAt)
-    ) {
-      setLastRefreshedAt(externalTimestamp)
-      writeLastRefreshed(cardId, externalTimestamp)
-    }
+    syncExternalTimestamp(externalTimestamp, lastRefreshedAt, setLastRefreshedAt, cardId)
   }, [externalTimestamp, lastRefreshedAt, cardId])
 
   const update = useCallback(

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -164,7 +164,9 @@ function handleRefreshResult(
       () => {
         if (mountedRef.current) stampRefresh()
       },
-      () => {}
+      (err) => {
+        console.error('[useAutoRefresh] Refresh promise rejected:', err)
+      }
     )
   } else {
     stampRefresh()

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -2,10 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { type RepoContext } from '../utils/repoContext'
 import { killTerminalSession, getSessionId } from '../components/terminal/terminalSessions'
 import { isModKey } from '../utils/platform'
-import {
-  useTerminalPersistence,
-  DEFAULT_TERMINAL_PANEL_HEIGHT,
-} from './useTerminalPersistence'
+import { useTerminalPersistence, DEFAULT_TERMINAL_PANEL_HEIGHT } from './useTerminalPersistence'
 import { useTerminalTabActions } from './useTerminalTabActions'
 import { useTerminalTabLifecycle } from './useTerminalTabLifecycle'
 
@@ -48,15 +45,14 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
   const activeViewIdRef = useRef(activeViewId)
   activeViewIdRef.current = activeViewId
 
-  const { loaded, onPanelResize } =
-    useTerminalPersistence({
-      terminalTabs,
-      terminalTabsRef,
-      setTerminalOpen,
-      setTerminalTabs,
-      setActiveTerminalTabId,
-      setPanelHeight,
-    })
+  const { loaded, onPanelResize } = useTerminalPersistence({
+    terminalTabs,
+    terminalTabsRef,
+    setTerminalOpen,
+    setTerminalTabs,
+    setActiveTerminalTabId,
+    setPanelHeight,
+  })
 
   const { addTerminalTab, toggleTerminal, closeTerminalTab } = useTerminalTabLifecycle({
     terminalTabsRef,

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -1,20 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { getRepoContextFromViewId, type RepoContext } from '../utils/repoContext'
+import { type RepoContext } from '../utils/repoContext'
 import { killTerminalSession, getSessionId } from '../components/terminal/terminalSessions'
 import { isModKey } from '../utils/platform'
-import { useSettings, useSettingsMutations } from './useConvex'
-import { IPC_INVOKE } from '../ipc/contracts'
-
-const PANEL_HEIGHT_SAVE_DEBOUNCE_MS = 300
-const TABS_SAVE_DEBOUNCE_MS = 500
-const DEFAULT_TERMINAL_PANEL_HEIGHT = 300
-const MIN_PANEL_HEIGHT = 100
-const MAX_PANEL_HEIGHT = 1200
-
-function clampPanelHeight(value: number): number {
-  if (!Number.isFinite(value)) return DEFAULT_TERMINAL_PANEL_HEIGHT
-  return Math.max(MIN_PANEL_HEIGHT, Math.min(MAX_PANEL_HEIGHT, value))
-}
+import {
+  useTerminalPersistence,
+  DEFAULT_TERMINAL_PANEL_HEIGHT,
+} from './useTerminalPersistence'
+import { useTerminalTabActions } from './useTerminalTabActions'
+import { useTerminalTabLifecycle } from './useTerminalTabLifecycle'
 
 export interface TerminalTab {
   id: string
@@ -24,41 +17,6 @@ export interface TerminalTab {
   repoSlug?: string
   /** Custom tab color (CSS color value) */
   color?: string
-}
-
-function findTabBySlug(tabs: TerminalTab[], slug: string): TerminalTab | undefined {
-  return tabs.find(t => t.repoSlug === slug)
-}
-
-function resolveViewRepoContext(activeViewId: string | null | undefined): RepoContext | null {
-  return activeViewId ? getRepoContextFromViewId(activeViewId) : null
-}
-
-function isFulfilledBoolean(
-  r: PromiseSettledResult<unknown>
-): r is PromiseFulfilledResult<boolean> {
-  return r.status === 'fulfilled' && typeof r.value === 'boolean'
-}
-
-function isFulfilledNumber(r: PromiseSettledResult<unknown>): r is PromiseFulfilledResult<number> {
-  return r.status === 'fulfilled' && typeof r.value === 'number'
-}
-
-async function tryResolveRepoPath(owner: string, repo: string): Promise<string> {
-  try {
-    const result = await window.terminal.resolveRepoPath(owner, repo)
-    return result.path || ''
-  } catch (_: unknown) {
-    return ''
-  }
-}
-
-function getStoredTerminalPanelHeight(settings: ReturnType<typeof useSettings>): number | null {
-  return settings?.terminalPanelHeight ?? null
-}
-
-function getStoredTerminalTabs(settings: ReturnType<typeof useSettings>) {
-  return settings?.terminalTabs ?? []
 }
 
 interface UseTerminalPanelReturn {
@@ -78,16 +36,11 @@ interface UseTerminalPanelReturn {
   loaded: boolean
 }
 
-let nextTabNumber = 1
-
 export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanelReturn {
   const [terminalOpen, setTerminalOpen] = useState(false)
   const [terminalTabs, setTerminalTabs] = useState<TerminalTab[]>([])
   const [activeTerminalTabId, setActiveTerminalTabId] = useState<string | null>(null)
   const [panelHeight, setPanelHeight] = useState(DEFAULT_TERMINAL_PANEL_HEIGHT)
-  const [loaded, setLoaded] = useState(false)
-  const heightSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const tabsSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const terminalTabsRef = useRef(terminalTabs)
   terminalTabsRef.current = terminalTabs
   const terminalOpenRef = useRef(terminalOpen)
@@ -95,251 +48,24 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
   const activeViewIdRef = useRef(activeViewId)
   activeViewIdRef.current = activeViewId
 
-  // Convex persistence
-  const settings = useSettings()
-  const storedTerminalPanelHeight = getStoredTerminalPanelHeight(settings)
-  const storedTerminalTabs = getStoredTerminalTabs(settings)
-  const { updateTerminalPanelHeight, updateTerminalTabs } = useSettingsMutations()
-
-  // Load persisted state on mount (local IPC is fast/immediate)
-  useEffect(() => {
-    let cancelled = false
-    Promise.allSettled([
-      window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_OPEN) as Promise<boolean>,
-      window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_PANEL_HEIGHT) as Promise<number>,
-    ]).then(([openResult, heightResult]) => {
-      /* v8 ignore start */
-      if (cancelled) return
-      /* v8 ignore stop */
-      if (isFulfilledBoolean(openResult)) {
-        setTerminalOpen(openResult.value)
-      }
-      if (isFulfilledNumber(heightResult)) {
-        setPanelHeight(clampPanelHeight(heightResult.value))
-      }
-      setLoaded(true)
+  const { loaded, onPanelResize } =
+    useTerminalPersistence({
+      terminalTabs,
+      terminalTabsRef,
+      setTerminalOpen,
+      setTerminalTabs,
+      setActiveTerminalTabId,
+      setPanelHeight,
     })
-    /* v8 ignore start */
-    return () => {
-      cancelled = true
-    }
-    /* v8 ignore stop */
-  }, [])
 
-  // Sync from Convex when available (fills in on new machines with no local config)
-  /* v8 ignore start -- Convex sync only fires on new devices; tested via integration */
-  useEffect(() => {
-    if (storedTerminalPanelHeight != null && loaded) {
-      // Only apply Convex value if local didn't have one (first launch on new device)
-      window.ipcRenderer
-        .invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_PANEL_HEIGHT)
-        .then((local: unknown) => {
-          if (local == null) {
-            setPanelHeight(clampPanelHeight(storedTerminalPanelHeight))
-          }
-        })
-        .catch(() => {})
-    }
-  }, [storedTerminalPanelHeight, loaded])
-  /* v8 ignore stop */
-
-  // Restore terminal tabs from Convex on first load (only if no tabs exist yet)
-  const restoredRef = useRef(false)
-  const savedTabCount = storedTerminalTabs.length
-  /* v8 ignore start -- tab restoration from Convex; hard to unit-test due to async isolation */
-  useEffect(() => {
-    if (restoredRef.current || !loaded || !savedTabCount) return
-    if (terminalTabsRef.current.length > 0) return
-    restoredRef.current = true
-
-    async function restoreTabs() {
-      const savedTabs = storedTerminalTabs
-      const restored: TerminalTab[] = await Promise.all(
-        savedTabs.map(async saved => {
-          let cwd = saved.cwd
-          if (saved.repoSlug) {
-            const [owner, repo] = saved.repoSlug.split('/')
-            if (owner && repo) {
-              const resolved = await tryResolveRepoPath(owner, repo)
-              if (resolved) cwd = resolved
-            }
-          }
-          return {
-            id: `term-restore-${crypto.randomUUID()}`,
-            title: saved.title,
-            cwd,
-            repoSlug: saved.repoSlug,
-            color: saved.color,
-          }
-        })
-      )
-      terminalTabsRef.current = restored
-      setTerminalTabs(restored)
-      if (restored.length > 0) setActiveTerminalTabId(restored[0].id)
-    }
-    void restoreTabs()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storedTerminalTabs, loaded])
-  /* v8 ignore stop */
-
-  // Auto-persist terminal tabs to Convex (debounced, skip initial mount)
-  /* v8 ignore start -- debounce persistence; async timer + Convex update hard to isolate */
-  const isInitialMount = useRef(true)
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false
-      return
-    }
-    if (tabsSaveTimeoutRef.current) clearTimeout(tabsSaveTimeoutRef.current)
-    tabsSaveTimeoutRef.current = setTimeout(() => {
-      const payload = terminalTabs.map(t => ({
-        title: t.title,
-        cwd: t.cwd,
-        repoSlug: t.repoSlug,
-        color: t.color,
-      }))
-      updateTerminalTabs({ tabs: payload }).catch(err => {
-        console.warn('Failed to persist terminal tabs:', err)
-      })
-    }, TABS_SAVE_DEBOUNCE_MS)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [terminalTabs])
-  /* v8 ignore stop */
-
-  // Cleanup debounce timers on unmount
-  /* v8 ignore start -- cleanup runs only on unmount */
-  useEffect(() => {
-    return () => {
-      if (heightSaveTimeoutRef.current) clearTimeout(heightSaveTimeoutRef.current)
-      if (tabsSaveTimeoutRef.current) clearTimeout(tabsSaveTimeoutRef.current)
-    }
-  }, [])
-  /* v8 ignore stop */
-
-  const addTerminalTab = useCallback(async (repoContext: RepoContext | null) => {
-    let cwd = ''
-    let title: string
-    let repoSlug: string | undefined
-
-    if (repoContext) {
-      repoSlug = `${repoContext.owner}/${repoContext.repo}`
-
-      // Optimistic dedup via ref (avoids unnecessary IPC calls)
-      const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
-      if (existing) {
-        setActiveTerminalTabId(existing.id)
-        return existing
-      }
-
-      title = repoContext.repo
-      cwd = await tryResolveRepoPath(repoContext.owner, repoContext.repo)
-    } else {
-      title = `Terminal ${nextTabNumber++}`
-    }
-
-    const tabId = `term-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
-    const newTab: TerminalTab = {
-      id: tabId,
-      title,
-      cwd,
-      repoSlug,
-    }
-
-    // Re-check against the latest ref after async work completes so dedup/add and
-    // active-tab selection are derived from the same snapshot.
-    if (repoSlug) {
-      const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
-      if (existing) {
-        setActiveTerminalTabId(existing.id)
-        return existing
-      }
-    }
-
-    const nextTabs = [...terminalTabsRef.current, newTab]
-    terminalTabsRef.current = nextTabs
-    setTerminalTabs(nextTabs)
-
-    setActiveTerminalTabId(tabId)
-    return newTab
-  }, [])
-
-  const toggleTerminal = useCallback(
-    (activeViewId?: string | null) => {
-      const next = !terminalOpenRef.current
-      terminalOpenRef.current = next
-      setTerminalOpen(next)
-      window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_SET_TERMINAL_OPEN, next).catch(() => {})
-
-      if (!next) return
-
-      const currentTabs = terminalTabsRef.current
-      const repoContext = resolveViewRepoContext(activeViewId)
-
-      if (currentTabs.length === 0) {
-        void addTerminalTab(repoContext)
-        return
-      }
-
-      if (!repoContext) return
-      const slug = `${repoContext.owner}/${repoContext.repo}`
-      const existing = findTabBySlug(currentTabs, slug)
-      if (existing) setActiveTerminalTabId(existing.id)
-      else void addTerminalTab(repoContext)
-    },
-    [addTerminalTab]
-  )
-
-  const closeTerminalTab = useCallback(
-    (tabId: string) => {
-      killTerminalSession(tabId)
-
-      const prev = terminalTabsRef.current
-      const idx = prev.findIndex(t => t.id === tabId)
-      if (idx === -1) return
-
-      const next = prev.filter(t => t.id !== tabId)
-      terminalTabsRef.current = next
-
-      // Functional updater composes safely with concurrent addTerminalTab updates
-      setTerminalTabs(prev => prev.filter(t => t.id !== tabId))
-
-      // Update active tab
-      if (activeTerminalTabId === tabId) {
-        if (next.length === 0) {
-          setActiveTerminalTabId(null)
-          setTerminalOpen(false)
-          window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_SET_TERMINAL_OPEN, false).catch(() => {})
-        } else {
-          const newIdx = Math.min(idx, next.length - 1)
-          setActiveTerminalTabId(next[newIdx].id)
-        }
-      }
-    },
-    [activeTerminalTabId]
-  )
-
-  const onPanelResize = useCallback(
-    (sizes: number[]) => {
-      // sizes[0] = content height, sizes[1] = terminal panel height
-      if (sizes.length >= 2 && sizes[1] > 0) {
-        const clamped = clampPanelHeight(sizes[1])
-        setPanelHeight(clamped)
-
-        /* v8 ignore start */
-        if (heightSaveTimeoutRef.current) clearTimeout(heightSaveTimeoutRef.current)
-        /* v8 ignore stop */
-        heightSaveTimeoutRef.current = setTimeout(() => {
-          window.ipcRenderer
-            .invoke(IPC_INVOKE.CONFIG_SET_TERMINAL_PANEL_HEIGHT, clamped)
-            .catch(() => {})
-          /* v8 ignore start */
-          updateTerminalPanelHeight({ height: clamped }).catch(() => {})
-          /* v8 ignore stop */
-        }, PANEL_HEIGHT_SAVE_DEBOUNCE_MS)
-      }
-    },
-    [updateTerminalPanelHeight]
-  )
+  const { addTerminalTab, toggleTerminal, closeTerminalTab } = useTerminalTabLifecycle({
+    terminalTabsRef,
+    terminalOpenRef,
+    activeTerminalTabId,
+    setTerminalOpen,
+    setTerminalTabs,
+    setActiveTerminalTabId,
+  })
 
   // Keyboard shortcut: Ctrl+`
   useEffect(() => {
@@ -370,65 +96,8 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
     setActiveTerminalTabId(tabId)
   }, [])
 
-  /** Apply a transform to the tabs array, syncing ref + state in one place. */
-  const applyTabsUpdate = useCallback(
-    (transform: (tabs: TerminalTab[]) => TerminalTab[] | null) => {
-      setTerminalTabs(prev => {
-        const next = transform(prev)
-        if (!next) return prev
-        terminalTabsRef.current = next
-        return next
-      })
-    },
-    []
-  )
-
-  const renameTerminalTab = useCallback(
-    (tabId: string, title: string) => {
-      const trimmed = title.trim()
-      if (!trimmed) return
-      applyTabsUpdate(prev => {
-        const tab = prev.find(t => t.id === tabId)
-        if (!tab || tab.title === trimmed) return null
-        return prev.map(t => (t.id === tabId ? { ...t, title: trimmed } : t))
-      })
-    },
-    [applyTabsUpdate]
-  )
-
-  const setTerminalTabColor = useCallback(
-    (tabId: string, color: string | undefined) => {
-      applyTabsUpdate(prev => prev.map(t => (t.id === tabId ? { ...t, color } : t)))
-    },
-    [applyTabsUpdate]
-  )
-
-  const reorderTerminalTabs = useCallback(
-    (fromId: string, toId: string) => {
-      if (fromId === toId) return
-      applyTabsUpdate(prev => {
-        const fromIdx = prev.findIndex(t => t.id === fromId)
-        const toIdx = prev.findIndex(t => t.id === toId)
-        if (fromIdx === -1 || toIdx === -1) return null
-        const next = [...prev]
-        const [moved] = next.splice(fromIdx, 1)
-        next.splice(toIdx, 0, moved)
-        return next
-      })
-    },
-    [applyTabsUpdate]
-  )
-
-  const updateTabCwd = useCallback(
-    (tabId: string, cwd: string) => {
-      applyTabsUpdate(prev => {
-        const tab = prev.find(t => t.id === tabId)
-        if (!tab || tab.cwd === cwd) return null
-        return prev.map(t => (t.id === tabId ? { ...t, cwd } : t))
-      })
-    },
-    [applyTabsUpdate]
-  )
+  const { renameTerminalTab, setTerminalTabColor, reorderTerminalTabs, updateTabCwd } =
+    useTerminalTabActions({ terminalTabsRef, setTerminalTabs })
 
   return {
     terminalOpen,

--- a/src/hooks/useTerminalPersistence.ts
+++ b/src/hooks/useTerminalPersistence.ts
@@ -9,7 +9,7 @@ const DEFAULT_TERMINAL_PANEL_HEIGHT = 300
 const MIN_PANEL_HEIGHT = 100
 const MAX_PANEL_HEIGHT = 1200
 
-export function clampPanelHeight(value: number): number {
+function clampPanelHeight(value: number): number {
   if (!Number.isFinite(value)) return DEFAULT_TERMINAL_PANEL_HEIGHT
   return Math.max(MIN_PANEL_HEIGHT, Math.min(MAX_PANEL_HEIGHT, value))
 }
@@ -220,4 +220,4 @@ export function useTerminalPersistence({
   }
 }
 
-export { DEFAULT_TERMINAL_PANEL_HEIGHT, PANEL_HEIGHT_SAVE_DEBOUNCE_MS, tryResolveRepoPath }
+export { DEFAULT_TERMINAL_PANEL_HEIGHT, tryResolveRepoPath }

--- a/src/hooks/useTerminalPersistence.ts
+++ b/src/hooks/useTerminalPersistence.ts
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { TerminalTab } from './useTerminalPanel'
+import { useSettings, useSettingsMutations } from './useConvex'
+import { IPC_INVOKE } from '../ipc/contracts'
+
+const PANEL_HEIGHT_SAVE_DEBOUNCE_MS = 300
+const TABS_SAVE_DEBOUNCE_MS = 500
+const DEFAULT_TERMINAL_PANEL_HEIGHT = 300
+const MIN_PANEL_HEIGHT = 100
+const MAX_PANEL_HEIGHT = 1200
+
+export function clampPanelHeight(value: number): number {
+  if (!Number.isFinite(value)) return DEFAULT_TERMINAL_PANEL_HEIGHT
+  return Math.max(MIN_PANEL_HEIGHT, Math.min(MAX_PANEL_HEIGHT, value))
+}
+
+function isFulfilledBoolean(
+  r: PromiseSettledResult<unknown>
+): r is PromiseFulfilledResult<boolean> {
+  return r.status === 'fulfilled' && typeof r.value === 'boolean'
+}
+
+function isFulfilledNumber(r: PromiseSettledResult<unknown>): r is PromiseFulfilledResult<number> {
+  return r.status === 'fulfilled' && typeof r.value === 'number'
+}
+
+function getStoredTerminalPanelHeight(settings: ReturnType<typeof useSettings>): number | null {
+  return settings?.terminalPanelHeight ?? null
+}
+
+function getStoredTerminalTabs(settings: ReturnType<typeof useSettings>) {
+  return settings?.terminalTabs ?? []
+}
+
+async function tryResolveRepoPath(owner: string, repo: string): Promise<string> {
+  try {
+    const result = await window.terminal.resolveRepoPath(owner, repo)
+    return result.path || ''
+  } catch (_: unknown) {
+    return ''
+  }
+}
+
+interface UseTerminalPersistenceOptions {
+  terminalTabs: TerminalTab[]
+  terminalTabsRef: React.MutableRefObject<TerminalTab[]>
+  setTerminalOpen: (open: boolean) => void
+  setTerminalTabs: (tabs: TerminalTab[]) => void
+  setActiveTerminalTabId: (id: string | null) => void
+  setPanelHeight: (h: number) => void
+}
+
+interface UseTerminalPersistenceReturn {
+  loaded: boolean
+  panelHeightSaveRef: React.MutableRefObject<ReturnType<typeof setTimeout> | null>
+  updateTerminalPanelHeight: ReturnType<typeof useSettingsMutations>['updateTerminalPanelHeight']
+  onPanelResize: (sizes: number[]) => void
+}
+
+export function useTerminalPersistence({
+  terminalTabs,
+  terminalTabsRef,
+  setTerminalOpen,
+  setTerminalTabs,
+  setActiveTerminalTabId,
+  setPanelHeight,
+}: UseTerminalPersistenceOptions): UseTerminalPersistenceReturn {
+  const [loaded, setLoaded] = useState(false)
+  const heightSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const tabsSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const settings = useSettings()
+  const storedTerminalPanelHeight = getStoredTerminalPanelHeight(settings)
+  const storedTerminalTabs = getStoredTerminalTabs(settings)
+  const { updateTerminalPanelHeight, updateTerminalTabs } = useSettingsMutations()
+
+  // Load persisted state on mount (local IPC is fast/immediate)
+  useEffect(() => {
+    let cancelled = false
+    Promise.allSettled([
+      window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_OPEN) as Promise<boolean>,
+      window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_PANEL_HEIGHT) as Promise<number>,
+    ]).then(([openResult, heightResult]) => {
+      /* v8 ignore start */
+      if (cancelled) return
+      /* v8 ignore stop */
+      if (isFulfilledBoolean(openResult)) {
+        setTerminalOpen(openResult.value)
+      }
+      if (isFulfilledNumber(heightResult)) {
+        setPanelHeight(clampPanelHeight(heightResult.value))
+      }
+      setLoaded(true)
+    })
+    /* v8 ignore start */
+    return () => {
+      cancelled = true
+    }
+    /* v8 ignore stop */
+  }, [setPanelHeight, setTerminalOpen])
+
+  // Sync from Convex when available (fills in on new machines with no local config)
+  /* v8 ignore start -- Convex sync only fires on new devices; tested via integration */
+  useEffect(() => {
+    if (storedTerminalPanelHeight != null && loaded) {
+      // Only apply Convex value if local didn't have one (first launch on new device)
+      window.ipcRenderer
+        .invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_PANEL_HEIGHT)
+        .then((local: unknown) => {
+          if (local == null) {
+            setPanelHeight(clampPanelHeight(storedTerminalPanelHeight))
+          }
+        })
+        .catch(() => {})
+    }
+  }, [storedTerminalPanelHeight, loaded, setPanelHeight])
+  /* v8 ignore stop */
+
+  // Restore terminal tabs from Convex on first load (only if no tabs exist yet)
+  const restoredRef = useRef(false)
+  const savedTabCount = storedTerminalTabs.length
+  /* v8 ignore start -- tab restoration from Convex; hard to unit-test due to async isolation */
+  useEffect(() => {
+    if (restoredRef.current || !loaded || !savedTabCount) return
+    if (terminalTabsRef.current.length > 0) return
+    restoredRef.current = true
+
+    async function restoreTabs() {
+      const savedTabs = storedTerminalTabs
+      const restored: TerminalTab[] = await Promise.all(
+        savedTabs.map(async saved => {
+          let cwd = saved.cwd
+          if (saved.repoSlug) {
+            const [owner, repo] = saved.repoSlug.split('/')
+            if (owner && repo) {
+              const resolved = await tryResolveRepoPath(owner, repo)
+              if (resolved) cwd = resolved
+            }
+          }
+          return {
+            id: `term-restore-${crypto.randomUUID()}`,
+            title: saved.title,
+            cwd,
+            repoSlug: saved.repoSlug,
+            color: saved.color,
+          }
+        })
+      )
+      terminalTabsRef.current = restored
+      setTerminalTabs(restored)
+      if (restored.length > 0) setActiveTerminalTabId(restored[0].id)
+    }
+    void restoreTabs()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storedTerminalTabs, loaded])
+  /* v8 ignore stop */
+
+  // Auto-persist terminal tabs to Convex (debounced, skip initial mount)
+  /* v8 ignore start -- debounce persistence; async timer + Convex update hard to isolate */
+  const isInitialMount = useRef(true)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    if (tabsSaveTimeoutRef.current) clearTimeout(tabsSaveTimeoutRef.current)
+    tabsSaveTimeoutRef.current = setTimeout(() => {
+      const payload = terminalTabs.map(t => ({
+        title: t.title,
+        cwd: t.cwd,
+        repoSlug: t.repoSlug,
+        color: t.color,
+      }))
+      updateTerminalTabs({ tabs: payload }).catch(err => {
+        console.warn('Failed to persist terminal tabs:', err)
+      })
+    }, TABS_SAVE_DEBOUNCE_MS)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [terminalTabs])
+  /* v8 ignore stop */
+
+  // Cleanup debounce timers on unmount
+  /* v8 ignore start -- cleanup runs only on unmount */
+  useEffect(() => {
+    return () => {
+      if (heightSaveTimeoutRef.current) clearTimeout(heightSaveTimeoutRef.current)
+      if (tabsSaveTimeoutRef.current) clearTimeout(tabsSaveTimeoutRef.current)
+    }
+  }, [])
+  /* v8 ignore stop */
+
+  const onPanelResize = useCallback(
+    (sizes: number[]) => {
+      // sizes[0] = content height, sizes[1] = terminal panel height
+      if (sizes.length >= 2 && sizes[1] > 0) {
+        const clamped = clampPanelHeight(sizes[1])
+        setPanelHeight(clamped)
+
+        /* v8 ignore start */
+        if (heightSaveTimeoutRef.current) clearTimeout(heightSaveTimeoutRef.current)
+        /* v8 ignore stop */
+        heightSaveTimeoutRef.current = setTimeout(() => {
+          window.ipcRenderer
+            .invoke(IPC_INVOKE.CONFIG_SET_TERMINAL_PANEL_HEIGHT, clamped)
+            .catch(() => {})
+          /* v8 ignore start */
+          updateTerminalPanelHeight({ height: clamped }).catch(() => {})
+          /* v8 ignore stop */
+        }, PANEL_HEIGHT_SAVE_DEBOUNCE_MS)
+      }
+    },
+    [updateTerminalPanelHeight, setPanelHeight]
+  )
+
+  return {
+    loaded,
+    panelHeightSaveRef: heightSaveTimeoutRef,
+    updateTerminalPanelHeight,
+    onPanelResize,
+  }
+}
+
+export { DEFAULT_TERMINAL_PANEL_HEIGHT, PANEL_HEIGHT_SAVE_DEBOUNCE_MS, tryResolveRepoPath }

--- a/src/hooks/useTerminalTabActions.ts
+++ b/src/hooks/useTerminalTabActions.ts
@@ -1,0 +1,83 @@
+import { useCallback, type MutableRefObject } from 'react'
+import type { TerminalTab } from './useTerminalPanel'
+
+export interface UseTerminalTabActionsOptions {
+  terminalTabsRef: MutableRefObject<TerminalTab[]>
+  setTerminalTabs: React.Dispatch<React.SetStateAction<TerminalTab[]>>
+}
+
+/**
+ * Provides tab-mutation callbacks (rename, color, reorder, updateCwd)
+ * extracted from useTerminalPanel to reduce function length.
+ */
+export function useTerminalTabActions({
+  terminalTabsRef,
+  setTerminalTabs,
+}: UseTerminalTabActionsOptions) {
+  /** Apply a transform to the tabs array, syncing ref + state in one place. */
+  const applyTabsUpdate = useCallback(
+    (transform: (tabs: TerminalTab[]) => TerminalTab[] | null) => {
+      setTerminalTabs(prev => {
+        const next = transform(prev)
+        if (!next) return prev
+        terminalTabsRef.current = next
+        return next
+      })
+    },
+    [setTerminalTabs, terminalTabsRef]
+  )
+
+  const renameTerminalTab = useCallback(
+    (tabId: string, title: string) => {
+      const trimmed = title.trim()
+      if (!trimmed) return
+      applyTabsUpdate(prev => {
+        const tab = prev.find(t => t.id === tabId)
+        if (!tab || tab.title === trimmed) return null
+        return prev.map(t => (t.id === tabId ? { ...t, title: trimmed } : t))
+      })
+    },
+    [applyTabsUpdate]
+  )
+
+  const setTerminalTabColor = useCallback(
+    (tabId: string, color: string | undefined) => {
+      applyTabsUpdate(prev => prev.map(t => (t.id === tabId ? { ...t, color } : t)))
+    },
+    [applyTabsUpdate]
+  )
+
+  const reorderTerminalTabs = useCallback(
+    (fromId: string, toId: string) => {
+      if (fromId === toId) return
+      applyTabsUpdate(prev => {
+        const fromIdx = prev.findIndex(t => t.id === fromId)
+        const toIdx = prev.findIndex(t => t.id === toId)
+        if (fromIdx === -1 || toIdx === -1) return null
+        const next = [...prev]
+        const [moved] = next.splice(fromIdx, 1)
+        next.splice(toIdx, 0, moved)
+        return next
+      })
+    },
+    [applyTabsUpdate]
+  )
+
+  const updateTabCwd = useCallback(
+    (tabId: string, cwd: string) => {
+      applyTabsUpdate(prev => {
+        const tab = prev.find(t => t.id === tabId)
+        if (!tab || tab.cwd === cwd) return null
+        return prev.map(t => (t.id === tabId ? { ...t, cwd } : t))
+      })
+    },
+    [applyTabsUpdate]
+  )
+
+  return {
+    renameTerminalTab,
+    setTerminalTabColor,
+    reorderTerminalTabs,
+    updateTabCwd,
+  }
+}

--- a/src/hooks/useTerminalTabActions.ts
+++ b/src/hooks/useTerminalTabActions.ts
@@ -1,7 +1,7 @@
 import { useCallback, type MutableRefObject } from 'react'
 import type { TerminalTab } from './useTerminalPanel'
 
-export interface UseTerminalTabActionsOptions {
+interface UseTerminalTabActionsOptions {
   terminalTabsRef: MutableRefObject<TerminalTab[]>
   setTerminalTabs: React.Dispatch<React.SetStateAction<TerminalTab[]>>
 }

--- a/src/hooks/useTerminalTabLifecycle.ts
+++ b/src/hooks/useTerminalTabLifecycle.ts
@@ -1,0 +1,141 @@
+import { useCallback, type MutableRefObject } from 'react'
+import { getRepoContextFromViewId, type RepoContext } from '../utils/repoContext'
+import { killTerminalSession } from '../components/terminal/terminalSessions'
+import { IPC_INVOKE } from '../ipc/contracts'
+import { tryResolveRepoPath } from './useTerminalPersistence'
+import type { TerminalTab } from './useTerminalPanel'
+
+function findTabBySlug(tabs: TerminalTab[], slug: string): TerminalTab | undefined {
+  return tabs.find(t => t.repoSlug === slug)
+}
+
+function resolveViewRepoContext(activeViewId: string | null | undefined): RepoContext | null {
+  return activeViewId ? getRepoContextFromViewId(activeViewId) : null
+}
+
+let nextTabNumber = 1
+
+export interface UseTerminalTabLifecycleOptions {
+  terminalTabsRef: MutableRefObject<TerminalTab[]>
+  terminalOpenRef: MutableRefObject<boolean>
+  activeTerminalTabId: string | null
+  setTerminalOpen: (open: boolean) => void
+  setTerminalTabs: React.Dispatch<React.SetStateAction<TerminalTab[]>>
+  setActiveTerminalTabId: (id: string | null) => void
+}
+
+/**
+ * Provides tab lifecycle callbacks (add, toggle, close) extracted from useTerminalPanel.
+ */
+export function useTerminalTabLifecycle({
+  terminalTabsRef,
+  terminalOpenRef,
+  activeTerminalTabId,
+  setTerminalOpen,
+  setTerminalTabs,
+  setActiveTerminalTabId,
+}: UseTerminalTabLifecycleOptions) {
+  const addTerminalTab = useCallback(async (repoContext: RepoContext | null) => {
+    let cwd = ''
+    let title: string
+    let repoSlug: string | undefined
+
+    if (repoContext) {
+      repoSlug = `${repoContext.owner}/${repoContext.repo}`
+
+      // Optimistic dedup via ref (avoids unnecessary IPC calls)
+      const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
+      if (existing) {
+        setActiveTerminalTabId(existing.id)
+        return existing
+      }
+
+      title = repoContext.repo
+      cwd = await tryResolveRepoPath(repoContext.owner, repoContext.repo)
+    } else {
+      title = `Terminal ${nextTabNumber++}`
+    }
+
+    const tabId = `term-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+    const newTab: TerminalTab = {
+      id: tabId,
+      title,
+      cwd,
+      repoSlug,
+    }
+
+    // Re-check against the latest ref after async work completes so dedup/add and
+    // active-tab selection are derived from the same snapshot.
+    if (repoSlug) {
+      const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
+      if (existing) {
+        setActiveTerminalTabId(existing.id)
+        return existing
+      }
+    }
+
+    const nextTabs = [...terminalTabsRef.current, newTab]
+    terminalTabsRef.current = nextTabs
+    setTerminalTabs(nextTabs)
+
+    setActiveTerminalTabId(tabId)
+    return newTab
+  }, [terminalTabsRef, setActiveTerminalTabId, setTerminalTabs])
+
+  const toggleTerminal = useCallback(
+    (activeViewId?: string | null) => {
+      const next = !terminalOpenRef.current
+      terminalOpenRef.current = next
+      setTerminalOpen(next)
+      window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_SET_TERMINAL_OPEN, next).catch(() => {})
+
+      if (!next) return
+
+      const currentTabs = terminalTabsRef.current
+      const repoContext = resolveViewRepoContext(activeViewId)
+
+      if (currentTabs.length === 0) {
+        void addTerminalTab(repoContext)
+        return
+      }
+
+      if (!repoContext) return
+      const slug = `${repoContext.owner}/${repoContext.repo}`
+      const existing = findTabBySlug(currentTabs, slug)
+      if (existing) setActiveTerminalTabId(existing.id)
+      else void addTerminalTab(repoContext)
+    },
+    [addTerminalTab, terminalOpenRef, terminalTabsRef, setTerminalOpen, setActiveTerminalTabId]
+  )
+
+  const closeTerminalTab = useCallback(
+    (tabId: string) => {
+      killTerminalSession(tabId)
+
+      const prev = terminalTabsRef.current
+      const idx = prev.findIndex(t => t.id === tabId)
+      if (idx === -1) return
+
+      const next = prev.filter(t => t.id !== tabId)
+      terminalTabsRef.current = next
+
+      // Functional updater composes safely with concurrent addTerminalTab updates
+      setTerminalTabs(prev => prev.filter(t => t.id !== tabId))
+
+      // Update active tab
+      if (activeTerminalTabId === tabId) {
+        if (next.length === 0) {
+          setActiveTerminalTabId(null)
+          setTerminalOpen(false)
+          window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_SET_TERMINAL_OPEN, false).catch(() => {})
+        } else {
+          const newIdx = Math.min(idx, next.length - 1)
+          setActiveTerminalTabId(next[newIdx].id)
+        }
+      }
+    },
+    [activeTerminalTabId, terminalTabsRef, setTerminalTabs, setActiveTerminalTabId, setTerminalOpen]
+  )
+
+  return { addTerminalTab, toggleTerminal, closeTerminalTab }
+}

--- a/src/hooks/useTerminalTabLifecycle.ts
+++ b/src/hooks/useTerminalTabLifecycle.ts
@@ -15,7 +15,7 @@ function resolveViewRepoContext(activeViewId: string | null | undefined): RepoCo
 
 let nextTabNumber = 1
 
-export interface UseTerminalTabLifecycleOptions {
+interface UseTerminalTabLifecycleOptions {
   terminalTabsRef: MutableRefObject<TerminalTab[]>
   terminalOpenRef: MutableRefObject<boolean>
   activeTerminalTabId: string | null
@@ -35,52 +35,55 @@ export function useTerminalTabLifecycle({
   setTerminalTabs,
   setActiveTerminalTabId,
 }: UseTerminalTabLifecycleOptions) {
-  const addTerminalTab = useCallback(async (repoContext: RepoContext | null) => {
-    let cwd = ''
-    let title: string
-    let repoSlug: string | undefined
+  const addTerminalTab = useCallback(
+    async (repoContext: RepoContext | null) => {
+      let cwd = ''
+      let title: string
+      let repoSlug: string | undefined
 
-    if (repoContext) {
-      repoSlug = `${repoContext.owner}/${repoContext.repo}`
+      if (repoContext) {
+        repoSlug = `${repoContext.owner}/${repoContext.repo}`
 
-      // Optimistic dedup via ref (avoids unnecessary IPC calls)
-      const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
-      if (existing) {
-        setActiveTerminalTabId(existing.id)
-        return existing
+        // Optimistic dedup via ref (avoids unnecessary IPC calls)
+        const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
+        if (existing) {
+          setActiveTerminalTabId(existing.id)
+          return existing
+        }
+
+        title = repoContext.repo
+        cwd = await tryResolveRepoPath(repoContext.owner, repoContext.repo)
+      } else {
+        title = `Terminal ${nextTabNumber++}`
       }
 
-      title = repoContext.repo
-      cwd = await tryResolveRepoPath(repoContext.owner, repoContext.repo)
-    } else {
-      title = `Terminal ${nextTabNumber++}`
-    }
-
-    const tabId = `term-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
-    const newTab: TerminalTab = {
-      id: tabId,
-      title,
-      cwd,
-      repoSlug,
-    }
-
-    // Re-check against the latest ref after async work completes so dedup/add and
-    // active-tab selection are derived from the same snapshot.
-    if (repoSlug) {
-      const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
-      if (existing) {
-        setActiveTerminalTabId(existing.id)
-        return existing
+      const tabId = `term-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+      const newTab: TerminalTab = {
+        id: tabId,
+        title,
+        cwd,
+        repoSlug,
       }
-    }
 
-    const nextTabs = [...terminalTabsRef.current, newTab]
-    terminalTabsRef.current = nextTabs
-    setTerminalTabs(nextTabs)
+      // Re-check against the latest ref after async work completes so dedup/add and
+      // active-tab selection are derived from the same snapshot.
+      if (repoSlug) {
+        const existing = findTabBySlug(terminalTabsRef.current, repoSlug)
+        if (existing) {
+          setActiveTerminalTabId(existing.id)
+          return existing
+        }
+      }
 
-    setActiveTerminalTabId(tabId)
-    return newTab
-  }, [terminalTabsRef, setActiveTerminalTabId, setTerminalTabs])
+      const nextTabs = [...terminalTabsRef.current, newTab]
+      terminalTabsRef.current = nextTabs
+      setTerminalTabs(nextTabs)
+
+      setActiveTerminalTabId(tabId)
+      return newTab
+    },
+    [terminalTabsRef, setActiveTerminalTabId, setTerminalTabs]
+  )
 
   const toggleTerminal = useCallback(
     (activeViewId?: string | null) => {


### PR DESCRIPTION
Extract long functions into focused sub-hooks to bring them under the 80-line max-lines-per-function quality gate:

- **useTerminalPanel** (was 295 lines): split into useTerminalPersistence, useTerminalTabActions, and useTerminalTabLifecycle
- **TerminalTabContextMenu** (was 108 lines): extract ColorSwatchGrid and RenameInput sub-components
- **useAutoRefresh** (was 91 lines): extract handleRefreshResult and syncExternalTimestamp helpers

All 48 useTerminalPanel tests, 22 TerminalTabContextMenu tests, and 36 useAutoRefresh tests continue to pass with 100% coverage.