### PR TITLE
feat: show bookmark title in tab headers instead of hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stabilize branch coverage and restore changelog entries
 - Stabilize useWeather abort coverage test for CI
 
+### Changed
+
+- Strengthen distinct-URL test with identity assertions
+
 ## [0.1.760] - 2026-05-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove dead branches in browser tab matching for 100% coverage
 - Address PR review feedback - changelog and test assertions
 - Stabilize branch coverage and restore changelog entries
+- Stabilize useWeather abort coverage test for CI
 
 ## [0.1.760] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Address PR review feedback
 - Guard browser route against malformed URLs and empty titles
 - Match browser tabs by URL identity to prevent duplicates on bookmark rename
+- Remove dead branches in browser tab matching for 100% coverage
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove dead branches in browser tab matching for 100% coverage
 - Address PR review feedback - changelog and test assertions
 - Stabilize branch coverage and restore changelog entries
-- Stabilize useWeather abort coverage test for CI
+- Refactor useWeather error handling and stabilize abort coverage tests
 
 ### Changed
 
 - Strengthen distinct-URL test with identity assertions
+- Improve useWeather changelog entry to reflect full scope
 
 ## [0.1.760] - 2026-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove phantom terminalWorkspaces reference from generated api.d.ts
 - Address PR review feedback
 - Guard browser route against malformed URLs and empty titles
+- Match browser tabs by URL identity to prevent duplicates on bookmark rename
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve CI failures (lint + coverage)
 - Correct type error in usePRContextMenu test
 - Address all 11 PR review comments
-- Fallback to github.token when GH_AW_GITHUB_TOKEN secret missing
 - Remove phantom terminalWorkspaces reference from generated api.d.ts
 - Address PR review feedback
 - Guard browser route against malformed URLs and empty titles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Address all 11 PR review comments
 - Fallback to github.token when GH_AW_GITHUB_TOKEN secret missing
 
+### Added
+
+- Show bookmark title in tab headers instead of hostname
+
 ## [0.1.759] - 2026-05-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.761] - 2026-05-24
 
+### Added
+
+- Show bookmark title in tab headers instead of hostname
+
 ### Fixed
 
 - Remove unrelated CodeRabbit changelog entry
+- Guard browser route against malformed URLs and empty titles
+- Match browser tabs by URL identity to prevent duplicates on bookmark rename
+- Remove dead branches in browser tab matching for 100% coverage
+- Address PR review feedback - changelog and test assertions
 
 ## [0.1.760] - 2026-05-23
 
@@ -35,13 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct type error in usePRContextMenu test
 - Address all 11 PR review comments
 - Address PR review feedback
-- Guard browser route against malformed URLs and empty titles
-- Match browser tabs by URL identity to prevent duplicates on bookmark rename
-- Remove dead branches in browser tab matching for 100% coverage
-
-### Added
-
-- Show bookmark title in tab headers instead of hostname
 
 ## [0.1.759] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add coverage for nullish coalescing branch in resolveBookmarkTarget
 - Cover missing branches in RalphLaunchForm and usePollen
 - Disable CodeRabbit auto-pause after reviewed commits
+- Assert viewId updates on browser tab reuse
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Match browser tabs by URL identity to prevent duplicates on bookmark rename
 - Remove dead branches in browser tab matching for 100% coverage
 - Address PR review feedback - changelog and test assertions
+- Stabilize branch coverage and restore changelog entries
 
 ## [0.1.760] - 2026-05-23
 
@@ -31,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce cyclomatic complexity in toggleBookmark and parseSpawnOpts
 - Add coverage for nullish coalescing branch in resolveBookmarkTarget
 - Cover missing branches in RalphLaunchForm and usePollen
-- Assert viewId updates on browser tab reuse
+- Disable CodeRabbit auto-pause after reviewed commits
 
 ### Fixed
 
@@ -42,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve CI failures (lint + coverage)
 - Correct type error in usePRContextMenu test
 - Address all 11 PR review comments
-- Address PR review feedback
+- Fallback to github.token when GH_AW_GITHUB_TOKEN secret missing
 
 ## [0.1.759] - 2026-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolve CI failures (lint + coverage)
 - Correct type error in usePRContextMenu test
 - Address all 11 PR review comments
-- Remove phantom terminalWorkspaces reference from generated api.d.ts
 - Address PR review feedback
 - Guard browser route against malformed URLs and empty titles
 - Match browser tabs by URL identity to prevent duplicates on bookmark rename

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.761] - 2026-05-24
+
+### Fixed
+
+- Remove unrelated CodeRabbit changelog entry
+
 ## [0.1.760] - 2026-05-23
 
 ### Changed
@@ -17,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduce cyclomatic complexity in toggleBookmark and parseSpawnOpts
 - Add coverage for nullish coalescing branch in resolveBookmarkTarget
 - Cover missing branches in RalphLaunchForm and usePollen
-- Disable CodeRabbit auto-pause after reviewed commits
 - Assert viewId updates on browser tab reuse
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Correct type error in usePRContextMenu test
 - Address all 11 PR review comments
 - Fallback to github.token when GH_AW_GITHUB_TOKEN secret missing
+- Remove phantom terminalWorkspaces reference from generated api.d.ts
+- Address PR review feedback
+- Guard browser route against malformed URLs and empty titles
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.760",
+  "version": "0.1.761",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/AppContentRouter.test.tsx
+++ b/src/components/AppContentRouter.test.tsx
@@ -301,6 +301,13 @@ describe('AppContentRouter', () => {
 
   it('renders browser tab route', () => {
     const encoded = encodeURIComponent('https://example.com')
+    const title = encodeURIComponent('My Page')
+    renderRouter(`browser:${encoded}|${title}`)
+    expect(screen.getByText('BrowserTab:https://example.com')).toBeInTheDocument()
+  })
+
+  it('renders browser tab route without title (backwards compat)', () => {
+    const encoded = encodeURIComponent('https://example.com')
     renderRouter(`browser:${encoded}`)
     expect(screen.getByText('BrowserTab:https://example.com')).toBeInTheDocument()
   })

--- a/src/components/AppContentRouter.test.tsx
+++ b/src/components/AppContentRouter.test.tsx
@@ -312,6 +312,11 @@ describe('AppContentRouter', () => {
     expect(screen.getByText('BrowserTab:https://example.com')).toBeInTheDocument()
   })
 
+  it('renders null for browser tab route with malformed encoded URL', () => {
+    renderRouter('browser:%ZZ-invalid')
+    expect(screen.queryByText(/BrowserTab/)).toBeNull()
+  })
+
   it('renders crew-project route', () => {
     renderRouter('crew-project:proj-123')
     expect(screen.getByText('CrewProject:proj-123')).toBeInTheDocument()

--- a/src/components/AppContentRouter.tsx
+++ b/src/components/AppContentRouter.tsx
@@ -238,7 +238,11 @@ const prefixRoutes: PrefixRouteEntry[] = [
   { prefix: 'bookmarks-category:', render: (slug, ctx) => renderBookmarkCategory(slug, ctx) },
   {
     prefix: 'browser:',
-    render: slug => <BrowserTabView key={`browser:${slug}`} url={decodeURIComponent(slug)} />,
+    render: slug => {
+      const pipeIndex = slug.indexOf('|')
+      const encodedUrl = pipeIndex >= 0 ? slug.slice(0, pipeIndex) : slug
+      return <BrowserTabView key={`browser:${encodedUrl}`} url={decodeURIComponent(encodedUrl)} />
+    },
   },
   { prefix: 'crew-project:', render: slug => <CrewProjectView projectId={slug} /> },
   {

--- a/src/components/AppContentRouter.tsx
+++ b/src/components/AppContentRouter.tsx
@@ -241,7 +241,11 @@ const prefixRoutes: PrefixRouteEntry[] = [
     render: slug => {
       const pipeIndex = slug.indexOf('|')
       const encodedUrl = pipeIndex >= 0 ? slug.slice(0, pipeIndex) : slug
-      return <BrowserTabView key={`browser:${encodedUrl}`} url={decodeURIComponent(encodedUrl)} />
+      try {
+        return <BrowserTabView key={`browser:${encodedUrl}`} url={decodeURIComponent(encodedUrl)} />
+      } catch (_: unknown) {
+        return null
+      }
     },
   },
   { prefix: 'crew-project:', render: slug => <CrewProjectView projectId={slug} /> },

--- a/src/components/appContentViewLabels.test.ts
+++ b/src/components/appContentViewLabels.test.ts
@@ -150,6 +150,12 @@ describe('getViewLabel', () => {
       expect(getViewLabel(`browser:${encoded}`)).toBe('example.com')
     })
 
+    it('returns bookmark title when pipe-separated title is present', () => {
+      const encoded = encodeURIComponent('https://example.com/path')
+      const title = encodeURIComponent('My Bookmark')
+      expect(getViewLabel(`browser:${encoded}|${title}`)).toBe('My Bookmark')
+    })
+
     it('returns "Browser" for an invalid URL', () => {
       expect(getViewLabel('browser:not-a-valid-url')).toBe('Browser')
     })

--- a/src/components/appContentViewLabels.test.ts
+++ b/src/components/appContentViewLabels.test.ts
@@ -161,6 +161,15 @@ describe('getViewLabel', () => {
       expect(getViewLabel(`browser:${encoded}|`)).toBe('example.com')
     })
 
+    it('returns title when URL before pipe is empty but title exists', () => {
+      const title = encodeURIComponent('My Title')
+      expect(getViewLabel(`browser:|${title}`)).toBe('My Title')
+    })
+
+    it('returns "Browser" when both URL and title are empty', () => {
+      expect(getViewLabel('browser:|')).toBe('Browser')
+    })
+
     it('returns "Browser" for an invalid URL', () => {
       expect(getViewLabel('browser:not-a-valid-url')).toBe('Browser')
     })

--- a/src/components/appContentViewLabels.test.ts
+++ b/src/components/appContentViewLabels.test.ts
@@ -156,6 +156,11 @@ describe('getViewLabel', () => {
       expect(getViewLabel(`browser:${encoded}|${title}`)).toBe('My Bookmark')
     })
 
+    it('falls back to hostname when pipe-separated title is empty', () => {
+      const encoded = encodeURIComponent('https://example.com/path')
+      expect(getViewLabel(`browser:${encoded}|`)).toBe('example.com')
+    })
+
     it('returns "Browser" for an invalid URL', () => {
       expect(getViewLabel('browser:not-a-valid-url')).toBe('Browser')
     })

--- a/src/components/appContentViewLabels.ts
+++ b/src/components/appContentViewLabels.ts
@@ -48,7 +48,9 @@ function getBrowserLabel(viewId: string): string {
     const raw = viewId.slice('browser:'.length)
     const pipeIndex = raw.indexOf('|')
     if (pipeIndex >= 0) {
-      return decodeURIComponent(raw.slice(pipeIndex + 1))
+      const title = decodeURIComponent(raw.slice(pipeIndex + 1)).trim()
+      if (title) return title
+      return new URL(decodeURIComponent(raw.slice(0, pipeIndex))).hostname
     }
     return new URL(decodeURIComponent(raw)).hostname
   } catch (_: unknown) {

--- a/src/components/appContentViewLabels.ts
+++ b/src/components/appContentViewLabels.ts
@@ -50,7 +50,9 @@ function getBrowserLabel(viewId: string): string {
     if (pipeIndex >= 0) {
       const title = decodeURIComponent(raw.slice(pipeIndex + 1)).trim()
       if (title) return title
-      return new URL(decodeURIComponent(raw.slice(0, pipeIndex))).hostname
+      const encodedUrl = raw.slice(0, pipeIndex)
+      if (!encodedUrl) return 'Browser'
+      return new URL(decodeURIComponent(encodedUrl)).hostname
     }
     return new URL(decodeURIComponent(raw)).hostname
   } catch (_: unknown) {

--- a/src/components/appContentViewLabels.ts
+++ b/src/components/appContentViewLabels.ts
@@ -45,7 +45,12 @@ function parseRepoViewId(viewId: string, prefix: string): { repoName: string; su
 
 function getBrowserLabel(viewId: string): string {
   try {
-    return new URL(decodeURIComponent(viewId.slice('browser:'.length))).hostname
+    const raw = viewId.slice('browser:'.length)
+    const pipeIndex = raw.indexOf('|')
+    if (pipeIndex >= 0) {
+      return decodeURIComponent(raw.slice(pipeIndex + 1))
+    }
+    return new URL(decodeURIComponent(raw)).hostname
   } catch (_: unknown) {
     return 'Browser'
   }

--- a/src/components/bookmarks/BookmarkList.tsx
+++ b/src/components/bookmarks/BookmarkList.tsx
@@ -393,7 +393,9 @@ export function BookmarkList({ filterCategory, onOpenTab }: BookmarkListProps) {
     (bookmark: Bookmark) => {
       recordVisit({ id: bookmark._id })
       if (onOpenTab) {
-        onOpenTab(`browser:${encodeURIComponent(bookmark.url)}`)
+        onOpenTab(
+          `browser:${encodeURIComponent(bookmark.url)}|${encodeURIComponent(bookmark.title)}`
+        )
       } else {
         window.shell.openInAppBrowser(bookmark.url, bookmark.title)
       }

--- a/src/components/sidebar/BookmarksSidebar.test.tsx
+++ b/src/components/sidebar/BookmarksSidebar.test.tsx
@@ -94,7 +94,7 @@ describe('BookmarksSidebar', () => {
     expandCategory('Dev Tools')
     fireEvent.click(screen.getByText('Example').closest('[role="button"]') as HTMLElement)
     expect(onItemSelect).toHaveBeenCalledWith(
-      `browser:${encodeURIComponent('https://example.com')}`
+      `browser:${encodeURIComponent('https://example.com')}|${encodeURIComponent('Example')}`
     )
   })
 
@@ -119,7 +119,7 @@ describe('BookmarksSidebar', () => {
       key: 'Enter',
     })
     expect(onItemSelect).toHaveBeenCalledWith(
-      `browser:${encodeURIComponent('https://example.com')}`
+      `browser:${encodeURIComponent('https://example.com')}|${encodeURIComponent('Example')}`
     )
   })
 
@@ -136,7 +136,7 @@ describe('BookmarksSidebar', () => {
   })
 
   it('applies selected class to a selected bookmark', () => {
-    const selectedItem = `browser:${encodeURIComponent('https://example.com')}`
+    const selectedItem = `browser:${encodeURIComponent('https://example.com')}|${encodeURIComponent('Example')}`
     render(<BookmarksSidebar onItemSelect={vi.fn()} selectedItem={selectedItem} />)
 
     expandCategory('Dev Tools')
@@ -307,7 +307,9 @@ describe('BookmarksSidebar', () => {
     render(<BookmarksSidebar onItemSelect={onItemSelect} selectedItem={null} />)
     const item = screen.getByText('Orphan').closest('[role="button"]') as HTMLElement
     fireEvent.keyDown(item, { key: ' ' })
-    expect(onItemSelect).toHaveBeenCalledWith(`browser:${encodeURIComponent('https://orphan.com')}`)
+    expect(onItemSelect).toHaveBeenCalledWith(
+      `browser:${encodeURIComponent('https://orphan.com')}|${encodeURIComponent('Orphan')}`
+    )
   })
 
   it('selects a category via keyboard Enter', () => {
@@ -461,7 +463,7 @@ describe('BookmarksSidebar', () => {
   })
 
   it('applies selected class on uncategorized bookmark', () => {
-    const selectedUrl = `browser:${encodeURIComponent('https://orphan.com')}`
+    const selectedUrl = `browser:${encodeURIComponent('https://orphan.com')}|${encodeURIComponent('Orphan')}`
     mockUseBookmarks.mockReturnValue([
       {
         _id: '10',
@@ -676,7 +678,9 @@ describe('BookmarksSidebar', () => {
     render(<BookmarksSidebar onItemSelect={onItemSelect} selectedItem={null} />)
     const item = screen.getByText('Orphan').closest('[role="button"]') as HTMLElement
     fireEvent.keyDown(item, { key: 'Enter' })
-    expect(onItemSelect).toHaveBeenCalledWith(`browser:${encodeURIComponent('https://orphan.com')}`)
+    expect(onItemSelect).toHaveBeenCalledWith(
+      `browser:${encodeURIComponent('https://orphan.com')}|${encodeURIComponent('Orphan')}`
+    )
   })
 
   it('supports drag-and-drop reorder on uncategorized bookmarks', () => {
@@ -844,7 +848,9 @@ describe('BookmarksSidebar', () => {
 
     render(<BookmarksSidebar onItemSelect={onItemSelect} selectedItem={null} />)
     fireEvent.click(screen.getByText('Orphan').closest('[role="button"]') as HTMLElement)
-    expect(onItemSelect).toHaveBeenCalledWith(`browser:${encodeURIComponent('https://orphan.com')}`)
+    expect(onItemSelect).toHaveBeenCalledWith(
+      `browser:${encodeURIComponent('https://orphan.com')}|${encodeURIComponent('Orphan')}`
+    )
   })
 
   it('renders children of empty-name root node via renderCategoryNode', () => {

--- a/src/components/sidebar/BookmarksSidebar.test.tsx
+++ b/src/components/sidebar/BookmarksSidebar.test.tsx
@@ -113,9 +113,12 @@ describe('BookmarksSidebar', () => {
     const onItemSelect = vi.fn()
     render(<BookmarksSidebar onItemSelect={onItemSelect} selectedItem={null} />)
     expandCategory('Dev Tools')
-    // Component renders without crashing; empty title produces empty label
-    const labels = document.querySelectorAll('.sidebar-item-label')
-    expect(labels.length).toBeGreaterThan(0)
+    const row = document.querySelector('[title="https://example.com"]') as HTMLElement
+    expect(row).toBeInTheDocument()
+    fireEvent.click(row)
+    expect(onItemSelect).toHaveBeenCalledWith(
+      `browser:${encodeURIComponent('https://example.com')}|${encodeURIComponent('')}`
+    )
   })
 
   it('handles bookmarks with empty URL', () => {

--- a/src/components/sidebar/BookmarksSidebar.test.tsx
+++ b/src/components/sidebar/BookmarksSidebar.test.tsx
@@ -98,6 +98,41 @@ describe('BookmarksSidebar', () => {
     )
   })
 
+  it('handles bookmarks with empty title', () => {
+    mockUseBookmarks.mockReturnValue([
+      {
+        _id: '1',
+        url: 'https://example.com',
+        title: '',
+        category: 'Dev Tools',
+        tags: [],
+        sortOrder: 0,
+      },
+    ])
+    mockUseBookmarkCategories.mockReturnValue(['Dev Tools'])
+    const onItemSelect = vi.fn()
+    render(<BookmarksSidebar onItemSelect={onItemSelect} selectedItem={null} />)
+    expandCategory('Dev Tools')
+    // Component renders without crashing; empty title produces empty label
+    const labels = document.querySelectorAll('.sidebar-item-label')
+    expect(labels.length).toBeGreaterThan(0)
+  })
+
+  it('handles bookmarks with empty URL', () => {
+    mockUseBookmarks.mockReturnValue([
+      { _id: '1', url: '', title: 'Example', category: 'Dev Tools', tags: [], sortOrder: 0 },
+    ])
+    mockUseBookmarkCategories.mockReturnValue(['Dev Tools'])
+    const onItemSelect = vi.fn()
+    render(<BookmarksSidebar onItemSelect={onItemSelect} selectedItem={null} />)
+    expandCategory('Dev Tools')
+    expect(screen.getByText('Example')).toBeInTheDocument()
+    fireEvent.click(screen.getByText('Example').closest('[role="button"]') as HTMLElement)
+    expect(onItemSelect).toHaveBeenCalledWith(
+      `browser:${encodeURIComponent('')}|${encodeURIComponent('Example')}`
+    )
+  })
+
   it('expands and collapses a category', () => {
     render(<BookmarksSidebar onItemSelect={vi.fn()} selectedItem={null} />)
 

--- a/src/components/sidebar/BookmarksSidebar.tsx
+++ b/src/components/sidebar/BookmarksSidebar.tsx
@@ -272,7 +272,7 @@ function BookmarkItem({
   onDragEnd,
   onDrop,
 }: BookmarkItemProps) {
-  const bmViewId = `browser:${encodeURIComponent(bm.url)}`
+  const bmViewId = `browser:${encodeURIComponent(bm.url)}|${encodeURIComponent(bm.title)}`
   return (
     <div
       key={bm._id}

--- a/src/components/sidebar/BookmarksSidebar.tsx
+++ b/src/components/sidebar/BookmarksSidebar.tsx
@@ -272,7 +272,7 @@ function BookmarkItem({
   onDragEnd,
   onDrop,
 }: BookmarkItemProps) {
-  const bmViewId = `browser:${encodeURIComponent(bm.url)}|${encodeURIComponent(bm.title)}`
+  const bmViewId = `browser:${encodeURIComponent(bm.url || '')}|${encodeURIComponent(bm.title || '')}`
   return (
     <div
       key={bm._id}

--- a/src/hooks/useAppTabs.test.ts
+++ b/src/hooks/useAppTabs.test.ts
@@ -918,6 +918,7 @@ describe('useAppTabs', () => {
 
       expect(result.current.tabs).toHaveLength(2)
       const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
+      expect(browserTab.viewId).toBe(`browser:${encoded}|${encodeURIComponent('Bookmark Name')}`)
       expect(browserTab.label).toBe('Bookmark Name')
     })
 

--- a/src/hooks/useAppTabs.test.ts
+++ b/src/hooks/useAppTabs.test.ts
@@ -890,6 +890,7 @@ describe('useAppTabs', () => {
       })
 
       expect(result.current.tabs).toHaveLength(2) // dashboard + browser
+      const initialBrowserTabId = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!.id
 
       await act(async () => {
         await result.current.openTab(`browser:${encoded}|${encodeURIComponent('New Title')}`)
@@ -899,6 +900,7 @@ describe('useAppTabs', () => {
       expect(result.current.tabs).toHaveLength(2)
       // The tab's viewId and label should be updated
       const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
+      expect(browserTab.id).toBe(initialBrowserTabId)
       expect(browserTab.viewId).toBe(`browser:${encoded}|${encodeURIComponent('New Title')}`)
       expect(browserTab.label).toBe('New Title')
       expect(result.current.activeViewId).toBe(browserTab.viewId)
@@ -912,6 +914,7 @@ describe('useAppTabs', () => {
       })
 
       expect(result.current.tabs).toHaveLength(2)
+      const initialBrowserTabId = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!.id
 
       await act(async () => {
         await result.current.openTab(`browser:${encoded}|${encodeURIComponent('Bookmark Name')}`)
@@ -919,6 +922,7 @@ describe('useAppTabs', () => {
 
       expect(result.current.tabs).toHaveLength(2)
       const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
+      expect(browserTab.id).toBe(initialBrowserTabId)
       expect(browserTab.viewId).toBe(`browser:${encoded}|${encodeURIComponent('Bookmark Name')}`)
       expect(browserTab.label).toBe('Bookmark Name')
       expect(result.current.activeViewId).toBe(browserTab.viewId)

--- a/src/hooks/useAppTabs.test.ts
+++ b/src/hooks/useAppTabs.test.ts
@@ -877,4 +877,61 @@ describe('useAppTabs', () => {
       expect(result.current.tabs).toBe(tabsBefore)
     })
   })
+
+  describe('browser tab URL-based identity matching', () => {
+    const url = 'https://example.com/page'
+    const encoded = encodeURIComponent(url)
+
+    it('reuses existing browser tab when title changes (bookmark rename)', async () => {
+      const { result } = renderHook(() => useAppTabs({ onViewOpen: vi.fn() }))
+
+      await act(async () => {
+        await result.current.openTab(`browser:${encoded}|${encodeURIComponent('Old Title')}`)
+      })
+
+      expect(result.current.tabs).toHaveLength(2) // dashboard + browser
+
+      await act(async () => {
+        await result.current.openTab(`browser:${encoded}|${encodeURIComponent('New Title')}`)
+      })
+
+      // Should NOT create a duplicate tab
+      expect(result.current.tabs).toHaveLength(2)
+      // The tab's viewId and label should be updated
+      const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
+      expect(browserTab.viewId).toBe(`browser:${encoded}|${encodeURIComponent('New Title')}`)
+      expect(browserTab.label).toBe('New Title')
+    })
+
+    it('reuses browser tab opened without title when opened again with title', async () => {
+      const { result } = renderHook(() => useAppTabs({ onViewOpen: vi.fn() }))
+
+      await act(async () => {
+        await result.current.openTab(`browser:${encoded}`)
+      })
+
+      expect(result.current.tabs).toHaveLength(2)
+
+      await act(async () => {
+        await result.current.openTab(`browser:${encoded}|${encodeURIComponent('Bookmark Name')}`)
+      })
+
+      expect(result.current.tabs).toHaveLength(2)
+      const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
+      expect(browserTab.label).toBe('Bookmark Name')
+    })
+
+    it('does not match different browser URLs', async () => {
+      const { result } = renderHook(() => useAppTabs({ onViewOpen: vi.fn() }))
+
+      await act(async () => {
+        await result.current.openTab(`browser:${encoded}|${encodeURIComponent('Title A')}`)
+        await result.current.openTab(
+          `browser:${encodeURIComponent('https://other.com')}|${encodeURIComponent('Title B')}`
+        )
+      })
+
+      expect(result.current.tabs).toHaveLength(3) // dashboard + 2 browser tabs
+    })
+  })
 })

--- a/src/hooks/useAppTabs.test.ts
+++ b/src/hooks/useAppTabs.test.ts
@@ -939,6 +939,18 @@ describe('useAppTabs', () => {
       })
 
       expect(result.current.tabs).toHaveLength(3) // dashboard + 2 browser tabs
+      expect(
+        result.current.tabs.some(
+          t => t.viewId === `browser:${encoded}|${encodeURIComponent('Title A')}`
+        )
+      ).toBe(true)
+      expect(
+        result.current.tabs.some(
+          t =>
+            t.viewId ===
+            `browser:${encodeURIComponent('https://other.com')}|${encodeURIComponent('Title B')}`
+        )
+      ).toBe(true)
     })
   })
 })

--- a/src/hooks/useAppTabs.test.ts
+++ b/src/hooks/useAppTabs.test.ts
@@ -901,6 +901,7 @@ describe('useAppTabs', () => {
       const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
       expect(browserTab.viewId).toBe(`browser:${encoded}|${encodeURIComponent('New Title')}`)
       expect(browserTab.label).toBe('New Title')
+      expect(result.current.activeViewId).toBe(browserTab.viewId)
     })
 
     it('reuses browser tab opened without title when opened again with title', async () => {
@@ -920,6 +921,7 @@ describe('useAppTabs', () => {
       const browserTab = result.current.tabs.find(t => t.viewId.startsWith('browser:'))!
       expect(browserTab.viewId).toBe(`browser:${encoded}|${encodeURIComponent('Bookmark Name')}`)
       expect(browserTab.label).toBe('Bookmark Name')
+      expect(result.current.activeViewId).toBe(browserTab.viewId)
     })
 
     it('does not match different browser URLs', async () => {

--- a/src/hooks/useAppTabs.ts
+++ b/src/hooks/useAppTabs.ts
@@ -163,11 +163,9 @@ export function useAppTabs({ onViewOpen, onViewClose }: UseAppTabsOptions) {
         // Match browser tabs by URL identity only (ignore mutable title after pipe)
         const browserMatch = findExistingBrowserTab(previousState.tabs, viewId)
         if (browserMatch) {
-          const needsUpdate = browserMatch.viewId !== viewId
-          const updatedTabs = needsUpdate
-            ? previousState.tabs.map(t => (t.id === browserMatch.id ? { ...t, viewId, label } : t))
-            : previousState.tabs
-          if (previousState.activeTabId === browserMatch.id && !needsUpdate) return previousState
+          const updatedTabs = previousState.tabs.map(t =>
+            t.id === browserMatch.id ? { ...t, viewId, label } : t
+          )
           return { ...previousState, tabs: updatedTabs, activeTabId: browserMatch.id }
         }
         return {

--- a/src/hooks/useAppTabs.ts
+++ b/src/hooks/useAppTabs.ts
@@ -61,6 +61,25 @@ function resolveRemainingActiveTabId(nextTabs: Tab[], activeTabId: string | null
   /* v8 ignore stop */
 }
 
+/** Extract the URL identity portion of a browser: viewId (before the pipe). */
+function getBrowserUrlIdentity(viewId: string): string | null {
+  if (!viewId.startsWith('browser:')) return null
+  const slug = viewId.slice('browser:'.length)
+  const pipeIndex = slug.indexOf('|')
+  return pipeIndex >= 0 ? `browser:${slug.slice(0, pipeIndex)}` : viewId
+}
+
+/**
+ * Find an existing browser tab that matches by URL identity, ignoring the
+ * mutable title segment after the pipe. This prevents duplicate tabs when
+ * a bookmark is renamed.
+ */
+function findExistingBrowserTab(tabs: Tab[], viewId: string): Tab | undefined {
+  const identity = getBrowserUrlIdentity(viewId)
+  if (!identity) return undefined
+  return tabs.find(tab => getBrowserUrlIdentity(tab.viewId) === identity)
+}
+
 function resolveActiveTabAfterClose(
   previousState: TabState,
   tabId: string,
@@ -140,6 +159,16 @@ export function useAppTabs({ onViewOpen, onViewClose }: UseAppTabsOptions) {
         if (existingTab) {
           if (previousState.activeTabId === existingTab.id) return previousState
           return { ...previousState, activeTabId: existingTab.id }
+        }
+        // Match browser tabs by URL identity only (ignore mutable title after pipe)
+        const browserMatch = findExistingBrowserTab(previousState.tabs, viewId)
+        if (browserMatch) {
+          const needsUpdate = browserMatch.viewId !== viewId
+          const updatedTabs = needsUpdate
+            ? previousState.tabs.map(t => (t.id === browserMatch.id ? { ...t, viewId, label } : t))
+            : previousState.tabs
+          if (previousState.activeTabId === browserMatch.id && !needsUpdate) return previousState
+          return { ...previousState, tabs: updatedTabs, activeTabId: browserMatch.id }
         }
         return {
           tabs: [...previousState.tabs, { id: newTabId, label, viewId }],

--- a/src/hooks/useWeather.test.ts
+++ b/src/hooks/useWeather.test.ts
@@ -452,10 +452,10 @@ describe('useWeather', () => {
     fetchPromise.catch(() => {})
     mockFetch.mockReturnValueOnce(fetchPromise)
 
-    const { result, unmount } = renderHook(() => useWeather())
+    const { unmount } = renderHook(() => useWeather())
 
-    // Wait for hydration to complete and refresh() to be called (enters loading)
-    await waitFor(() => expect(result.current.loading).toBe(true))
+    // Wait for hydration to complete and refresh() to actually call fetch
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
 
     // Unmount aborts the signal
     unmount()
@@ -881,10 +881,10 @@ describe('useWeather', () => {
     })
     mockFetch.mockReturnValueOnce(fetchPromise)
 
-    const { result, unmount } = renderHook(() => useWeather())
+    const { unmount } = renderHook(() => useWeather())
 
-    // Wait for the effect to fire (hydration) and enter loading
-    await waitFor(() => expect(result.current.loading).toBe(true))
+    // Wait for the effect to fire (hydration) and fetch to actually be called
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled())
 
     // Unmount aborts the signal
     unmount()

--- a/src/hooks/useWeather.ts
+++ b/src/hooks/useWeather.ts
@@ -160,11 +160,10 @@ async function fetchReverseGeocode(
       `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lon}&format=json`,
       { headers: { 'User-Agent': 'hs-buddy/1.0' } }
     )
-    return resp.ok
-      ? ((await resp.json()) as {
-          address?: { city?: string; town?: string; village?: string; state?: string }
-        })
-      : null
+    if (!resp.ok) return null
+    return (await resp.json()) as {
+      address?: { city?: string; town?: string; village?: string; state?: string }
+    }
   } catch (_: unknown) {
     return null
   }
@@ -266,13 +265,14 @@ export function useWeather() {
         }
       })
       .catch(err => {
-        if (!controller.signal.aborted) {
-          setState(prev => ({
-            data: prev.data, // keep stale data visible
-            loading: false,
-            error: getErrorMessageWithFallback(err, 'Failed to fetch weather'),
-          }))
+        if (controller.signal.aborted) {
+          throw err
         }
+        setState(prev => ({
+          data: prev.data, // keep stale data visible
+          loading: false,
+          error: getErrorMessageWithFallback(err, 'Failed to fetch weather'),
+        }))
         throw err
       })
   }, [])


### PR DESCRIPTION
Tab headers now display the bookmark's title (matching what's shown in the treeview sidebar) instead of just the URL hostname.

## Implementation
- Encode title in browser viewId format: \rowser:<url>|<title>\
- \getBrowserLabel\ extracts title from pipe-separated format
- Backwards-compatible: old format (no pipe) falls back to hostname

## Changes
8 files, +45 / -11 — single commit.