### PR TITLE
Add Copilot usage org totals

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
+src/**/* text=auto eol=lf
+
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 .husky/* text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.788] - 2026-06-03
+
+### Fixed
+
+- Address Copilot usage review feedback
+
 ## [0.1.787] - 2026-06-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Migrate Copilot Usage page to June 2026 AI Credits billing
+- Add Copilot usage org totals
 
 ## [0.1.785] - 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.787] - 2026-06-03
+
+### Changed
+
+- Enforce LF for source files
+
 ## [0.1.786] - 2026-06-01
 
 ### Changed

--- a/electron/ipc/copilotMetricsHandlers.test.ts
+++ b/electron/ipc/copilotMetricsHandlers.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { join, resolve } from 'node:path'
+import { IPC_INVOKE } from '../../src/ipc/contracts'
+
+const mocks = vi.hoisted(() => ({
+  appGetPath: vi.fn(),
+  ipcHandle: vi.fn(),
+  normalizeSnapshot: vi.fn(),
+  parseContent: vi.fn(),
+  readFile: vi.fn(),
+  stat: vi.fn(),
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: mocks.appGetPath,
+  },
+  ipcMain: {
+    handle: mocks.ipcHandle,
+  },
+}))
+
+vi.mock('node:fs/promises', () => ({
+  readFile: mocks.readFile,
+  stat: mocks.stat,
+}))
+
+vi.mock('../../src/utils/copilotEnterpriseUsers', () => ({
+  normalizeCopilotEnterpriseUsersSnapshot: mocks.normalizeSnapshot,
+  parseCopilotEnterpriseUsersContent: mocks.parseContent,
+}))
+
+import { registerCopilotMetricsHandlers, resolveCopilotMetricsFile } from './copilotMetricsHandlers'
+
+const originalMetricsFile = process.env.COPILOT_METRICS_FILE
+
+describe('copilotMetricsHandlers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    if (originalMetricsFile === undefined) delete process.env.COPILOT_METRICS_FILE
+    else process.env.COPILOT_METRICS_FILE = originalMetricsFile
+    mocks.appGetPath.mockReturnValue('C:\\Users\\User\\AppData\\Roaming\\hs-buddy')
+  })
+
+  it('resolves an explicit Copilot metrics file override', () => {
+    process.env.COPILOT_METRICS_FILE = 'C:\\metrics\\copilot-metrics.json'
+
+    expect(resolveCopilotMetricsFile()).toBe(resolve('C:\\metrics\\copilot-metrics.json'))
+    expect(mocks.appGetPath).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the portable Electron userData location', () => {
+    delete process.env.COPILOT_METRICS_FILE
+
+    expect(resolveCopilotMetricsFile()).toBe(
+      join('C:\\Users\\User\\AppData\\Roaming\\hs-buddy', 'copilot-metrics.json')
+    )
+  })
+
+  it('reads the resolved file path when handling enterprise users', async () => {
+    const metricsFile = 'C:\\metrics\\copilot-metrics.json'
+    const parsed = { users: [] }
+    const snapshot = { generatedAt: '2026-06-03T00:00:00.000Z', users: [] }
+    process.env.COPILOT_METRICS_FILE = metricsFile
+    mocks.stat.mockResolvedValue({ mtime: new Date('2026-06-03T01:02:03.000Z') })
+    mocks.readFile.mockResolvedValue('{"users":[]}')
+    mocks.parseContent.mockReturnValue(parsed)
+    mocks.normalizeSnapshot.mockReturnValue(snapshot)
+
+    registerCopilotMetricsHandlers()
+    const handler = mocks.ipcHandle.mock.calls.find(
+      ([channel]) => channel === IPC_INVOKE.GITHUB_GET_COPILOT_ENTERPRISE_USERS
+    )?.[1]
+
+    const result = await handler()
+    const resolvedFile = resolve(metricsFile)
+
+    expect(mocks.stat).toHaveBeenCalledWith(resolvedFile)
+    expect(mocks.readFile).toHaveBeenCalledWith(resolvedFile, 'utf-8')
+    expect(mocks.normalizeSnapshot).toHaveBeenCalledWith(parsed, {
+      sourceFile: resolvedFile,
+      fileLastWriteTime: '2026-06-03T01:02:03.000Z',
+    })
+    expect(result).toEqual({ success: true, data: snapshot })
+  })
+})

--- a/electron/ipc/copilotMetricsHandlers.ts
+++ b/electron/ipc/copilotMetricsHandlers.ts
@@ -1,5 +1,6 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
 import { IPC_INVOKE } from '../../src/ipc/contracts'
 import {
   normalizeCopilotEnterpriseUsersSnapshot,
@@ -8,21 +9,29 @@ import {
 import type { CopilotEnterpriseUsersResponse } from '../../src/types/copilotEnterpriseUsers'
 import { getErrorMessageWithFallback } from '../../src/utils/errorUtils'
 
-const COPILOT_METRICS_FILE = 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json'
+const COPILOT_METRICS_FILE_ENV = 'COPILOT_METRICS_FILE'
+
+export function resolveCopilotMetricsFile(): string {
+  const configuredPath = process.env[COPILOT_METRICS_FILE_ENV]?.trim()
+  if (configuredPath) return resolve(configuredPath)
+
+  return join(app.getPath('userData'), 'copilot-metrics.json')
+}
 
 export function registerCopilotMetricsHandlers(): void {
   ipcMain.handle(
     IPC_INVOKE.GITHUB_GET_COPILOT_ENTERPRISE_USERS,
     async (): Promise<CopilotEnterpriseUsersResponse> => {
       try {
+        const metricsFile = resolveCopilotMetricsFile()
         const [fileStats, content] = await Promise.all([
-          stat(COPILOT_METRICS_FILE),
-          readFile(COPILOT_METRICS_FILE, 'utf-8'),
+          stat(metricsFile),
+          readFile(metricsFile, 'utf-8'),
         ])
         const snapshot = normalizeCopilotEnterpriseUsersSnapshot(
           parseCopilotEnterpriseUsersContent(content),
           {
-            sourceFile: COPILOT_METRICS_FILE,
+            sourceFile: metricsFile,
             fileLastWriteTime: fileStats.mtime.toISOString(),
           }
         )

--- a/electron/ipc/copilotMetricsHandlers.ts
+++ b/electron/ipc/copilotMetricsHandlers.ts
@@ -1,0 +1,39 @@
+import { ipcMain } from 'electron'
+import { readFile, stat } from 'node:fs/promises'
+import { IPC_INVOKE } from '../../src/ipc/contracts'
+import {
+  normalizeCopilotEnterpriseUsersSnapshot,
+  parseCopilotEnterpriseUsersContent,
+} from '../../src/utils/copilotEnterpriseUsers'
+import type { CopilotEnterpriseUsersResponse } from '../../src/types/copilotEnterpriseUsers'
+import { getErrorMessageWithFallback } from '../../src/utils/errorUtils'
+
+const COPILOT_METRICS_FILE = 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json'
+
+export function registerCopilotMetricsHandlers(): void {
+  ipcMain.handle(
+    IPC_INVOKE.GITHUB_GET_COPILOT_ENTERPRISE_USERS,
+    async (): Promise<CopilotEnterpriseUsersResponse> => {
+      try {
+        const [fileStats, content] = await Promise.all([
+          stat(COPILOT_METRICS_FILE),
+          readFile(COPILOT_METRICS_FILE, 'utf-8'),
+        ])
+        const snapshot = normalizeCopilotEnterpriseUsersSnapshot(
+          parseCopilotEnterpriseUsersContent(content),
+          {
+            sourceFile: COPILOT_METRICS_FILE,
+            fileLastWriteTime: fileStats.mtime.toISOString(),
+          }
+        )
+
+        return { success: true, data: snapshot }
+      } catch (error: unknown) {
+        return {
+          success: false,
+          error: getErrorMessageWithFallback(error, 'Failed to read Copilot Enterprise users file'),
+        }
+      }
+    }
+  )
+}

--- a/electron/ipc/index.ts
+++ b/electron/ipc/index.ts
@@ -16,6 +16,7 @@ import { registerFilesystemHandlers } from './filesystemHandlers'
 import { registerRalphHandlers } from './ralphHandlers'
 import { registerSlackHandlers } from './slackHandlers'
 import { registerPollenHandlers } from './pollenHandlers'
+import { registerCopilotMetricsHandlers } from './copilotMetricsHandlers'
 
 export function registerAllHandlers(win: BrowserWindow): void {
   // Patch ipcMain.handle before any handlers register — gives every
@@ -38,4 +39,5 @@ export function registerAllHandlers(win: BrowserWindow): void {
   registerRalphHandlers(win)
   registerSlackHandlers()
   registerPollenHandlers()
+  registerCopilotMetricsHandlers()
 }

--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -77,8 +77,10 @@ vi.mock('./zoom', () => ({ loadZoomLevel: vi.fn(() => 1.0) }))
 vi.mock('./menu', () => ({ buildMenu: vi.fn(() => ({})), registerKeyboardShortcuts: vi.fn() }))
 vi.mock('./ipc', () => ({ registerAllHandlers: vi.fn() }))
 const mockDispatcher = { start: vi.fn(), stop: vi.fn() }
-vi.mock('./workers', () => ({
+vi.mock('./workers/dispatcher', () => ({
   getDispatcher: vi.fn(() => mockDispatcher),
+}))
+vi.mock('./workers/offlineSync', () => ({
   runOfflineSync: vi.fn(async () => ({
     runsCreated: 0,
     schedulesProcessed: 0,

--- a/electron/preload.test.ts
+++ b/electron/preload.test.ts
@@ -431,6 +431,11 @@ describe('preload', () => {
         true
       )
     })
+
+    it('getCopilotEnterpriseUsers invokes github:get-copilot-enterprise-users', () => {
+      exposedApis.github.getCopilotEnterpriseUsers()
+      expect(mockInvoke).toHaveBeenCalledWith(IPC_INVOKE.GITHUB_GET_COPILOT_ENTERPRISE_USERS)
+    })
   })
 
   describe('crew bridge - additional methods', () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -78,6 +78,8 @@ contextBridge.exposeInMainWorld('github', {
           skipDayProbing
         )
       : Promise.resolve({ success: false, error: 'Invalid arguments' }),
+  getCopilotEnterpriseUsers: () =>
+    ipcRenderer.invoke(IPC_INVOKE.GITHUB_GET_COPILOT_ENTERPRISE_USERS),
 })
 
 contextBridge.exposeInMainWorld('crew', {

--- a/electron/services/copilotSessionService.test.ts
+++ b/electron/services/copilotSessionService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest'
 import { EventEmitter } from 'events'
 
 const mockExistsSync = vi.fn((_p: string): boolean => false)
-const mockReadFileSync = vi.fn((_p: string): string => {
+const mockReadFileSync = vi.fn((_p: string, _encoding?: BufferEncoding): string => {
   throw new Error('ENOENT')
 })
 const mockOpenSync = vi.fn((_p: string): number => 3)
@@ -15,7 +15,7 @@ const mockStatSync = vi.fn((_p: string) => ({ size: 100, mtimeMs: Date.now() }))
 
 vi.mock('fs', () => ({
   existsSync: (p: string) => mockExistsSync(p),
-  readFileSync: (p: string) => mockReadFileSync(p),
+  readFileSync: (p: string, encoding?: BufferEncoding) => mockReadFileSync(p, encoding),
   openSync: (p: string) => mockOpenSync(p),
   readSync: (fd: number, buf: Buffer, off: number, len: number, pos: number | null) =>
     mockReadSync(fd, buf, off, len, pos),
@@ -416,6 +416,33 @@ describe('copilotSessionService', () => {
       expect(result!.workspaceHash).toBe('hash1')
       expect(mockParseKeyPath).toHaveBeenCalled()
       expect(mockProcessSessionLine).toHaveBeenCalled()
+    })
+
+    it('parses small JSONL files without opening a stream', async () => {
+      mockExistsSync.mockReturnValue(true)
+      mockReadFileSync.mockReturnValue('{"kind":1,"data":"init"}\ninvalid line without kind')
+      const { createReadStream } = await import('fs')
+
+      mockProcessSessionLine.mockImplementation(
+        (_kind: number, _keyPath: unknown, _line: string, state: Record<string, unknown>) => {
+          state.init = {
+            sessionId: 'small-session',
+            creationDate: 1000,
+            model: 'gpt-4',
+          }
+          state.title = 'Small Session'
+        }
+      )
+
+      const result = await getSessionDetail('/workspace/hash1/chatSessions/test.jsonl')
+
+      expect(result).not.toBeNull()
+      expect(result!.sessionId).toBe('small-session')
+      expect(mockReadFileSync).toHaveBeenCalledWith(
+        '/workspace/hash1/chatSessions/test.jsonl',
+        'utf8'
+      )
+      expect(createReadStream).not.toHaveBeenCalled()
     })
 
     it('uses fallback title when state.title is empty', async () => {

--- a/electron/services/copilotSessionService.ts
+++ b/electron/services/copilotSessionService.ts
@@ -16,6 +16,53 @@ import {
 } from '../../src/utils/copilotSessionParsing'
 import { aggregateResults } from '../../src/utils/sessionDigest'
 
+const SMALL_SESSION_FILE_BYTES = 128 * 1024
+
+function createSessionParseState(): SessionParseState {
+  return {
+    init: null,
+    title: '',
+    resultsByIndex: new Map(),
+    prompts: new Map(),
+  }
+}
+
+function processSessionContentLine(line: string, state: SessionParseState): void {
+  const kindMatch = /^\{"kind":(\d+)/.exec(line)
+  if (!kindMatch) return
+
+  const kind = parseInt(kindMatch[1])
+  const keyPath = parseKeyPath(line)
+  processSessionLine(kind, keyPath, line, state)
+}
+
+function parseSessionContent(
+  content: string,
+  workspaceHash: string,
+  filePath: string
+): CopilotSession | null {
+  const state = createSessionParseState()
+
+  for (const line of content.split(/\r?\n/)) {
+    processSessionContentLine(line, state)
+  }
+
+  return buildSessionFromState(state, workspaceHash, filePath)
+}
+
+function readSmallSessionDetail(
+  filePath: string,
+  workspaceHash: string
+): CopilotSession | null | undefined {
+  try {
+    if (fs.statSync(filePath).size > SMALL_SESSION_FILE_BYTES) return undefined
+
+    return parseSessionContent(fs.readFileSync(filePath, 'utf8'), workspaceHash, filePath)
+  } catch (_: unknown) {
+    return undefined
+  }
+}
+
 // ─── VS Code Storage Discovery ────────────────────────────
 
 export function getVSCodeStoragePath(): string {
@@ -137,24 +184,17 @@ export async function getSessionDetail(filePath: string): Promise<CopilotSession
   if (!fs.existsSync(filePath)) return null
 
   const workspaceHash = path.basename(path.dirname(path.dirname(filePath)))
+  const smallSession = readSmallSessionDetail(filePath, workspaceHash)
+  if (smallSession !== undefined) return smallSession
 
   return new Promise(resolve => {
-    const state: SessionParseState = {
-      init: null,
-      title: '',
-      resultsByIndex: new Map(),
-      prompts: new Map(),
-    }
+    const state = createSessionParseState()
 
     const stream = fs.createReadStream(filePath, { encoding: 'utf8' })
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity })
 
     rl.on('line', line => {
-      const kindMatch = /^\{"kind":(\d+)/.exec(line)
-      if (!kindMatch) return
-      const kind = parseInt(kindMatch[1])
-      const keyPath = parseKeyPath(line)
-      processSessionLine(kind, keyPath, line, state)
+      processSessionContentLine(line, state)
     })
 
     rl.on('close', () => resolve(buildSessionFromState(state, workspaceHash, filePath)))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.786",
+  "version": "0.1.787",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.787",
+  "version": "0.1.788",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/browser-ipc-mock.ts
+++ b/src/browser-ipc-mock.ts
@@ -115,6 +115,8 @@ export function installBrowserIpcMock(): void {
     getCopilotBudget: () => Promise.resolve({ success: false }),
     getCopilotMemberUsage: () => Promise.resolve({ success: false }),
     getUserPremiumRequests: () => Promise.resolve({ success: false }),
+    getCopilotEnterpriseUsers: () =>
+      Promise.resolve({ success: false, error: 'Browser mock: metrics file unavailable' }),
   }
   w.terminal = {
     spawn: () => Promise.resolve({ success: false, error: 'Browser mock' }),

--- a/src/components/CopilotUsagePanel.css
+++ b/src/components/CopilotUsagePanel.css
@@ -351,30 +351,107 @@
   gap: 10px;
 }
 
-.top-users-table {
+.top-users-meta {
   display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--text-secondary, #888);
+  font-size: 11px;
+}
+
+.top-users-meta span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 22px;
+  padding: 3px 8px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.enterprise-users-filter {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.enterprise-users-filter-box {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: min(360px, 100%);
+  min-height: 32px;
+  padding: 0 10px;
+  border: 1px solid var(--border-primary, #3c3c3c);
+  border-radius: 6px;
+  background: var(--bg-secondary, #252526);
+  color: var(--text-secondary, #888);
+}
+
+.enterprise-users-filter-box input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--text-primary, #ccc);
+  font: inherit;
+  font-size: 12px;
+}
+
+.enterprise-users-filter-box input::placeholder {
+  color: var(--text-tertiary, #666);
+}
+
+.enterprise-users-filter-count {
+  color: var(--text-tertiary, #666);
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.enterprise-users-message {
+  padding: 14px;
+  border: 1px solid var(--border-primary, #3c3c3c);
+  border-radius: 8px;
+  background: var(--bg-secondary, #252526);
+  color: var(--text-secondary, #888);
+  font-size: 12px;
+}
+
+.enterprise-users-message-error {
+  color: #e89b3c;
+}
+
+.enterprise-users-table {
+  overflow-x: auto;
+  overflow-y: hidden;
   border: 1px solid var(--border-primary, #3c3c3c);
   border-radius: 8px;
   background: var(--bg-secondary, #252526);
 }
 
-.top-users-header,
-.top-users-row {
+.enterprise-users-header,
+.enterprise-users-row {
   display: grid;
   grid-template-columns:
-    42px minmax(160px, 1.8fr) minmax(120px, 1fr) minmax(92px, 0.7fr) minmax(90px, 0.7fr)
-    minmax(100px, 0.8fr);
+    42px minmax(150px, 1.6fr) minmax(92px, 0.7fr) minmax(80px, 0.55fr)
+    minmax(58px, 0.4fr) minmax(170px, 1.3fr) minmax(76px, 0.55fr);
   align-items: center;
   gap: 12px;
+  min-width: 740px;
   min-height: 38px;
   padding: 0 14px;
 }
 
-.top-users-header {
+.enterprise-users-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
   min-height: 34px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--bg-secondary, #252526);
   color: var(--text-secondary, #888);
   font-size: 10px;
   font-weight: 600;
@@ -382,72 +459,157 @@
   letter-spacing: 0.5px;
 }
 
-.top-users-row {
+.enterprise-users-row {
+  width: 100%;
+  border: 0;
+  background: transparent;
   color: var(--text-primary, #ccc);
   font-size: 12px;
+  text-align: left;
+  cursor: pointer;
 }
 
-.top-users-row + .top-users-row {
+.enterprise-users-row + .enterprise-users-row {
   border-top: 1px solid rgba(255, 255, 255, 0.04);
 }
 
-.top-users-rank,
-.top-users-requests {
+.enterprise-users-row:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.enterprise-users-row:focus-visible {
+  outline: 1px solid #4ec9b0;
+  outline-offset: -1px;
+  background: rgba(78, 201, 176, 0.08);
+}
+
+.enterprise-users-rank,
+.enterprise-users-credits,
+.enterprise-users-money,
+.enterprise-users-model-count {
   font-family: var(--font-family-mono, 'Cascadia Code', monospace);
 }
 
-.top-users-rank {
+.enterprise-users-rank {
   color: var(--text-tertiary, #666);
 }
 
-.top-users-login {
+.enterprise-users-login,
+.enterprise-users-model {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.enterprise-users-login {
   color: var(--text-heading, #e8e8e8);
   font-weight: 600;
 }
 
-.top-users-org,
-.top-users-plan,
-.top-users-editor {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.enterprise-users-model,
+.enterprise-users-status {
   color: var(--text-secondary, #888);
 }
 
-.top-users-requests {
-  color: #4ec9b0;
-  font-weight: 700;
+.enterprise-users-credits,
+.enterprise-users-money,
+.enterprise-users-model-count {
   text-align: right;
 }
 
-.top-users-errors {
+.enterprise-users-credits {
+  color: #4ec9b0;
+  font-weight: 700;
+}
+
+.enterprise-users-json-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(0, 0, 0, 0.58);
+  backdrop-filter: blur(4px);
+}
+
+.enterprise-users-json-backdrop {
+  position: absolute;
+  inset: 0;
+  border: 0;
+  background: transparent;
+  cursor: default;
+}
+
+.enterprise-users-json-modal {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  width: min(920px, calc(100vw - 48px));
+  max-height: min(760px, calc(100vh - 48px));
+  overflow: hidden;
+  border: 1px solid var(--border-primary, #3c3c3c);
+  border-radius: 8px;
+  background: var(--bg-primary, #1e1e1e);
+  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.45);
 }
 
-.top-users-truncated {
+.enterprise-users-json-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: var(--bg-secondary, #252526);
+}
+
+.enterprise-users-json-header h4 {
   margin: 0;
-  color: #e89b3c;
-  font-size: 11px;
+  color: var(--text-heading, #e8e8e8);
+  font-size: 14px;
+  font-weight: 700;
 }
 
-@media (max-width: 760px) {
-  .top-users-header,
-  .top-users-row {
-    grid-template-columns: 34px minmax(120px, 1fr) minmax(76px, 0.6fr);
-  }
+.enterprise-users-json-header p {
+  margin: 4px 0 0;
+  color: var(--text-tertiary, #666);
+  font-size: 11px;
+  word-break: break-all;
+}
 
-  .top-users-org,
-  .top-users-plan,
-  .top-users-editor {
-    display: none;
-  }
+.enterprise-users-json-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-secondary, #888);
+  cursor: pointer;
+}
+
+.enterprise-users-json-close:hover {
+  color: var(--text-heading, #e8e8e8);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.enterprise-users-json-block {
+  margin: 0;
+  padding: 16px;
+  overflow: auto;
+  color: #d4d4d4;
+  background: #151515;
+  font-family: var(--font-family-mono, 'Cascadia Code', monospace);
+  font-size: 12px;
+  line-height: 1.55;
+  white-space: pre;
 }
 
 .usage-budgets-section {
@@ -488,6 +650,32 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.usage-org-budget-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding-top: 10px;
+  border-top: 1px dashed rgba(255, 255, 255, 0.08);
+}
+
+.usage-org-budget-summary-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.usage-org-budget-summary-title {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex: 1;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary, #888);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
 }
 
 .usage-budget-org-name {
@@ -555,6 +743,36 @@
 .usage-share-of-org-value {
   color: rgba(255, 255, 255, 0.8);
   font-variant-numeric: tabular-nums;
+}
+
+.usage-org-pool {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-primary, #3c3c3c);
+  border-radius: 8px;
+  background: var(--bg-secondary, #252526);
+}
+
+.usage-org-pool-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 11px;
+}
+
+.usage-org-pool-label {
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.usage-org-pool-value {
+  color: rgba(255, 255, 255, 0.8);
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-family-mono, 'Cascadia Code', monospace);
 }
 
 .usage-budget-bar-myshare {

--- a/src/components/CopilotUsagePanel.css
+++ b/src/components/CopilotUsagePanel.css
@@ -550,10 +550,13 @@
   flex-direction: column;
   width: min(920px, calc(100vw - 48px));
   max-height: min(760px, calc(100vh - 48px));
+  margin: 0;
+  padding: 0;
   overflow: hidden;
   border: 1px solid var(--border-primary, #3c3c3c);
   border-radius: 8px;
   background: var(--bg-primary, #1e1e1e);
+  color: inherit;
   box-shadow: 0 18px 60px rgba(0, 0, 0, 0.45);
 }
 

--- a/src/components/CopilotUsagePanel.test.tsx
+++ b/src/components/CopilotUsagePanel.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { CopilotUsagePanel } from './CopilotUsagePanel'
 
 let mockAccounts: Array<{ username: string; org?: string }> = [
@@ -9,6 +9,13 @@ let mockAggregateProjections: { projectedTotal: number; projectedOverageCost: nu
   projectedTotal: 200,
   projectedOverageCost: 0,
 }
+let mockAggregateSpend: { totalSpent: number; projectedSpend: number } | null = {
+  totalSpent: 50,
+  projectedSpend: 100,
+}
+let mockOrgBudgets: Record<string, { data: unknown; loading: boolean; error: string | null }> = {}
+let mockOrgOverageFromQuotas = new Map<string, number>()
+const mockRefreshAll = vi.fn()
 
 vi.mock('../hooks/useCopilotUsage', () => ({
   useCopilotUsage: () => ({
@@ -24,69 +31,83 @@ vi.mock('../hooks/useCopilotUsage', () => ({
         },
       },
     },
-    orgBudgets: {},
+    orgBudgets: mockOrgBudgets,
     uniqueOrgs: new Map([['testorg', 'testuser']]),
-    refreshAll: vi.fn(),
+    refreshAll: mockRefreshAll,
     anyLoading: false,
-    aggregateTotals: { totalUsed: 100, totalOverageCost: 0 },
+    aggregateTotals: { totalUsed: 100, totalEntitlement: 500, totalOverageCost: 0 },
     aggregateProjections: mockAggregateProjections,
-    orgOverageFromQuotas: {},
-  }),
-}))
-
-vi.mock('../hooks/useCopilotSeats', () => ({
-  useCopilotSeats: () => ({
-    seats: [
-      {
-        login: 'alice',
-        displayName: null,
-        org: 'testorg',
-        planType: 'business',
-        lastActivityAt: null,
-        lastActivityEditor: 'vscode/1.95.0',
-        createdAt: null,
-        pendingCancellation: null,
-        premiumRequests: 42,
-        lastPremiumRequestDate: null,
-      },
-    ],
-    loading: false,
-    orgErrors: [],
-    truncated: false,
-    refresh: vi.fn(),
+    aggregateSpend: mockAggregateSpend,
+    orgOverageFromQuotas: mockOrgOverageFromQuotas,
   }),
 }))
 
 vi.mock('./copilot-usage/AccountQuotaCard', () => ({
-  AccountQuotaCard: ({ account }: { account: { username: string; org: string } }) => (
+  AccountQuotaCard: ({
+    account,
+    budgetState,
+    quotaOverage,
+  }: {
+    account: { username: string; org: string }
+    budgetState?: { data: unknown; loading: boolean; error: string | null }
+    quotaOverage?: number
+  }) => (
     <div data-testid={`quota-card-${account.username}`}>
-      Quota: {account.username} org={account.org}
+      Quota: {account.username} org={account.org} budget={budgetState ? 'yes' : 'no'} overage=
+      {quotaOverage ?? 0}
     </div>
   ),
-}))
-
-vi.mock('./copilot-usage/OrgBudgetsSection', () => ({
-  OrgBudgetsSection: () => <div data-testid="org-budgets">Org Budgets</div>,
 }))
 
 vi.mock('./copilot-usage/UsageHeader', () => ({
   UsageHeader: ({
     totalUsed,
     projectedTotal,
+    totalSpent,
+    projectedSpend,
+    onRefreshAll,
   }: {
     totalUsed: number
     projectedTotal: number | null
+    totalSpent: number | null
+    projectedSpend: number | null
+    onRefreshAll: () => void
   }) => (
     <div data-testid="usage-header">
-      Total: {totalUsed} Projected: {projectedTotal === null ? 'null' : projectedTotal}
+      Total: {totalUsed} Projected: {projectedTotal === null ? 'null' : projectedTotal} Spend:{' '}
+      {totalSpent === null ? 'null' : totalSpent} ProjSpend:{' '}
+      {projectedSpend === null ? 'null' : projectedSpend}
+      <button type="button" onClick={onRefreshAll}>
+        Refresh
+      </button>
     </div>
   ),
+}))
+
+const mockTopUsersSection = vi.fn()
+
+vi.mock('./copilot-usage/TopUsersSection', () => ({
+  TopUsersSection: ({ refreshToken }: { refreshToken: number }) => {
+    mockTopUsersSection(refreshToken)
+    return (
+      <div>
+        <h3>Copilot Enterprise Users</h3>
+        <span>fhemmerrelias</span>
+        <span data-testid="enterprise-users-refresh-token">{refreshToken}</span>
+      </div>
+    )
+  },
 }))
 
 describe('CopilotUsagePanel', () => {
   beforeEach(() => {
     mockAccounts = [{ username: 'testuser', org: 'testorg' }]
     mockAggregateProjections = { projectedTotal: 200, projectedOverageCost: 0 }
+    mockAggregateSpend = { totalSpent: 50, projectedSpend: 100 }
+    mockOrgBudgets = {}
+    mockOrgOverageFromQuotas = new Map()
+    mockRefreshAll.mockClear()
+    mockTopUsersSection.mockClear()
   })
 
   it('renders usage header', () => {
@@ -95,21 +116,42 @@ describe('CopilotUsagePanel', () => {
     expect(screen.getByText(/Total: 100/)).toBeTruthy()
   })
 
+  it('passes aggregate spend through to the header', () => {
+    render(<CopilotUsagePanel />)
+    expect(screen.getByText(/Spend: 50/)).toBeTruthy()
+    expect(screen.getByText(/ProjSpend: 100/)).toBeTruthy()
+  })
+
   it('renders account quota cards', () => {
     render(<CopilotUsagePanel />)
     expect(screen.getByTestId('quota-card-testuser')).toBeTruthy()
   })
 
-  it('renders org budgets section', () => {
+  it('passes org budget details to account quota cards', () => {
+    mockOrgBudgets = {
+      testorg: { data: { spent: 42 }, loading: false, error: null },
+    }
+    mockOrgOverageFromQuotas = new Map([['testorg', 12]])
     render(<CopilotUsagePanel />)
-    expect(screen.getByTestId('org-budgets')).toBeTruthy()
+    expect(screen.getByText(/budget=yes/)).toBeTruthy()
+    expect(screen.getByText(/overage=12/)).toBeTruthy()
   })
 
-  it('renders top premium request users section', () => {
+  it('renders the Copilot enterprise users section', () => {
     render(<CopilotUsagePanel />)
-    expect(screen.getByText('Top AI Credit Users')).toBeTruthy()
-    expect(screen.getByText('alice')).toBeTruthy()
-    expect(screen.getByText('42')).toBeTruthy()
+    expect(screen.getByText('Copilot Enterprise Users')).toBeTruthy()
+    expect(screen.getByText('fhemmerrelias')).toBeTruthy()
+  })
+
+  it('refreshes the Copilot Enterprise users list when the page refresh button is clicked', () => {
+    render(<CopilotUsagePanel />)
+
+    expect(screen.getByTestId('enterprise-users-refresh-token').textContent).toBe('0')
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }))
+
+    expect(mockRefreshAll).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('enterprise-users-refresh-token').textContent).toBe('1')
+    expect(mockTopUsersSection).toHaveBeenLastCalledWith(1)
   })
 })
 
@@ -127,6 +169,16 @@ describe('CopilotUsagePanel – null projections', () => {
     mockAccounts = [{ username: 'testuser', org: 'testorg' }]
     render(<CopilotUsagePanel />)
     expect(screen.getByText(/Projected: null/)).toBeTruthy()
+  })
+})
+
+describe('CopilotUsagePanel – null aggregate spend', () => {
+  it('passes null spend through to the header when aggregateSpend is null', () => {
+    mockAggregateSpend = null
+    mockAccounts = [{ username: 'testuser', org: 'testorg' }]
+    render(<CopilotUsagePanel />)
+    expect(screen.getByText(/Spend: null/)).toBeTruthy()
+    expect(screen.getByText(/ProjSpend: null/)).toBeTruthy()
   })
 })
 

--- a/src/components/CopilotUsagePanel.tsx
+++ b/src/components/CopilotUsagePanel.tsx
@@ -1,11 +1,11 @@
 import { AlertCircle } from 'lucide-react'
+import { useCallback, useState } from 'react'
 import { useCopilotUsage } from '../hooks/useCopilotUsage'
 import type { AccountQuotaState } from './copilot-usage/quotaUtils'
+import type { OrgBudgetState } from './copilot-usage/types'
 import { AccountQuotaCard } from './copilot-usage/AccountQuotaCard'
-import { OrgBudgetsSection } from './copilot-usage/OrgBudgetsSection'
 import { TopUsersSection } from './copilot-usage/TopUsersSection'
 import { UsageHeader } from './copilot-usage/UsageHeader'
-import { useCopilotSeats } from '../hooks/useCopilotSeats'
 import './CopilotUsagePanel.css'
 
 function resolveProjection(
@@ -23,9 +23,13 @@ function resolveProjection(
 function AccountsGrid({
   accounts,
   quotas,
+  orgBudgets,
+  orgOverageFromQuotas,
 }: {
   accounts: { username: string; org?: string }[]
   quotas: Record<string, AccountQuotaState>
+  orgBudgets: Record<string, OrgBudgetState>
+  orgOverageFromQuotas: Map<string, number>
 }) {
   if (accounts.length === 0) {
     return (
@@ -46,6 +50,8 @@ function AccountsGrid({
                 key={account.username}
                 account={{ username: account.username, org: account.org ?? '' }}
                 state={quotas[account.username]}
+                budgetState={account.org ? orgBudgets[account.org] : undefined}
+                quotaOverage={account.org ? (orgOverageFromQuotas.get(account.org) ?? 0) : 0}
               />,
             ]
       )}
@@ -54,49 +60,49 @@ function AccountsGrid({
 }
 
 export function CopilotUsagePanel() {
+  const [enterpriseUsersRefreshToken, setEnterpriseUsersRefreshToken] = useState(0)
   const {
     accounts,
     quotas,
     orgBudgets,
-    uniqueOrgs,
     refreshAll,
     anyLoading,
     aggregateTotals,
     aggregateProjections,
+    aggregateSpend,
     orgOverageFromQuotas,
   } = useCopilotUsage()
-  const topUsers = useCopilotSeats(uniqueOrgs)
 
   const projections = resolveProjection(aggregateProjections)
+  const handleRefreshAll = useCallback(() => {
+    refreshAll()
+    setEnterpriseUsersRefreshToken(token => token + 1)
+  }, [refreshAll])
 
   return (
     <div className="copilot-usage-panel">
       <UsageHeader
         totalUsed={aggregateTotals.totalUsed}
+        totalEntitlement={aggregateTotals.totalEntitlement}
         totalOverageCost={aggregateTotals.totalOverageCost}
+        totalSpent={aggregateSpend?.totalSpent ?? null}
+        projectedSpend={aggregateSpend?.projectedSpend ?? null}
         projectedTotal={projections.projectedTotal}
         projectedOverageCost={projections.projectedOverageCost}
         anyLoading={anyLoading}
-        onRefreshAll={refreshAll}
+        onRefreshAll={handleRefreshAll}
       />
 
       <div className="usage-accounts-grid">
-        <AccountsGrid accounts={accounts} quotas={quotas} />
+        <AccountsGrid
+          accounts={accounts}
+          quotas={quotas}
+          orgBudgets={orgBudgets}
+          orgOverageFromQuotas={orgOverageFromQuotas}
+        />
       </div>
 
-      <TopUsersSection
-        seats={topUsers.seats}
-        loading={topUsers.loading}
-        orgErrors={topUsers.orgErrors}
-        truncated={topUsers.truncated}
-        hasOrgs={uniqueOrgs.size > 0}
-      />
-
-      <OrgBudgetsSection
-        uniqueOrgs={uniqueOrgs}
-        orgBudgets={orgBudgets}
-        orgOverageFromQuotas={orgOverageFromQuotas}
-      />
+      <TopUsersSection refreshToken={enterpriseUsersRefreshToken} />
     </div>
   )
 }

--- a/src/components/automation/index.ts
+++ b/src/components/automation/index.ts
@@ -1,4 +1,0 @@
-export { ScheduleDetailPanel } from './ScheduleDetailPanel'
-export { ScheduleOverviewPanel } from './ScheduleOverviewPanel'
-export { JobDetailPanel } from './JobDetailPanel'
-export { RunList } from './RunList'

--- a/src/components/copilot-usage/AccountQuotaCard.test.tsx
+++ b/src/components/copilot-usage/AccountQuotaCard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, within } from '@testing-library/react'
 import { AccountQuotaCard } from './AccountQuotaCard'
 import type { GitHubAccount } from '../../types/config'
 import type { AccountQuotaState } from './quotaUtils'
+import type { OrgBudgetState } from './types'
 
 vi.mock('./UsageRing', () => ({
   UsageRing: ({ percentUsed }: { percentUsed: number }) => (
@@ -55,6 +56,20 @@ function makeQuotaData(overrides: Record<string, unknown> = {}) {
         timestamp_utc: '2026-04-14T00:00:00Z',
       },
     },
+    ...overrides,
+  }
+}
+
+function makeOrgBudgetData(overrides: Record<string, unknown> = {}) {
+  return {
+    budgetAmount: 100,
+    spent: 42,
+    useQuotaOverage: false,
+    preventFurtherUsage: false,
+    spentUnavailable: false,
+    billingYear: 2026,
+    billingMonth: 4,
+    fetchedAt: 1700000000000,
     ...overrides,
   }
 }
@@ -262,5 +277,33 @@ describe('AccountQuotaCard', () => {
     }
     render(<AccountQuotaCard account={testAccount} state={state} />)
     expect(screen.queryByTestId('share-of-org')).not.toBeInTheDocument()
+  })
+
+  it('renders org budget details inside the quota card', () => {
+    const state: AccountQuotaState = {
+      data: makeQuotaData() as AccountQuotaState['data'],
+      loading: false,
+      error: null,
+      fetchedAt: 1700000000000,
+    }
+    const budgetState: OrgBudgetState = {
+      data: makeOrgBudgetData() as OrgBudgetState['data'],
+      loading: false,
+      error: null,
+    }
+
+    render(
+      <AccountQuotaCard
+        account={testAccount}
+        state={state}
+        budgetState={budgetState}
+        quotaOverage={15}
+      />
+    )
+
+    expect(screen.getByTestId('org-budget-summary')).toBeInTheDocument()
+    expect(screen.getByText('Org Budget')).toBeInTheDocument()
+    expect(screen.getByText('$42.00 spent')).toBeInTheDocument()
+    expect(screen.getByText('$15.00 mine')).toBeInTheDocument()
   })
 })

--- a/src/components/copilot-usage/AccountQuotaCard.tsx
+++ b/src/components/copilot-usage/AccountQuotaCard.tsx
@@ -14,6 +14,8 @@ import {
   computeProjection,
   type AccountQuotaState,
 } from './quotaUtils'
+import { OrgBudgetSummary } from './OrgBudgetsSection'
+import type { OrgBudgetState } from './types'
 import type { GitHubAccount } from '../../types/config'
 import { daysUntilReset, formatCopilotPlan, formatResetDate } from '../../utils/copilotFormatUtils'
 import { formatTime } from '../../utils/dateUtils'
@@ -28,6 +30,8 @@ const INITIAL_QUOTA_STATE: AccountQuotaState = {
 interface AccountQuotaCardProps {
   account: GitHubAccount
   state: AccountQuotaState | undefined
+  budgetState?: OrgBudgetState
+  quotaOverage?: number
 }
 
 const PLAN_ICONS: Record<string, typeof Building2> = {
@@ -197,12 +201,16 @@ function QuotaDataView({
   premium,
   metrics,
   projection,
+  budgetState,
+  quotaOverage,
 }: {
   state: AccountQuotaState
   data: NonNullable<AccountQuotaState['data']>
   premium: NonNullable<AccountQuotaState['data']>['quota_snapshots']['premium_interactions']
   metrics: QuotaMetrics
   projection: ReturnType<typeof computeProjection>
+  budgetState: OrgBudgetState | undefined
+  quotaOverage: number
 }) {
   return (
     <>
@@ -227,6 +235,7 @@ function QuotaDataView({
       />
 
       <ShareOfOrgBar used={metrics.used} orgConsumed={data.orgConsumed} />
+      <OrgBudgetSummary state={budgetState} quotaOverage={quotaOverage} />
 
       <QuotaProjectionView projection={projection} />
       <QuotaFooter state={state} data={data} />
@@ -248,7 +257,10 @@ function ShareOfOrgBar({ used, orgConsumed }: { used: number; orgConsumed?: numb
         </span>
       </div>
       <div className="usage-budget-bar-track">
-        <div className="usage-budget-bar-fill" style={{ width: `${pct}%`, background: '#5babe3' }} />
+        <div
+          className="usage-budget-bar-fill"
+          style={{ width: `${pct}%`, background: '#5babe3' }}
+        />
       </div>
     </div>
   )
@@ -303,10 +315,14 @@ function QuotaCardContent({
   state,
   account,
   quotaView,
+  budgetState,
+  quotaOverage,
 }: {
   state: AccountQuotaState
   account: AccountQuotaCardProps['account']
   quotaView: QuotaViewData | null
+  budgetState: OrgBudgetState | undefined
+  quotaOverage: number
 }) {
   if (isLoadingWithoutData(state.loading, state.data)) return <QuotaLoadingView />
   if (state.error && !state.data) {
@@ -321,17 +337,30 @@ function QuotaCardContent({
       premium={quotaView.premium}
       metrics={quotaView.metrics}
       projection={quotaView.projection}
+      budgetState={budgetState}
+      quotaOverage={quotaOverage}
     />
   )
 }
 
-export function AccountQuotaCard({ account, state: rawState }: AccountQuotaCardProps) {
+export function AccountQuotaCard({
+  account,
+  state: rawState,
+  budgetState,
+  quotaOverage = 0,
+}: AccountQuotaCardProps) {
   const state = rawState ?? INITIAL_QUOTA_STATE
   const quotaView = prepareQuotaViewData(state)
 
   return (
     <div className="usage-account-card">
-      <QuotaCardContent state={state} account={account} quotaView={quotaView} />
+      <QuotaCardContent
+        state={state}
+        account={account}
+        quotaView={quotaView}
+        budgetState={budgetState}
+        quotaOverage={quotaOverage}
+      />
     </div>
   )
 }

--- a/src/components/copilot-usage/OrgBudgetsSection.test.tsx
+++ b/src/components/copilot-usage/OrgBudgetsSection.test.tsx
@@ -120,6 +120,23 @@ describe('OrgBudgetsSection', () => {
     expect(screen.getByText('no budget set')).toBeInTheDocument()
   })
 
+  it('hides the budget progress bar when no budget is set', () => {
+    const orgs = new Map([['unknown-org', 'token']])
+    const budgets: Record<string, OrgBudgetState> = {
+      'unknown-org': {
+        data: makeOrgBudgetData({ budgetAmount: null }) as OrgBudgetState['data'],
+        loading: false,
+        error: null,
+      },
+    }
+
+    render(
+      <OrgBudgetsSection uniqueOrgs={orgs} orgBudgets={budgets} orgOverageFromQuotas={new Map()} />
+    )
+
+    expect(document.querySelector('.usage-budget-bar-track')).not.toBeInTheDocument()
+  })
+
   it('shows overage when useQuotaOverage is true', () => {
     const orgs = new Map([['acme', 'token']])
     const overages = new Map([['acme', 25]])

--- a/src/components/copilot-usage/OrgBudgetsSection.test.tsx
+++ b/src/components/copilot-usage/OrgBudgetsSection.test.tsx
@@ -154,7 +154,7 @@ describe('OrgBudgetsSection', () => {
     expect(screen.getByText(/overage/)).toBeInTheDocument()
   })
 
-  it('treats null spent as zero when useQuotaOverage is false', () => {
+  it('shows spend unavailable when spent is null', () => {
     const orgs = new Map([['acme', 'token']])
     const overages = new Map([['acme', 0]])
     const budgets: Record<string, OrgBudgetState> = {
@@ -169,7 +169,8 @@ describe('OrgBudgetsSection', () => {
       <OrgBudgetsSection uniqueOrgs={orgs} orgBudgets={budgets} orgOverageFromQuotas={overages} />
     )
     expect(screen.getByText('acme')).toBeInTheDocument()
-    expect(screen.getByText(/spent/i)).toBeInTheDocument()
+    expect(screen.getByText('Spend unavailable')).toBeInTheDocument()
+    expect(screen.queryByText(/\$0\.00 spent/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/NaN/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/overage/i)).not.toBeInTheDocument()
   })

--- a/src/components/copilot-usage/OrgBudgetsSection.tsx
+++ b/src/components/copilot-usage/OrgBudgetsSection.tsx
@@ -16,7 +16,7 @@ interface OrgBudgetSummaryProps {
 
 interface BudgetCardMetrics {
   effectiveBudget: number | null
-  displaySpent: number
+  displaySpent: number | null
   myShare: number
   pct: number | null
   mySharePct: number | null
@@ -24,7 +24,7 @@ interface BudgetCardMetrics {
 }
 
 interface BudgetUsageAmounts {
-  displaySpent: number
+  displaySpent: number | null
   myShare: number
 }
 
@@ -40,13 +40,13 @@ function resolveBudgetUsageAmounts(
   d: NonNullable<OrgBudgetState['data']>,
   quotaOverage: number
 ): BudgetUsageAmounts {
-  const spent = d.spent ?? 0
-
   if (d.useQuotaOverage) {
     return { displaySpent: quotaOverage, myShare: 0 }
   }
 
-  return { displaySpent: spent, myShare: quotaOverage }
+  const displaySpent = typeof d.spent === 'number' && Number.isFinite(d.spent) ? d.spent : null
+
+  return { displaySpent, myShare: quotaOverage }
 }
 
 function resolveMySharePct(myShare: number, effectiveBudget: number, pct: number): number | null {
@@ -61,7 +61,7 @@ function computeBudgetCardMetrics(
 ): BudgetCardMetrics {
   const effectiveBudget = resolveEffectiveBudget(d)
   const { displaySpent, myShare } = resolveBudgetUsageAmounts(d, quotaOverage)
-  const barValue = Math.max(displaySpent, myShare)
+  const barValue = Math.max(displaySpent ?? 0, myShare)
 
   if (effectiveBudget === null || effectiveBudget === 0) {
     return {
@@ -83,10 +83,12 @@ function computeBudgetCardMetrics(
 function canRenderBudgetProjection(d: NonNullable<OrgBudgetState['data']>): boolean {
   if (d.useQuotaOverage) return false
 
-  return !d.spentUnavailable
+  return !d.spentUnavailable && typeof d.spent === 'number' && Number.isFinite(d.spent)
 }
 
 function resolveBudgetProjection(d: NonNullable<OrgBudgetState['data']>) {
+  if (typeof d.spent !== 'number' || !Number.isFinite(d.spent)) return null
+
   return computeBudgetProjection(d.spent, d.billingYear, d.billingMonth, d.fetchedAt)
 }
 
@@ -168,6 +170,30 @@ function resolveBudgetBarWidth(pct: number | null): string {
 
 function resolveSpentLabel(useQuotaOverage: boolean): string {
   return useQuotaOverage ? 'overage' : 'spent'
+}
+
+function BudgetSpentLabel({
+  displaySpent,
+  useQuotaOverage,
+  barColor,
+}: {
+  displaySpent: number | null
+  useQuotaOverage: boolean
+  barColor: string
+}) {
+  if (displaySpent === null) {
+    return (
+      <span className="usage-budget-spent" style={{ color: barColor }}>
+        Spend unavailable
+      </span>
+    )
+  }
+
+  return (
+    <span className="usage-budget-spent" style={{ color: barColor }}>
+      {formatCurrency(displaySpent)} {resolveSpentLabel(useQuotaOverage)}
+    </span>
+  )
 }
 
 function BudgetMyShareBar({ mySharePct, myShare }: { mySharePct: number | null; myShare: number }) {
@@ -268,9 +294,11 @@ function BudgetCardBody({
         myShare={myShare}
       />
       <div className="usage-budget-amounts">
-        <span className="usage-budget-spent" style={{ color: barColor }}>
-          {formatCurrency(displaySpent)} {resolveSpentLabel(d.useQuotaOverage)}
-        </span>
+        <BudgetSpentLabel
+          displaySpent={displaySpent}
+          useQuotaOverage={d.useQuotaOverage}
+          barColor={barColor}
+        />
         <BudgetGrossLabel gross={d.gross ?? 0} useQuotaOverage={d.useQuotaOverage} />
         <BudgetMyShareLabel myShare={myShare} useQuotaOverage={d.useQuotaOverage} />
         <BudgetLimitLabel effectiveBudget={effectiveBudget} useQuotaOverage={d.useQuotaOverage} />

--- a/src/components/copilot-usage/OrgBudgetsSection.tsx
+++ b/src/components/copilot-usage/OrgBudgetsSection.tsx
@@ -9,6 +9,11 @@ interface OrgBudgetsSectionProps {
   orgOverageFromQuotas: Map<string, number>
 }
 
+interface OrgBudgetSummaryProps {
+  state: OrgBudgetState | undefined
+  quotaOverage: number
+}
+
 interface BudgetCardMetrics {
   effectiveBudget: number | null
   displaySpent: number
@@ -189,6 +194,26 @@ function BudgetMyShareLabel({
   return <span className="usage-budget-myshare-label">{formatCurrency(myShare)} mine</span>
 }
 
+function BudgetProgressBar({
+  effectiveBudget,
+  pct,
+  barColor,
+  mySharePct,
+  myShare,
+}: Pick<BudgetCardMetrics, 'effectiveBudget' | 'pct' | 'barColor' | 'mySharePct' | 'myShare'>) {
+  if (effectiveBudget === null || pct === null) return null
+
+  return (
+    <div className="usage-budget-bar-track">
+      <div
+        className="usage-budget-bar-fill"
+        style={{ width: resolveBudgetBarWidth(pct), background: barColor }}
+      />
+      <BudgetMyShareBar mySharePct={mySharePct} myShare={myShare} />
+    </div>
+  )
+}
+
 function BudgetGrossLabel({ gross, useQuotaOverage }: { gross: number; useQuotaOverage: boolean }) {
   if (gross <= 0 || useQuotaOverage) return null
 
@@ -235,13 +260,13 @@ function BudgetCardBody({
 
   return (
     <>
-      <div className="usage-budget-bar-track">
-        <div
-          className="usage-budget-bar-fill"
-          style={{ width: resolveBudgetBarWidth(pct), background: barColor }}
-        />
-        <BudgetMyShareBar mySharePct={mySharePct} myShare={myShare} />
-      </div>
+      <BudgetProgressBar
+        effectiveBudget={effectiveBudget}
+        pct={pct}
+        barColor={barColor}
+        mySharePct={mySharePct}
+        myShare={myShare}
+      />
       <div className="usage-budget-amounts">
         <span className="usage-budget-spent" style={{ color: barColor }}>
           {formatCurrency(displaySpent)} {resolveSpentLabel(d.useQuotaOverage)}
@@ -328,6 +353,33 @@ function BudgetCardMetricsContent({
 
   const metrics = computeBudgetCardMetrics(data, quotaOverage)
   return <BudgetCardBody d={data} metrics={metrics} />
+}
+
+export function OrgBudgetSummary({ state, quotaOverage }: OrgBudgetSummaryProps) {
+  if (!state) return null
+
+  const { data: d, loading, error } = resolveBudgetCardState(state)
+  const preventFurtherUsage = resolvePreventFurtherUsage(d)
+
+  return (
+    <div className="usage-org-budget-summary" data-testid="org-budget-summary">
+      <div className="usage-org-budget-summary-header">
+        <span className="usage-org-budget-summary-title">
+          <Building2 size={12} />
+          Org Budget
+        </span>
+        {loading && <RefreshCw size={12} className="spin" />}
+        {preventFurtherUsage && (
+          <span className="usage-budget-stop-badge" title="Usage stopped at limit">
+            <ShieldAlert size={11} />
+            Stop at limit
+          </span>
+        )}
+      </div>
+      <BudgetCardErrorContent error={error} data={d} />
+      <BudgetCardMetricsContent data={d} quotaOverage={quotaOverage} />
+    </div>
+  )
 }
 
 function BudgetCard({

--- a/src/components/copilot-usage/TopUsersSection.test.tsx
+++ b/src/components/copilot-usage/TopUsersSection.test.tsx
@@ -88,6 +88,18 @@ describe('TopUsersSection', () => {
     expect(screen.getByText('2 active')).toBeInTheDocument()
   })
 
+  it('uses a safe fallback for invalid snapshot update dates', () => {
+    mockUseCopilotEnterpriseUsers.mockReturnValue({
+      data: { ...snapshot, generatedAt: 'not-a-date' },
+      loading: false,
+      error: null,
+    })
+
+    render(<TopUsersSection />)
+
+    expect(screen.getByText('Updated Unknown date')).toBeInTheDocument()
+  })
+
   it('renders one table row per enterprise user from the metrics file', () => {
     render(<TopUsersSection />)
     expect(document.querySelectorAll('.enterprise-users-row')).toHaveLength(3)
@@ -138,6 +150,7 @@ describe('TopUsersSection', () => {
     fireEvent.click(screen.getByTitle('View source JSON for fhemmerrelias'))
 
     expect(screen.getByRole('dialog', { name: 'fhemmerrelias' })).toBeInTheDocument()
+    expect(screen.getByLabelText('Close source JSON dialog')).toHaveFocus()
     expect(screen.getByText(snapshot.sourceFile)).toBeInTheDocument()
     expect(screen.getByText(/"User": "fhemmerrelias"/)).toBeInTheDocument()
   })
@@ -149,6 +162,39 @@ describe('TopUsersSection', () => {
     fireEvent.click(screen.getByLabelText('Close source JSON dialog'))
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('closes the source JSON modal with Escape', () => {
+    render(<TopUsersSection />)
+
+    fireEvent.click(screen.getByTitle('View source JSON for fhemmerrelias'))
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' })
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('keeps tab focus inside the source JSON modal', () => {
+    render(<TopUsersSection />)
+
+    fireEvent.click(screen.getByTitle('View source JSON for fhemmerrelias'))
+    const closeButton = screen.getByLabelText('Close source JSON dialog')
+
+    expect(closeButton).toHaveFocus()
+    fireEvent.keyDown(closeButton, { key: 'Tab' })
+    expect(closeButton).toHaveFocus()
+    fireEvent.keyDown(closeButton, { key: 'Tab', shiftKey: true })
+    expect(closeButton).toHaveFocus()
+  })
+
+  it('restores focus when the source JSON modal closes', () => {
+    render(<TopUsersSection />)
+    const row = screen.getByTitle('View source JSON for fhemmerrelias')
+
+    row.focus()
+    fireEvent.click(row)
+    fireEvent.click(screen.getByLabelText('Close source JSON dialog'))
+
+    expect(row).toHaveFocus()
   })
 
   it('does not render a loading spinner for file data', () => {

--- a/src/components/copilot-usage/TopUsersSection.test.tsx
+++ b/src/components/copilot-usage/TopUsersSection.test.tsx
@@ -1,232 +1,171 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { TopUsersSection } from './TopUsersSection'
-import type { CopilotSeatInfo } from '../../hooks/useCopilotSeats'
+import type { CopilotEnterpriseUsersSnapshot } from '../../types/copilotEnterpriseUsers'
 
-function makeSeat(overrides: Partial<CopilotSeatInfo> = {}): CopilotSeatInfo {
-  return {
-    login: 'alice',
-    displayName: null,
-    org: 'org1',
-    planType: 'business',
-    lastActivityAt: '2026-05-16T12:00:00Z',
-    lastActivityEditor: 'vscode/1.95.0',
-    createdAt: '2024-01-01T00:00:00Z',
-    pendingCancellation: null,
-    premiumRequests: null,
-    lastPremiumRequestDate: null,
-    ...overrides,
-  }
+const mockUseCopilotEnterpriseUsers = vi.fn()
+
+vi.mock('../../hooks/useCopilotEnterpriseUsers', () => ({
+  useCopilotEnterpriseUsers: (refreshToken?: number) => mockUseCopilotEnterpriseUsers(refreshToken),
+}))
+
+const snapshot: CopilotEnterpriseUsersSnapshot = {
+  generatedAt: '2026-06-02T02:30:20.000Z',
+  fileLastWriteTime: '2026-06-02T02:30:20.000Z',
+  sourceFile: 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json',
+  enterprise: 'bertelsmann',
+  organization: 'Relias-Engineering',
+  year: 2026,
+  month: 6,
+  days: [1, 2],
+  totalUsers: 3,
+  activeUsers: 2,
+  users: [
+    {
+      login: 'fhemmerrelias',
+      grossQuantity: 11540.58,
+      grossAmount: 115.41,
+      netAmount: 0,
+      modelCount: 2,
+      topModel: 'Claude Opus 4.8',
+      topModelQuantity: 7000,
+      success: true,
+      errorMessage: null,
+      sourceJson: '{\n  "User": "fhemmerrelias",\n  "Success": true\n}',
+    },
+    {
+      login: 'vgautamRelias',
+      grossQuantity: 4907.36,
+      grossAmount: 49.07,
+      netAmount: 0,
+      modelCount: 1,
+      topModel: 'Claude Opus 4.6',
+      topModelQuantity: 4907.36,
+      success: true,
+      errorMessage: null,
+      sourceJson: '{\n  "User": "vgautamRelias",\n  "Success": true\n}',
+    },
+    {
+      login: 'aantony-relias',
+      grossQuantity: 0,
+      grossAmount: 0,
+      netAmount: 0,
+      modelCount: 0,
+      topModel: null,
+      topModelQuantity: 0,
+      success: true,
+      errorMessage: null,
+      sourceJson: '{\n  "User": "aantony-relias",\n  "Success": true\n}',
+    },
+  ],
 }
 
 describe('TopUsersSection', () => {
-  it('renders nothing when no seats and not loading', () => {
-    const { container } = render(
-      <TopUsersSection
-        seats={[]}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={false}
-      />
-    )
-    expect(container.firstChild).toBeNull()
+  beforeEach(() => {
+    mockUseCopilotEnterpriseUsers.mockClear()
+    mockUseCopilotEnterpriseUsers.mockReturnValue({ data: snapshot, loading: false, error: null })
   })
 
-  it('shows AI Credits annotation when orgs exist even without seats', () => {
-    render(
-      <TopUsersSection seats={[]} loading={false} orgErrors={[]} truncated={false} hasOrgs={true} />
-    )
-    expect(screen.getByText('Top AI Credit Users')).toBeInTheDocument()
-    expect(screen.getByText(/unavailable under GitHub's AI Credits billing/)).toBeInTheDocument()
+  it('renders the Copilot enterprise users title', () => {
+    render(<TopUsersSection />)
+    expect(screen.getByText('Copilot Enterprise Users')).toBeInTheDocument()
+    expect(screen.queryByText('Top AI Credit Users')).not.toBeInTheDocument()
   })
 
-  it('renders heading and table with seats', () => {
-    const seats = [
-      makeSeat({ login: 'alice', org: 'org1' }),
-      makeSeat({ login: 'bob', org: 'org2', lastActivityEditor: 'jetbrains/251.0' }),
-    ]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
+  it('passes refresh tokens into the Enterprise users loader', () => {
+    const { rerender } = render(<TopUsersSection refreshToken={1} />)
+    rerender(<TopUsersSection refreshToken={2} />)
 
-    expect(screen.getByText('Top AI Credit Users')).toBeInTheDocument()
-    expect(screen.getByText('alice')).toBeInTheDocument()
-    expect(screen.getByText('bob')).toBeInTheDocument()
-    expect(screen.getByText('org1')).toBeInTheDocument()
-    expect(screen.getByText('org2')).toBeInTheDocument()
-    expect(screen.getByText('JetBrains')).toBeInTheDocument()
+    expect(mockUseCopilotEnterpriseUsers).toHaveBeenNthCalledWith(1, 1)
+    expect(mockUseCopilotEnterpriseUsers).toHaveBeenNthCalledWith(2, 2)
   })
 
-  it('renders rank numbers', () => {
-    const seats = [makeSeat({ login: 'alice' }), makeSeat({ login: 'bob' })]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    const rankCells = screen.getAllByText(/^[12]$/)
-    expect(rankCells.length).toBeGreaterThanOrEqual(2)
+  it('shows snapshot update and user-count metadata', () => {
+    render(<TopUsersSection />)
+    expect(screen.getByText(/Updated/)).toBeInTheDocument()
+    expect(screen.getByText('Relias-Engineering')).toBeInTheDocument()
+    expect(screen.getByText('3 users')).toBeInTheDocument()
+    expect(screen.getByText('2 active')).toBeInTheDocument()
   })
 
-  it('shows loading spinner', () => {
-    render(
-      <TopUsersSection seats={[]} loading={true} orgErrors={[]} truncated={false} hasOrgs={true} />
-    )
-    expect(screen.getByText('Top AI Credit Users')).toBeInTheDocument()
+  it('renders one table row per enterprise user from the metrics file', () => {
+    render(<TopUsersSection />)
+    expect(document.querySelectorAll('.enterprise-users-row')).toHaveLength(3)
   })
 
-  it('displays org errors', () => {
-    render(
-      <TopUsersSection
-        seats={[]}
-        loading={false}
-        orgErrors={[{ org: 'org1', error: 'No billing access' }]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText(/No billing access/)).toBeInTheDocument()
+  it('renders high-usage users with credit and dollar totals', () => {
+    render(<TopUsersSection />)
+    expect(screen.getByText('fhemmerrelias')).toBeInTheDocument()
+    expect(screen.getByText('11,541')).toBeInTheDocument()
+    expect(screen.getByText('$115.41')).toBeInTheDocument()
+    expect(screen.queryByText('Net')).not.toBeInTheDocument()
+    expect(screen.getByText('Claude Opus 4.8')).toBeInTheDocument()
   })
 
-  it('shows truncation warning', () => {
-    const seats = [makeSeat()]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={true}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText(/Showing top 50/)).toBeInTheDocument()
+  it('includes users with no usage instead of dropping them', () => {
+    render(<TopUsersSection />)
+    expect(screen.getByText('aantony-relias')).toBeInTheDocument()
+    expect(screen.getAllByText('No usage').length).toBeGreaterThan(0)
   })
 
-  it('formats editor names', () => {
-    const seats = [
-      makeSeat({ login: 'vs', lastActivityEditor: 'vscode/1.95.0' }),
-      makeSeat({ login: 'jb', lastActivityEditor: 'jetbrains/251.0' }),
-      makeSeat({ login: 'custom', lastActivityEditor: 'custom-editor' }),
-      makeSeat({ login: 'no', lastActivityEditor: null }),
-    ]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText('VS Code')).toBeInTheDocument()
-    expect(screen.getByText('JetBrains')).toBeInTheDocument()
-    expect(screen.getByText('custom-editor')).toBeInTheDocument()
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  it('filters users by login text', () => {
+    render(<TopUsersSection />)
+
+    fireEvent.change(screen.getByLabelText('Filter Copilot Enterprise users'), {
+      target: { value: 'vgautam' },
+    })
+
+    expect(screen.getByText('vgautamRelias')).toBeInTheDocument()
+    expect(screen.queryByText('fhemmerrelias')).not.toBeInTheDocument()
+    expect(screen.getByText('1 of 3 users')).toBeInTheDocument()
   })
 
-  it('capitalizes plan type', () => {
-    const seats = [
-      makeSeat({ planType: 'enterprise' }),
-      makeSeat({ login: 'free', planType: null }),
-    ]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText('Enterprise')).toBeInTheDocument()
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  it('shows an empty match message when the filter excludes all users', () => {
+    render(<TopUsersSection />)
+
+    fireEvent.change(screen.getByLabelText('Filter Copilot Enterprise users'), {
+      target: { value: 'missing-user' },
+    })
+
+    expect(screen.getByText('No users match this filter.')).toBeInTheDocument()
+    expect(document.querySelectorAll('.enterprise-users-row')).toHaveLength(0)
+    expect(screen.getByText('0 of 3 users')).toBeInTheDocument()
   })
 
-  it('displays premium request counts with formatting', () => {
-    const seats = [
-      makeSeat({ login: 'alice', premiumRequests: 1234 }),
-      makeSeat({ login: 'bob', premiumRequests: 0 }),
-    ]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText('1,234')).toBeInTheDocument()
-    expect(screen.getByText('0')).toBeInTheDocument()
+  it('opens the source JSON modal when a user row is clicked', () => {
+    render(<TopUsersSection />)
+
+    fireEvent.click(screen.getByTitle('View source JSON for fhemmerrelias'))
+
+    expect(screen.getByRole('dialog', { name: 'fhemmerrelias' })).toBeInTheDocument()
+    expect(screen.getByText(snapshot.sourceFile)).toBeInTheDocument()
+    expect(screen.getByText(/"User": "fhemmerrelias"/)).toBeInTheDocument()
   })
 
-  it('shows dash for null premium requests', () => {
-    const seats = [makeSeat({ login: 'alice', premiumRequests: null })]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+  it('closes the source JSON modal from the close button', () => {
+    render(<TopUsersSection />)
+
+    fireEvent.click(screen.getByTitle('View source JSON for fhemmerrelias'))
+    fireEvent.click(screen.getByLabelText('Close source JSON dialog'))
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
-  it('does not render Last Active column', () => {
-    const seats = [makeSeat()]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText('Credits')).toBeInTheDocument()
-    expect(screen.queryByText('Last Active')).not.toBeInTheDocument()
-    expect(screen.queryByText('Last Request')).not.toBeInTheDocument()
+  it('does not render a loading spinner for file data', () => {
+    render(<TopUsersSection />)
+    expect(document.querySelector('.spin')).not.toBeInTheDocument()
   })
 
-  it('shows display name when available, login as tooltip', () => {
-    const seats = [makeSeat({ login: 'jdoe', displayName: 'Jane Doe' })]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText('Jane Doe')).toBeInTheDocument()
-    expect(screen.getByTitle('jdoe')).toBeInTheDocument()
-  })
+  it('shows source errors without a spinner', () => {
+    mockUseCopilotEnterpriseUsers.mockReturnValue({
+      data: null,
+      loading: false,
+      error: 'copilot-metrics.json was not found',
+    })
 
-  it('falls back to login when displayName is null', () => {
-    const seats = [makeSeat({ login: 'jdoe', displayName: null })]
-    render(
-      <TopUsersSection
-        seats={seats}
-        loading={false}
-        orgErrors={[]}
-        truncated={false}
-        hasOrgs={true}
-      />
-    )
-    expect(screen.getByText('jdoe')).toBeInTheDocument()
+    render(<TopUsersSection />)
+
+    expect(screen.getByText('copilot-metrics.json was not found')).toBeInTheDocument()
+    expect(document.querySelector('.spin')).not.toBeInTheDocument()
   })
 })

--- a/src/components/copilot-usage/TopUsersSection.tsx
+++ b/src/components/copilot-usage/TopUsersSection.tsx
@@ -1,136 +1,251 @@
-import { RefreshCw, Users } from 'lucide-react'
-import type { CopilotSeatInfo } from '../../hooks/useCopilotSeats'
+import { useMemo, useState } from 'react'
+import { CalendarClock, Search, Users, X } from 'lucide-react'
+import { useCopilotEnterpriseUsers } from '../../hooks/useCopilotEnterpriseUsers'
+import type {
+  CopilotEnterpriseUser,
+  CopilotEnterpriseUsersSnapshot,
+} from '../../types/copilotEnterpriseUsers'
+import { formatCurrency } from './quotaUtils'
+
+function formatCredits(value: number): string {
+  return Math.round(value).toLocaleString()
+}
+
+function formatUpdatedAt(value: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+function SnapshotMeta({ snapshot }: { snapshot: CopilotEnterpriseUsersSnapshot }) {
+  return (
+    <div className="top-users-meta">
+      <span>
+        <CalendarClock size={13} />
+        Updated {formatUpdatedAt(snapshot.generatedAt)}
+      </span>
+      {snapshot.organization ? <span>{snapshot.organization}</span> : null}
+      <span>{snapshot.totalUsers.toLocaleString()} users</span>
+      <span>{snapshot.activeUsers.toLocaleString()} active</span>
+    </div>
+  )
+}
+
+function statusLabel(user: CopilotEnterpriseUser): string {
+  if (!user.success) return 'Failed'
+  return user.grossQuantity > 0 ? 'Active' : 'No usage'
+}
+
+function EnterpriseUserRow({
+  user,
+  rank,
+  onSelect,
+}: {
+  user: CopilotEnterpriseUser
+  rank: number
+  onSelect: (user: CopilotEnterpriseUser) => void
+}) {
+  return (
+    <button
+      type="button"
+      className="enterprise-users-row"
+      onClick={() => onSelect(user)}
+      title={`View source JSON for ${user.login}`}
+    >
+      <span className="enterprise-users-rank">{rank}</span>
+      <span className="enterprise-users-login" title={user.login}>
+        {user.login}
+      </span>
+      <span className="enterprise-users-credits">{formatCredits(user.grossQuantity)}</span>
+      <span className="enterprise-users-money">{formatCurrency(user.grossAmount)}</span>
+      <span className="enterprise-users-model-count">{user.modelCount}</span>
+      <span className="enterprise-users-model" title={user.topModel ?? undefined}>
+        {user.topModel ?? '—'}
+      </span>
+      <span className="enterprise-users-status">{statusLabel(user)}</span>
+    </button>
+  )
+}
+
+function EnterpriseUsersTable({
+  users,
+  onSelectUser,
+}: {
+  users: CopilotEnterpriseUser[]
+  onSelectUser: (user: CopilotEnterpriseUser) => void
+}) {
+  return (
+    <div className="enterprise-users-table">
+      <div className="enterprise-users-header">
+        <span className="enterprise-users-rank">#</span>
+        <span className="enterprise-users-login">User</span>
+        <span className="enterprise-users-credits">Credits</span>
+        <span className="enterprise-users-money">Gross</span>
+        <span className="enterprise-users-model-count">Models</span>
+        <span className="enterprise-users-model">Top Model</span>
+        <span className="enterprise-users-status">Status</span>
+      </div>
+      {users.map((user, index) => (
+        <EnterpriseUserRow key={user.login} user={user} rank={index + 1} onSelect={onSelectUser} />
+      ))}
+    </div>
+  )
+}
+
+function EnterpriseUsersFilter({
+  value,
+  totalUsers,
+  visibleUsers,
+  onChange,
+}: {
+  value: string
+  totalUsers: number
+  visibleUsers: number
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="enterprise-users-filter">
+      <label className="enterprise-users-filter-box">
+        <Search size={14} />
+        <input
+          aria-label="Filter Copilot Enterprise users"
+          type="search"
+          value={value}
+          placeholder="Filter users"
+          onChange={event => onChange(event.target.value)}
+        />
+      </label>
+      <span className="enterprise-users-filter-count">
+        {visibleUsers.toLocaleString()} of {totalUsers.toLocaleString()} users
+      </span>
+    </div>
+  )
+}
+
+function filterUsers(users: CopilotEnterpriseUser[], filterText: string) {
+  const normalizedFilter = filterText.trim().toLowerCase()
+  if (!normalizedFilter) return users
+
+  return users.filter(user => user.login.toLowerCase().includes(normalizedFilter))
+}
+
+interface EnterpriseUsersContentProps extends ReturnType<typeof useCopilotEnterpriseUsers> {
+  filterText: string
+  onSelectUser: (user: CopilotEnterpriseUser) => void
+}
+
+function EnterpriseUsersContent({
+  data,
+  loading,
+  error,
+  filterText,
+  onSelectUser,
+}: EnterpriseUsersContentProps) {
+  const visibleUsers = useMemo(
+    () => (data ? filterUsers(data.users, filterText) : []),
+    [data, filterText]
+  )
+
+  if (data && visibleUsers.length > 0)
+    return <EnterpriseUsersTable users={visibleUsers} onSelectUser={onSelectUser} />
+  if (data && data.users.length > 0)
+    return <div className="enterprise-users-message">No users match this filter.</div>
+  if (loading)
+    return <div className="enterprise-users-message">Loading Copilot Enterprise users...</div>
+  if (error)
+    return <div className="enterprise-users-message enterprise-users-message-error">{error}</div>
+  if (data)
+    return <div className="enterprise-users-message">No Copilot Enterprise users found.</div>
+
+  return null
+}
+
+function SourceJsonModal({
+  user,
+  sourceFile,
+  onClose,
+}: {
+  user: CopilotEnterpriseUser
+  sourceFile: string
+  onClose: () => void
+}) {
+  return (
+    <div className="enterprise-users-json-overlay" role="presentation">
+      <button
+        type="button"
+        className="enterprise-users-json-backdrop"
+        aria-label="Close source JSON"
+        onClick={onClose}
+      />
+      <div
+        className="enterprise-users-json-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="enterprise-users-json-title"
+      >
+        <div className="enterprise-users-json-header">
+          <div>
+            <h4 id="enterprise-users-json-title">{user.login}</h4>
+            <p>{sourceFile}</p>
+          </div>
+          <button
+            type="button"
+            className="enterprise-users-json-close"
+            aria-label="Close source JSON dialog"
+            title="Close"
+            onClick={onClose}
+          >
+            <X size={16} />
+          </button>
+        </div>
+        <pre className="enterprise-users-json-block">{user.sourceJson}</pre>
+      </div>
+    </div>
+  )
+}
 
 interface TopUsersSectionProps {
-  seats: CopilotSeatInfo[]
-  loading: boolean
-  orgErrors: Array<{ org: string; error: string }>
-  truncated: boolean
-  hasOrgs: boolean
+  refreshToken?: number
 }
 
-function formatEditor(editor: string | null): string {
-  if (!editor) return '—'
-  const slash = editor.indexOf('/')
-  const name = slash > 0 ? editor.slice(0, slash) : editor
-  const map: Record<string, string> = {
-    vscode: 'VS Code',
-    'visual studio': 'Visual Studio',
-    jetbrains: 'JetBrains',
-    neovim: 'Neovim',
-    vim: 'Vim',
-    xcode: 'Xcode',
-    eclipse: 'Eclipse',
-  }
-  return map[name.toLowerCase()] ?? name
-}
-
-function formatPlanType(plan: string | null): string {
-  if (!plan) return '—'
-  return plan.charAt(0).toUpperCase() + plan.slice(1)
-}
-
-function UserRow({ seat, rank }: { seat: CopilotSeatInfo; rank: number }) {
-  return (
-    <div className="top-users-row">
-      <span className="top-users-rank">{rank}</span>
-      <span className="top-users-login" title={seat.login}>
-        {seat.displayName || seat.login}
-      </span>
-      <span className="top-users-org">{seat.org}</span>
-      <span className="top-users-requests">
-        {seat.premiumRequests !== null ? seat.premiumRequests.toLocaleString() : '—'}
-      </span>
-      <span className="top-users-plan">{formatPlanType(seat.planType)}</span>
-      <span className="top-users-editor">{formatEditor(seat.lastActivityEditor)}</span>
-    </div>
-  )
-}
-
-function OrgErrors({ errors }: { errors: Array<{ org: string; error: string }> }) {
-  if (errors.length === 0) return null
-  return (
-    <div className="top-users-errors">
-      {errors.map(({ org, error }) => (
-        <p key={org} className="usage-budget-error">
-          {org}: {error}
-        </p>
-      ))}
-    </div>
-  )
-}
-
-function UsersTable({ seats }: { seats: CopilotSeatInfo[] }) {
-  if (seats.length === 0) return null
-  return (
-    <div className="top-users-table">
-      <div className="top-users-header">
-        <span className="top-users-rank">#</span>
-        <span className="top-users-login">User</span>
-        <span className="top-users-org">Org</span>
-        <span className="top-users-requests">Credits</span>
-        <span className="top-users-plan">Plan</span>
-        <span className="top-users-editor">Editor</span>
-      </div>
-      {seats.map((seat, i) => (
-        <UserRow key={`${seat.org}/${seat.login}`} seat={seat} rank={i + 1} />
-      ))}
-    </div>
-  )
-}
-
-function shouldHideSection(
-  seats: CopilotSeatInfo[],
-  loading: boolean,
-  orgErrorCount: number,
-  hasOrgs: boolean
-): boolean {
-  return !hasOrgs && seats.length === 0 && !loading && orgErrorCount === 0
-}
-
-function AiCreditsNote() {
-  return (
-    <p className="top-users-note">
-      Per-user AI Credit breakdown is unavailable under GitHub&apos;s AI Credits billing.
-      Consumption is reported only at the organization level.
-    </p>
-  )
-}
-
-function LoadingIcon({ loading }: { loading: boolean }) {
-  return loading ? <RefreshCw size={12} className="spin" /> : null
-}
-
-function TruncationWarning({ truncated }: { truncated: boolean }) {
-  if (!truncated) return null
-  return (
-    <p className="top-users-truncated">
-      Some orgs have more seats than could be fetched. Showing top 50 from available data.
-    </p>
-  )
-}
-
-export function TopUsersSection({
-  seats,
-  loading,
-  orgErrors,
-  truncated,
-  hasOrgs,
-}: TopUsersSectionProps) {
-  if (shouldHideSection(seats, loading, orgErrors.length, hasOrgs)) return null
+export function TopUsersSection({ refreshToken = 0 }: TopUsersSectionProps) {
+  const enterpriseUsers = useCopilotEnterpriseUsers(refreshToken)
+  const { data } = enterpriseUsers
+  const [filterText, setFilterText] = useState('')
+  const [selectedUser, setSelectedUser] = useState<CopilotEnterpriseUser | null>(null)
+  const visibleUsers = data ? filterUsers(data.users, filterText).length : 0
 
   return (
     <div className="top-users-section">
       <h3 className="usage-budgets-heading">
         <Users size={14} />
-        Top AI Credit Users
-        <LoadingIcon loading={loading} />
+        Copilot Enterprise Users
       </h3>
-
-      <AiCreditsNote />
-      <OrgErrors errors={orgErrors} />
-      <TruncationWarning truncated={truncated} />
-      <UsersTable seats={seats} />
+      {data ? <SnapshotMeta snapshot={data} /> : null}
+      {data && data.users.length > 0 ? (
+        <EnterpriseUsersFilter
+          value={filterText}
+          totalUsers={data.users.length}
+          visibleUsers={visibleUsers}
+          onChange={setFilterText}
+        />
+      ) : null}
+      <EnterpriseUsersContent
+        {...enterpriseUsers}
+        filterText={filterText}
+        onSelectUser={setSelectedUser}
+      />
+      {selectedUser && data ? (
+        <SourceJsonModal
+          user={selectedUser}
+          sourceFile={data.sourceFile}
+          onClose={() => setSelectedUser(null)}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/copilot-usage/TopUsersSection.tsx
+++ b/src/components/copilot-usage/TopUsersSection.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
 import { CalendarClock, Search, Users, X } from 'lucide-react'
 import { useCopilotEnterpriseUsers } from '../../hooks/useCopilotEnterpriseUsers'
 import type {
@@ -12,13 +12,16 @@ function formatCredits(value: number): string {
 }
 
 function formatUpdatedAt(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return 'Unknown date'
+
   return new Intl.DateTimeFormat(undefined, {
     month: 'short',
     day: 'numeric',
     year: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
-  }).format(new Date(value))
+  }).format(date)
 }
 
 function SnapshotMeta({ snapshot }: { snapshot: CopilotEnterpriseUsersSnapshot }) {
@@ -134,7 +137,7 @@ function filterUsers(users: CopilotEnterpriseUser[], filterText: string) {
 }
 
 interface EnterpriseUsersContentProps extends ReturnType<typeof useCopilotEnterpriseUsers> {
-  filterText: string
+  filteredUsers: CopilotEnterpriseUser[]
   onSelectUser: (user: CopilotEnterpriseUser) => void
 }
 
@@ -142,16 +145,11 @@ function EnterpriseUsersContent({
   data,
   loading,
   error,
-  filterText,
+  filteredUsers,
   onSelectUser,
 }: EnterpriseUsersContentProps) {
-  const visibleUsers = useMemo(
-    () => (data ? filterUsers(data.users, filterText) : []),
-    [data, filterText]
-  )
-
-  if (data && visibleUsers.length > 0)
-    return <EnterpriseUsersTable users={visibleUsers} onSelectUser={onSelectUser} />
+  if (data && filteredUsers.length > 0)
+    return <EnterpriseUsersTable users={filteredUsers} onSelectUser={onSelectUser} />
   if (data && data.users.length > 0)
     return <div className="enterprise-users-message">No users match this filter.</div>
   if (loading)
@@ -164,6 +162,51 @@ function EnterpriseUsersContent({
   return null
 }
 
+const FOCUSABLE_MODAL_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+
+function getFocusableModalElements(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_MODAL_SELECTOR)).filter(
+    element => !element.hasAttribute('disabled') && element.tabIndex >= 0
+  )
+}
+
+function focusFirstModalElement(container: HTMLElement): void {
+  const firstFocusableElement = getFocusableModalElements(container)[0]
+  ;(firstFocusableElement ?? container).focus()
+}
+
+function handleModalTabKey(event: KeyboardEvent<HTMLDialogElement>): void {
+  const focusableElements = getFocusableModalElements(event.currentTarget)
+  if (focusableElements.length === 0) {
+    event.preventDefault()
+    event.currentTarget.focus()
+    return
+  }
+
+  const firstFocusableElement = focusableElements[0]
+  const lastFocusableElement = focusableElements[focusableElements.length - 1]
+  const activeElement = document.activeElement
+
+  if (event.shiftKey && activeElement === firstFocusableElement) {
+    event.preventDefault()
+    lastFocusableElement.focus()
+  } else if (!event.shiftKey && activeElement === lastFocusableElement) {
+    event.preventDefault()
+    firstFocusableElement.focus()
+  }
+}
+
+function handleModalKeyDown(event: KeyboardEvent<HTMLDialogElement>, onClose: () => void): void {
+  if (event.key === 'Escape') {
+    event.stopPropagation()
+    onClose()
+    return
+  }
+
+  if (event.key === 'Tab') handleModalTabKey(event)
+}
+
 function SourceJsonModal({
   user,
   sourceFile,
@@ -173,19 +216,36 @@ function SourceJsonModal({
   sourceFile: string
   onClose: () => void
 }) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  useEffect(() => {
+    const previouslyFocused =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const dialog = dialogRef.current
+    if (dialog) focusFirstModalElement(dialog)
+
+    return () => {
+      previouslyFocused?.focus()
+    }
+  }, [])
+
   return (
     <div className="enterprise-users-json-overlay" role="presentation">
       <button
         type="button"
         className="enterprise-users-json-backdrop"
         aria-label="Close source JSON"
+        tabIndex={-1}
         onClick={onClose}
       />
-      <div
+      <dialog
+        open
+        ref={dialogRef}
         className="enterprise-users-json-modal"
-        role="dialog"
         aria-modal="true"
         aria-labelledby="enterprise-users-json-title"
+        tabIndex={-1}
+        onKeyDown={event => handleModalKeyDown(event, onClose)}
       >
         <div className="enterprise-users-json-header">
           <div>
@@ -203,7 +263,7 @@ function SourceJsonModal({
           </button>
         </div>
         <pre className="enterprise-users-json-block">{user.sourceJson}</pre>
-      </div>
+      </dialog>
     </div>
   )
 }
@@ -217,7 +277,11 @@ export function TopUsersSection({ refreshToken = 0 }: TopUsersSectionProps) {
   const { data } = enterpriseUsers
   const [filterText, setFilterText] = useState('')
   const [selectedUser, setSelectedUser] = useState<CopilotEnterpriseUser | null>(null)
-  const visibleUsers = data ? filterUsers(data.users, filterText).length : 0
+  const filteredUsers = useMemo(
+    () => (data ? filterUsers(data.users, filterText) : []),
+    [data, filterText]
+  )
+  const visibleUsers = filteredUsers.length
 
   return (
     <div className="top-users-section">
@@ -236,7 +300,7 @@ export function TopUsersSection({ refreshToken = 0 }: TopUsersSectionProps) {
       ) : null}
       <EnterpriseUsersContent
         {...enterpriseUsers}
-        filterText={filterText}
+        filteredUsers={filteredUsers}
         onSelectUser={setSelectedUser}
       />
       {selectedUser && data ? (

--- a/src/components/copilot-usage/UsageHeader.test.tsx
+++ b/src/components/copilot-usage/UsageHeader.test.tsx
@@ -4,7 +4,10 @@ import { UsageHeader } from './UsageHeader'
 
 const baseProps = {
   totalUsed: 1500,
+  totalEntitlement: 7000,
   totalOverageCost: 25.5,
+  totalSpent: null,
+  projectedSpend: null,
   projectedTotal: null,
   projectedOverageCost: null,
   anyLoading: false,
@@ -45,6 +48,37 @@ describe('UsageHeader', () => {
 
     expect(screen.queryByText('Projected')).not.toBeInTheDocument()
     expect(screen.queryByText('Est. Overage')).not.toBeInTheDocument()
+  })
+
+  it('shows total and projected spend when provided', () => {
+    render(<UsageHeader {...baseProps} totalSpent={123.45} projectedSpend={250} />)
+
+    expect(screen.getByText('$123.45')).toBeInTheDocument()
+    expect(screen.getByText('Total Spend')).toBeInTheDocument()
+    expect(screen.getByText('$250.00')).toBeInTheDocument()
+    expect(screen.getByText('Proj. Spend')).toBeInTheDocument()
+  })
+
+  it('hides spend sections when spend values are absent', () => {
+    render(<UsageHeader {...baseProps} totalSpent={null} projectedSpend={null} />)
+
+    expect(screen.queryByText('Total Spend')).not.toBeInTheDocument()
+    expect(screen.queryByText('Proj. Spend')).not.toBeInTheDocument()
+  })
+
+  it('hides Proj. Spend when projected spend is zero', () => {
+    render(<UsageHeader {...baseProps} totalSpent={42} projectedSpend={0} />)
+
+    expect(screen.getByText('Total Spend')).toBeInTheDocument()
+    expect(screen.queryByText('Proj. Spend')).not.toBeInTheDocument()
+  })
+
+  it('shows total spend even when projected spend is unavailable', () => {
+    render(<UsageHeader {...baseProps} totalSpent={80} projectedSpend={null} />)
+
+    expect(screen.getByText('$80.00')).toBeInTheDocument()
+    expect(screen.getByText('Total Spend')).toBeInTheDocument()
+    expect(screen.queryByText('Proj. Spend')).not.toBeInTheDocument()
   })
 
   it('calls onRefreshAll when the refresh button is clicked', () => {

--- a/src/components/copilot-usage/UsageHeader.tsx
+++ b/src/components/copilot-usage/UsageHeader.tsx
@@ -3,76 +3,149 @@ import { formatCurrency } from './quotaUtils'
 
 interface UsageHeaderProps {
   totalUsed: number
+  totalEntitlement: number
   totalOverageCost: number
+  totalSpent: number | null
+  projectedSpend: number | null
   projectedTotal: number | null
   projectedOverageCost: number | null
   anyLoading: boolean
   onRefreshAll: () => void
 }
 
+function OrgPoolBar({
+  totalUsed,
+  totalEntitlement,
+}: {
+  totalUsed: number
+  totalEntitlement: number
+}) {
+  if (totalEntitlement <= 0) return null
+  const ratio = (totalUsed / totalEntitlement) * 100
+  const pct = Math.min(100, Math.max(0, ratio))
+  const pctLabel = ratio >= 0.1 ? ratio.toFixed(1) : ratio > 0 ? '<0.1' : '0'
+  return (
+    <div className="usage-org-pool" data-testid="org-pool">
+      <div className="usage-org-pool-head">
+        <span className="usage-org-pool-label">Org Pool</span>
+        <span className="usage-org-pool-value">
+          {totalUsed.toLocaleString()} / {totalEntitlement.toLocaleString()} ({pctLabel}%)
+        </span>
+      </div>
+      <div className="usage-budget-bar-track">
+        <div
+          className="usage-budget-bar-fill"
+          style={{ width: `${pct}%`, background: '#4ec9b0' }}
+        />
+      </div>
+    </div>
+  )
+}
+
+function SpendSummary({
+  totalSpent,
+  projectedSpend,
+}: {
+  totalSpent: number | null
+  projectedSpend: number | null
+}) {
+  return (
+    <>
+      {totalSpent != null && (
+        <>
+          <div className="usage-header-summary-divider" aria-hidden="true" />
+          <div className="usage-header-summary-item">
+            <span className="usage-header-summary-value">{formatCurrency(totalSpent)}</span>
+            <span className="usage-header-summary-label">Total Spend</span>
+          </div>
+        </>
+      )}
+      {projectedSpend != null && projectedSpend > 0 && (
+        <>
+          <div className="usage-header-summary-divider" aria-hidden="true" />
+          <div className="usage-header-summary-item usage-header-projected">
+            <span className="usage-header-summary-value">
+              <TrendingUp size={11} />
+              {formatCurrency(projectedSpend)}
+            </span>
+            <span className="usage-header-summary-label">Proj. Spend</span>
+          </div>
+        </>
+      )}
+    </>
+  )
+}
+
 export function UsageHeader({
   totalUsed,
+  totalEntitlement,
   totalOverageCost,
+  totalSpent,
+  projectedSpend,
   projectedTotal,
   projectedOverageCost,
   anyLoading,
   onRefreshAll,
 }: UsageHeaderProps) {
   return (
-    <div className="usage-header">
-      <div className="usage-header-left">
-        <div className="usage-header-icon">
-          <Zap size={20} />
+    <>
+      <div className="usage-header">
+        <div className="usage-header-left">
+          <div className="usage-header-icon">
+            <Zap size={20} />
+          </div>
+          <div>
+            <h2>Copilot Usage</h2>
+            <p className="usage-subtitle">Copilot AI credit quota per account</p>
+          </div>
         </div>
-        <div>
-          <h2>Copilot Usage</h2>
-          <p className="usage-subtitle">Copilot AI credit quota per account</p>
+        <div className="usage-header-summary" aria-live="polite">
+          <div className="usage-header-summary-item">
+            <span className="usage-header-summary-value">{totalUsed.toLocaleString()}</span>
+            <span className="usage-header-summary-label">Total Used</span>
+          </div>
+          <div className="usage-header-summary-divider" aria-hidden="true" />
+          <div className="usage-header-summary-item">
+            <span className="usage-header-summary-value">{formatCurrency(totalOverageCost)}</span>
+            <span className="usage-header-summary-label">Total Overage</span>
+          </div>
+          <SpendSummary totalSpent={totalSpent} projectedSpend={projectedSpend} />
+          {projectedTotal != null && (
+            <>
+              <div className="usage-header-summary-divider" aria-hidden="true" />
+              <div className="usage-header-summary-item usage-header-projected">
+                <span className="usage-header-summary-value">
+                  <TrendingUp size={11} />
+                  {projectedTotal.toLocaleString()}
+                </span>
+                <span className="usage-header-summary-label">Projected</span>
+              </div>
+            </>
+          )}
+          {projectedOverageCost != null && projectedOverageCost > 0 && (
+            <>
+              <div className="usage-header-summary-divider" aria-hidden="true" />
+              <div className="usage-header-summary-item usage-header-projected-overage">
+                <span className="usage-header-summary-value">
+                  {formatCurrency(projectedOverageCost)}
+                </span>
+                <span className="usage-header-summary-label">Est. Overage</span>
+              </div>
+            </>
+          )}
         </div>
+        <button
+          type="button"
+          className="usage-refresh-btn"
+          onClick={onRefreshAll}
+          disabled={anyLoading}
+          title="Refresh usage data"
+        >
+          <RefreshCw size={14} className={anyLoading ? 'spin' : ''} />
+          Refresh
+        </button>
       </div>
-      <div className="usage-header-summary" aria-live="polite">
-        <div className="usage-header-summary-item">
-          <span className="usage-header-summary-value">{totalUsed.toLocaleString()}</span>
-          <span className="usage-header-summary-label">Total Used</span>
-        </div>
-        <div className="usage-header-summary-divider" aria-hidden="true" />
-        <div className="usage-header-summary-item">
-          <span className="usage-header-summary-value">{formatCurrency(totalOverageCost)}</span>
-          <span className="usage-header-summary-label">Total Overage</span>
-        </div>
-        {projectedTotal != null && (
-          <>
-            <div className="usage-header-summary-divider" aria-hidden="true" />
-            <div className="usage-header-summary-item usage-header-projected">
-              <span className="usage-header-summary-value">
-                <TrendingUp size={11} />
-                {projectedTotal.toLocaleString()}
-              </span>
-              <span className="usage-header-summary-label">Projected</span>
-            </div>
-          </>
-        )}
-        {projectedOverageCost != null && projectedOverageCost > 0 && (
-          <>
-            <div className="usage-header-summary-divider" aria-hidden="true" />
-            <div className="usage-header-summary-item usage-header-projected-overage">
-              <span className="usage-header-summary-value">
-                {formatCurrency(projectedOverageCost)}
-              </span>
-              <span className="usage-header-summary-label">Est. Overage</span>
-            </div>
-          </>
-        )}
-      </div>
-      <button
-        type="button"
-        className="usage-refresh-btn"
-        onClick={onRefreshAll}
-        disabled={anyLoading}
-        title="Refresh usage data"
-      >
-        <RefreshCw size={14} className={anyLoading ? 'spin' : ''} />
-        Refresh
-      </button>
-    </div>
+      <OrgPoolBar totalUsed={totalUsed} totalEntitlement={totalEntitlement} />
+    </>
   )
 }

--- a/src/components/copilot-usage/quotaUtils.test.ts
+++ b/src/components/copilot-usage/quotaUtils.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   formatCurrency,
   getQuotaColor,
@@ -161,14 +161,17 @@ describe('computeProjection', () => {
     }
   })
 
-  it('returns null when less than 10% of the billing cycle has elapsed', () => {
-    const now = new Date()
-    // Reset ~29 days out → the period started ~a day ago → well under 10% elapsed.
-    const resetDate = new Date(now.getTime() + 29 * 24 * 60 * 60 * 1000)
+  it('floors early-cycle projection to one day of elapsed usage', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(new Date('2026-06-01T06:00:00Z').getTime())
+    const resetDate = '2026-07-01T00:00:00Z'
     const premium = makeSnapshot({ entitlement: 300, remaining: 100, percent_remaining: 33 })
 
-    const result = computeProjection(premium, resetDate.toISOString())
-    expect(result).toBeNull()
+    const result = computeProjection(premium, resetDate)
+    expect(result).not.toBeNull()
+    expect(result!.dailyRate).toBe(200)
+    expect(result!.projectedTotal).toBe(6000)
+
+    vi.restoreAllMocks()
   })
 })
 

--- a/src/components/copilot-usage/quotaUtils.ts
+++ b/src/components/copilot-usage/quotaUtils.ts
@@ -165,13 +165,13 @@ export function getQuotaColor(pct: number | null): string {
  * AI Credits included per seat per billing month.
  * GitHub's promotional allotment is 7,000 for 2026-06..2026-08, otherwise 3,900.
  */
-export function creditsPerSeat(year: number, month: number): number {
+function creditsPerSeat(year: number, month: number): number {
   if (year === 2026 && month >= 6 && month <= 8) return 7000
   return 3900
 }
 
 /** Total AI Credit allotment for an org = seats × per-seat credits (rounded). */
-export function computeCreditAllotment(seats: number, year: number, month: number): number {
+function computeCreditAllotment(seats: number, year: number, month: number): number {
   return Math.round(seats * creditsPerSeat(year, month))
 }
 

--- a/src/components/copilot-usage/quotaUtils.ts
+++ b/src/components/copilot-usage/quotaUtils.ts
@@ -60,13 +60,6 @@ interface Projection {
 export const OVERAGE_COST_PER_CREDIT = 0.01
 const SECONDS_PER_DAY = 86_400
 
-/**
- * Minimum fraction of the billing period that must have elapsed before a
- * month-end projection is shown. Early in the cycle a linear extrapolation
- * from a few hours of usage produces wildly inflated, meaningless numbers.
- */
-const MIN_ELAPSED_FRACTION_FOR_PROJECTION = 0.1
-
 export const formatCurrency = (amount: number) => {
   return new Intl.NumberFormat(undefined, {
     style: 'currency',
@@ -101,16 +94,16 @@ export function computeProjection(premium: QuotaSnapshot, resetDateStr: string):
   const elapsedSeconds = elapsedMs / 1000
   const totalSeconds = totalMs / 1000
 
-  // Need at least 1 second of elapsed time
-  if (elapsedSeconds < 1) return null
+  // Need at least 1 second of elapsed time and a non-degenerate period.
+  if (elapsedSeconds < 1 || totalSeconds < 1) return null
 
-  // Suppress noisy extrapolations during the first days of the billing cycle.
-  if (totalSeconds > 0 && elapsedSeconds / totalSeconds < MIN_ELAPSED_FRACTION_FOR_PROJECTION) {
-    return null
-  }
+  // Floor the elapsed window at one day so an early-cycle, sub-day rate can't
+  // explode into a meaningless month-end figure, and cap it at the full period
+  // so a stale/past reset date can't project below actual usage.
+  const effectiveElapsedSeconds = Math.min(Math.max(elapsedSeconds, SECONDS_PER_DAY), totalSeconds)
 
-  const used = premium.entitlement - premium.remaining
-  const ratePerSecond = used / elapsedSeconds
+  const used = Math.max(0, premium.entitlement - premium.remaining)
+  const ratePerSecond = used / effectiveElapsedSeconds
   const projectedTotal = Math.round(ratePerSecond * totalSeconds)
   const dailyRate = ratePerSecond * SECONDS_PER_DAY
   const projectedOverage = Math.max(0, projectedTotal - premium.entitlement)

--- a/src/components/copilot-usage/types.ts
+++ b/src/components/copilot-usage/types.ts
@@ -2,7 +2,7 @@ interface OrgBudgetData {
   org: string
   budgetAmount: number | null
   preventFurtherUsage: boolean
-  spent: number
+  spent: number | null
   gross: number
   spentUnavailable: boolean
   useQuotaOverage: boolean

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -1,7 +1,0 @@
-export { SettingsAccounts } from './SettingsAccounts'
-export { SettingsAppearance } from './SettingsAppearance'
-export { SettingsPullRequests } from './SettingsPullRequests'
-export { SettingsCopilot } from './SettingsCopilot'
-export { SettingsNotifications } from './SettingsNotifications'
-export { SettingsAdvanced } from './SettingsAdvanced'
-export { SettingsWeather } from './SettingsWeather'

--- a/src/hooks/useCopilotEnterpriseUsers.ts
+++ b/src/hooks/useCopilotEnterpriseUsers.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import type {
+  CopilotEnterpriseUsersResponse,
+  CopilotEnterpriseUsersSnapshot,
+} from '../types/copilotEnterpriseUsers'
+import { getErrorMessage } from '../utils/errorUtils'
+
+interface CopilotEnterpriseUsersState {
+  data: CopilotEnterpriseUsersSnapshot | null
+  loading: boolean
+  error: string | null
+}
+
+const EMPTY_STATE: CopilotEnterpriseUsersState = {
+  data: null,
+  loading: true,
+  error: null,
+}
+
+async function loadEnterpriseUsers(): Promise<CopilotEnterpriseUsersResponse> {
+  const github = window.github as typeof window.github & {
+    getCopilotEnterpriseUsers?: () => Promise<CopilotEnterpriseUsersResponse>
+  }
+
+  if (!github?.getCopilotEnterpriseUsers) {
+    return { success: false, error: 'Copilot Enterprise users source is unavailable.' }
+  }
+
+  return github.getCopilotEnterpriseUsers()
+}
+
+export function useCopilotEnterpriseUsers(refreshToken = 0): CopilotEnterpriseUsersState {
+  const [state, setState] = useState<CopilotEnterpriseUsersState>(EMPTY_STATE)
+
+  useEffect(() => {
+    let canceled = false
+
+    async function load(): Promise<void> {
+      setState(prev => ({ ...prev, loading: true, error: null }))
+
+      try {
+        const result = await loadEnterpriseUsers()
+        if (canceled) return
+
+        if (!result.success || !result.data) {
+          setState({
+            data: null,
+            loading: false,
+            error: result.error ?? 'Failed to read Copilot Enterprise users.',
+          })
+          return
+        }
+
+        setState({ data: result.data, loading: false, error: null })
+      } catch (error: unknown) {
+        if (canceled) return
+        setState({ data: null, loading: false, error: getErrorMessage(error) })
+      }
+    }
+
+    void load()
+
+    return () => {
+      canceled = true
+    }
+  }, [refreshToken])
+
+  return state
+}

--- a/src/hooks/useCopilotSeats.ts
+++ b/src/hooks/useCopilotSeats.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { getErrorMessage } from '../utils/errorUtils'
 
-export interface CopilotSeatInfo {
+interface CopilotSeatInfo {
   login: string
   displayName: string | null
   org: string

--- a/src/hooks/useCopilotUsage.test.ts
+++ b/src/hooks/useCopilotUsage.test.ts
@@ -331,6 +331,17 @@ describe('useCopilotUsage', () => {
     expect(result.current.aggregateSpend).toBeNull()
   })
 
+  it('aggregateSpend skips orgs with null spent values', async () => {
+    mockGetCopilotBudget.mockResolvedValue({
+      success: true,
+      data: makeBudgetData({ useQuotaOverage: false, spentUnavailable: false, spent: null }),
+    })
+
+    const { result } = renderHook(() => useCopilotUsage())
+    await waitFor(() => expect(result.current.anyLoading).toBe(false))
+    expect(result.current.aggregateSpend).toBeNull()
+  })
+
   it('aggregateSpend falls back to spent when a projection is unavailable', async () => {
     // Billing period in the past -> computeBudgetProjection returns null,
     // so projectedSpend should fall back to the raw spent figure.

--- a/src/hooks/useCopilotUsage.test.ts
+++ b/src/hooks/useCopilotUsage.test.ts
@@ -289,6 +289,71 @@ describe('useCopilotUsage', () => {
     expect(result.current.uniqueOrgs.get('org1')).toBe('user1')
   })
 
+  it('aggregateSpend is null when every org bills from the quota pool', async () => {
+    // Default budget mock has useQuotaOverage: true -> excluded from dollar spend.
+    const { result } = renderHook(() => useCopilotUsage())
+    await waitFor(() => expect(result.current.anyLoading).toBe(false))
+    expect(result.current.aggregateSpend).toBeNull()
+  })
+
+  it('aggregateSpend sums dollar spend and projects it to month-end', async () => {
+    // 15 days into the 30-day April 2026 period, $300 spent -> ~$600 projected.
+    const periodStartMs = Date.UTC(2026, 3, 1)
+    const midMonth = periodStartMs + 15 * 86_400_000
+    mockGetCopilotBudget.mockResolvedValue({
+      success: true,
+      data: makeBudgetData({
+        useQuotaOverage: false,
+        spentUnavailable: false,
+        spent: 300,
+        billingMonth: 4,
+        billingYear: 2026,
+        fetchedAt: midMonth,
+      }),
+    })
+
+    const { result } = renderHook(() => useCopilotUsage())
+    await waitFor(() => expect(result.current.anyLoading).toBe(false))
+
+    expect(result.current.aggregateSpend).not.toBeNull()
+    expect(result.current.aggregateSpend!.totalSpent).toBe(300)
+    expect(result.current.aggregateSpend!.projectedSpend).toBeCloseTo(600, 0)
+  })
+
+  it('aggregateSpend excludes orgs with unavailable spend', async () => {
+    mockGetCopilotBudget.mockResolvedValue({
+      success: true,
+      data: makeBudgetData({ useQuotaOverage: false, spentUnavailable: true, spent: 0 }),
+    })
+
+    const { result } = renderHook(() => useCopilotUsage())
+    await waitFor(() => expect(result.current.anyLoading).toBe(false))
+    expect(result.current.aggregateSpend).toBeNull()
+  })
+
+  it('aggregateSpend falls back to spent when a projection is unavailable', async () => {
+    // Billing period in the past -> computeBudgetProjection returns null,
+    // so projectedSpend should fall back to the raw spent figure.
+    mockGetCopilotBudget.mockResolvedValue({
+      success: true,
+      data: makeBudgetData({
+        useQuotaOverage: false,
+        spentUnavailable: false,
+        spent: 75,
+        billingMonth: 1,
+        billingYear: 2020,
+        fetchedAt: Date.now(),
+      }),
+    })
+
+    const { result } = renderHook(() => useCopilotUsage())
+    await waitFor(() => expect(result.current.anyLoading).toBe(false))
+
+    expect(result.current.aggregateSpend).not.toBeNull()
+    expect(result.current.aggregateSpend!.totalSpent).toBe(75)
+    expect(result.current.aggregateSpend!.projectedSpend).toBe(75)
+  })
+
   it('handles usage fetch error with no error message', async () => {
     mockGetCopilotUsage.mockResolvedValue({ success: false })
     const { result } = renderHook(() => useCopilotUsage())

--- a/src/hooks/useCopilotUsage.ts
+++ b/src/hooks/useCopilotUsage.ts
@@ -155,6 +155,7 @@ function computeAggregateSpend(
   for (const state of Object.values(orgBudgets)) {
     const d = state.data
     if (!d || d.useQuotaOverage || d.spentUnavailable) continue
+    if (typeof d.spent !== 'number' || !Number.isFinite(d.spent)) continue
 
     hasAny = true
     totalSpent += d.spent

--- a/src/hooks/useCopilotUsage.ts
+++ b/src/hooks/useCopilotUsage.ts
@@ -10,6 +10,7 @@ import { useGitHubAccounts } from './useConfig'
 import {
   OVERAGE_COST_PER_CREDIT,
   computeProjection,
+  computeBudgetProjection,
   synthesizeQuotaData,
   type AccountQuotaState,
 } from '../components/copilot-usage/quotaUtils'
@@ -124,11 +125,47 @@ function computeAggregateTotals(reps: { org: string; state: AccountQuotaState }[
       const used = premium.entitlement - premium.remaining
       const overageRequests = computeOverageRequests(premium)
       acc.totalUsed += used
+      acc.totalEntitlement += premium.entitlement
       acc.totalOverageCost += overageRequests * OVERAGE_COST_PER_CREDIT
       return acc
     },
-    { totalUsed: 0, totalOverageCost: 0 }
+    { totalUsed: 0, totalEntitlement: 0, totalOverageCost: 0 }
   )
+}
+
+/**
+ * Aggregate dollar spend across every org budget.
+ *
+ * `totalSpent` sums each org's net billed spend so far this period. `projectedSpend`
+ * extrapolates each org to month-end (same linear model as the per-org card) and sums
+ * the results, so the header total stays consistent with the individual projections.
+ *
+ * Orgs whose card hides a projection — those billing from the quota pool
+ * (`useQuotaOverage`) or with unavailable spend (`spentUnavailable`) — are excluded
+ * from both sums to avoid mixing dollar spend with credit-pool overage estimates.
+ * Returns null when no org contributes a usable dollar figure.
+ */
+function computeAggregateSpend(
+  orgBudgets: Record<string, OrgBudgetState>
+): { totalSpent: number; projectedSpend: number } | null {
+  let totalSpent = 0
+  let projectedSpend = 0
+  let hasAny = false
+
+  for (const state of Object.values(orgBudgets)) {
+    const d = state.data
+    if (!d || d.useQuotaOverage || d.spentUnavailable) continue
+
+    hasAny = true
+    totalSpent += d.spent
+
+    const projection = computeBudgetProjection(d.spent, d.billingYear, d.billingMonth, d.fetchedAt)
+    projectedSpend += projection ? projection.projectedSpend : d.spent
+  }
+
+  if (!hasAny) return null
+
+  return { totalSpent, projectedSpend }
 }
 
 function needsMonthRolloverRefresh(orgBudgets: Record<string, OrgBudgetState>): boolean {
@@ -321,6 +358,8 @@ export function useCopilotUsage() {
     [orgRepresentatives]
   )
 
+  const aggregateSpend = useMemo(() => computeAggregateSpend(orgBudgets), [orgBudgets])
+
   return {
     accounts,
     quotas,
@@ -330,6 +369,7 @@ export function useCopilotUsage() {
     anyLoading,
     aggregateTotals,
     aggregateProjections,
+    aggregateSpend,
     orgOverageFromQuotas,
   }
 }

--- a/src/ipc/contracts.test.ts
+++ b/src/ipc/contracts.test.ts
@@ -125,7 +125,7 @@ describe('IPC Contract Registry', () => {
     it('has the expected number of invoke channels', () => {
       // If this fails, a channel was added or removed without updating contracts.
       // Update the contract AND this count when adding new IPC handlers.
-      expect(ALL_INVOKE_CHANNELS.length).toBe(130)
+      expect(ALL_INVOKE_CHANNELS.length).toBe(131)
     })
 
     it('has the expected number of send channels', () => {
@@ -164,9 +164,10 @@ describe('IPC Contract Registry', () => {
       expect(githubChannels).toContain('github:get-copilot-budget')
       expect(githubChannels).toContain('github:get-copilot-member-usage')
       expect(githubChannels).toContain('github:get-user-premium-requests')
+      expect(githubChannels).toContain('github:get-copilot-enterprise-users')
       expect(githubChannels).toContain('github:switch-account')
       expect(githubChannels).toContain('github:collect-copilot-snapshots')
-      expect(githubChannels.length).toBe(11)
+      expect(githubChannels.length).toBe(12)
     })
 
     it('terminal domain has all expected invoke channels', () => {

--- a/src/ipc/contracts.ts
+++ b/src/ipc/contracts.ts
@@ -50,6 +50,7 @@ export const IPC_INVOKE = {
   GITHUB_GET_USER_PREMIUM_REQUESTS: 'github:get-user-premium-requests',
   GITHUB_GET_COPILOT_SEATS: 'github:get-copilot-seats',
   GITHUB_GET_BATCH_MONTHLY_REQUESTS: 'github:get-batch-monthly-requests',
+  GITHUB_GET_COPILOT_ENTERPRISE_USERS: 'github:get-copilot-enterprise-users',
   GITHUB_SWITCH_ACCOUNT: 'github:switch-account',
   GITHUB_COLLECT_COPILOT_SNAPSHOTS: 'github:collect-copilot-snapshots',
 

--- a/src/types/copilotEnterpriseUsers.ts
+++ b/src/types/copilotEnterpriseUsers.ts
@@ -1,0 +1,32 @@
+export interface CopilotEnterpriseUser {
+  login: string
+  grossQuantity: number
+  grossAmount: number
+  netAmount: number
+  modelCount: number
+  topModel: string | null
+  topModelQuantity: number
+  success: boolean
+  errorMessage: string | null
+  sourceJson: string
+}
+
+export interface CopilotEnterpriseUsersSnapshot {
+  generatedAt: string
+  fileLastWriteTime: string
+  sourceFile: string
+  enterprise: string
+  organization: string
+  year: number | null
+  month: number | null
+  days: number[]
+  totalUsers: number
+  activeUsers: number
+  users: CopilotEnterpriseUser[]
+}
+
+export interface CopilotEnterpriseUsersResponse {
+  success: boolean
+  data?: CopilotEnterpriseUsersSnapshot
+  error?: string
+}

--- a/src/utils/copilotEnterpriseUsers.test.ts
+++ b/src/utils/copilotEnterpriseUsers.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeCopilotEnterpriseUsersSnapshot,
+  parseCopilotEnterpriseUsersContent,
+} from './copilotEnterpriseUsers'
+
+describe('normalizeCopilotEnterpriseUsersSnapshot', () => {
+  it('normalizes CodexBar Copilot metrics into one row per enterprise user', () => {
+    const snapshot = normalizeCopilotEnterpriseUsersSnapshot(
+      {
+        GeneratedAtUtc: '2026-06-02T02:30:20.000Z',
+        Enterprise: 'bertelsmann',
+        Organization: 'Relias-Engineering',
+        Year: 2026,
+        Month: 6,
+        Days: [1, 2],
+        Users: [
+          {
+            User: 'no-usage-user',
+            Success: true,
+            Responses: [
+              {
+                Day: 1,
+                Response: { usageItems: [] },
+              },
+            ],
+          },
+          {
+            User: 'active-user',
+            Success: true,
+            Responses: [
+              {
+                Day: 1,
+                Response: {
+                  usageItems: [
+                    {
+                      model: 'Claude Opus 4.8',
+                      grossQuantity: 10,
+                      grossAmount: 0.1,
+                      netAmount: 0,
+                    },
+                    {
+                      model: 'Code Review model',
+                      grossQuantity: 4,
+                      grossAmount: 0.04,
+                      netAmount: 0,
+                    },
+                  ],
+                },
+              },
+              {
+                Day: 2,
+                Response: {
+                  usageItems: [
+                    {
+                      model: 'Claude Opus 4.8',
+                      grossQuantity: 5,
+                      grossAmount: 0.05,
+                      netAmount: 0,
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      },
+      {
+        sourceFile: 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json',
+        fileLastWriteTime: '2026-06-02T02:30:20.000Z',
+      }
+    )
+
+    expect(snapshot.organization).toBe('Relias-Engineering')
+    expect(snapshot.totalUsers).toBe(2)
+    expect(snapshot.activeUsers).toBe(1)
+    expect(snapshot.users.map(user => user.login)).toEqual(['active-user', 'no-usage-user'])
+    expect(snapshot.users[0]).toMatchObject({
+      grossQuantity: 19,
+      grossAmount: 0.19,
+      modelCount: 2,
+      topModel: 'Claude Opus 4.8',
+      topModelQuantity: 15,
+    })
+    expect(snapshot.users[0].sourceJson).toContain('"User": "active-user"')
+    expect(snapshot.users[0].sourceJson).toContain('"Responses"')
+    expect(snapshot.users[1]).toMatchObject({
+      login: 'no-usage-user',
+      grossQuantity: 0,
+      topModel: null,
+    })
+  })
+
+  it('uses file mtime when the metrics payload has no generated timestamp', () => {
+    const snapshot = normalizeCopilotEnterpriseUsersSnapshot(
+      { Users: [] },
+      {
+        sourceFile: 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json',
+        fileLastWriteTime: '2026-06-02T03:00:00.000Z',
+      }
+    )
+
+    expect(snapshot.generatedAt).toBe('2026-06-02T03:00:00.000Z')
+  })
+
+  it('parses metrics content with a UTF-8 BOM', () => {
+    expect(parseCopilotEnterpriseUsersContent('\uFEFF{"GeneratedAtUtc":"now","Users":[]}')).toEqual(
+      {
+        GeneratedAtUtc: 'now',
+        Users: [],
+      }
+    )
+  })
+})

--- a/src/utils/copilotEnterpriseUsers.ts
+++ b/src/utils/copilotEnterpriseUsers.ts
@@ -1,0 +1,226 @@
+import type {
+  CopilotEnterpriseUser,
+  CopilotEnterpriseUsersSnapshot,
+} from '../types/copilotEnterpriseUsers'
+
+interface FileMetadata {
+  sourceFile: string
+  fileLastWriteTime: string
+}
+
+interface UsageTotals {
+  grossQuantity: number
+  grossAmount: number
+  netAmount: number
+  models: Map<string, number>
+}
+
+export function parseCopilotEnterpriseUsersContent(content: string): unknown {
+  return JSON.parse(content.replace(/^\uFEFF/, ''))
+}
+
+const EMPTY_TOTALS: UsageTotals = {
+  grossQuantity: 0,
+  grossAmount: 0,
+  netAmount: 0,
+  models: new Map<string, number>(),
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readString(record: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim().length > 0) return value
+  }
+  return null
+}
+
+function readNumber(record: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return null
+}
+
+function readBoolean(record: Record<string, unknown>, ...keys: string[]): boolean | null {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'boolean') return value
+  }
+  return null
+}
+
+function readArray(record: Record<string, unknown>, ...keys: string[]): unknown[] {
+  for (const key of keys) {
+    const value = record[key]
+    if (Array.isArray(value)) return value
+  }
+  return []
+}
+
+function mergeTotals(target: UsageTotals, source: UsageTotals): void {
+  target.grossQuantity += source.grossQuantity
+  target.grossAmount += source.grossAmount
+  target.netAmount += source.netAmount
+  for (const [model, quantity] of source.models) {
+    target.models.set(model, (target.models.get(model) ?? 0) + quantity)
+  }
+}
+
+function collectUsageItemsFromValue(value: unknown): unknown[] {
+  if (Array.isArray(value)) return value.flatMap(item => collectUsageItemsFromValue(item))
+  if (!isRecord(value)) return []
+
+  const directItems = readArray(value, 'usageItems', 'UsageItems', 'items', 'Items')
+  if (directItems.length > 0) return directItems
+
+  const nestedValues = [
+    'Responses',
+    'responses',
+    'Response',
+    'response',
+    'data',
+    'Data',
+    'Raw',
+    'raw',
+  ]
+    .map(key => value[key])
+    .filter(item => item !== undefined)
+
+  return nestedValues.flatMap(item => collectUsageItemsFromValue(item))
+}
+
+function totalsFromUsageItems(items: unknown[]): UsageTotals {
+  const totals: UsageTotals = { ...EMPTY_TOTALS, models: new Map<string, number>() }
+
+  for (const item of items) {
+    if (!isRecord(item)) continue
+
+    const grossQuantity = readNumber(item, 'grossQuantity', 'GrossQuantity', 'gross_quantity') ?? 0
+    const grossAmount = readNumber(item, 'grossAmount', 'GrossAmount', 'gross_amount') ?? 0
+    const netAmount = readNumber(item, 'netAmount', 'NetAmount', 'net_amount') ?? 0
+    const model = readString(item, 'model', 'Model')
+
+    totals.grossQuantity += grossQuantity
+    totals.grossAmount += grossAmount
+    totals.netAmount += netAmount
+    if (model && grossQuantity > 0) {
+      totals.models.set(model, (totals.models.get(model) ?? 0) + grossQuantity)
+    }
+  }
+
+  return totals
+}
+
+function directTotalsFromRecord(record: Record<string, unknown>): UsageTotals | null {
+  const grossQuantity = readNumber(record, 'grossQuantity', 'GrossQuantity', 'gross_quantity')
+  if (grossQuantity === null) return null
+
+  const totals: UsageTotals = {
+    grossQuantity,
+    grossAmount: readNumber(record, 'grossAmount', 'GrossAmount', 'gross_amount') ?? 0,
+    netAmount: readNumber(record, 'netAmount', 'NetAmount', 'net_amount') ?? 0,
+    models: new Map<string, number>(),
+  }
+
+  const topModel = readString(record, 'topModel', 'TopModel', 'top_model')
+  const topModelQuantity =
+    readNumber(record, 'topModelQuantity', 'TopModelQuantity', 'top_model_quantity') ??
+    grossQuantity
+  if (topModel && topModelQuantity > 0) totals.models.set(topModel, topModelQuantity)
+
+  return totals
+}
+
+function resolveTopModel(models: Map<string, number>): {
+  topModel: string | null
+  topModelQuantity: number
+} {
+  let topModel: string | null = null
+  let topModelQuantity = 0
+
+  for (const [model, quantity] of models) {
+    if (quantity > topModelQuantity) {
+      topModel = model
+      topModelQuantity = quantity
+    }
+  }
+
+  return { topModel, topModelQuantity }
+}
+
+function normalizeUserRecord(record: Record<string, unknown>): CopilotEnterpriseUser | null {
+  const login = readString(record, 'User', 'user', 'login', 'Login', 'memberLogin', 'member_login')
+  if (!login) return null
+
+  const totals: UsageTotals = { ...EMPTY_TOTALS, models: new Map<string, number>() }
+  const directTotals = directTotalsFromRecord(record)
+  if (directTotals) {
+    mergeTotals(totals, directTotals)
+  } else {
+    mergeTotals(totals, totalsFromUsageItems(collectUsageItemsFromValue(record)))
+  }
+
+  const { topModel, topModelQuantity } = resolveTopModel(totals.models)
+  const success = readBoolean(record, 'Success', 'success') ?? true
+  const errorMessage = readString(record, 'Error', 'error', 'errorMessage', 'error_message')
+
+  return {
+    login,
+    grossQuantity: totals.grossQuantity,
+    grossAmount: totals.grossAmount,
+    netAmount: totals.netAmount,
+    modelCount: totals.models.size,
+    topModel,
+    topModelQuantity,
+    success,
+    errorMessage,
+    sourceJson: JSON.stringify(record, null, 2),
+  }
+}
+
+function readUsers(root: Record<string, unknown>): CopilotEnterpriseUser[] {
+  const records = readArray(root, 'Users', 'users', 'members', 'Members')
+  return records
+    .map(record => (isRecord(record) ? normalizeUserRecord(record) : null))
+    .filter((user): user is CopilotEnterpriseUser => user !== null)
+    .sort((a, b) => b.grossQuantity - a.grossQuantity || a.login.localeCompare(b.login))
+}
+
+function readDays(root: Record<string, unknown>): number[] {
+  return readArray(root, 'Days', 'days')
+    .map(day => (typeof day === 'number' && Number.isFinite(day) ? day : null))
+    .filter((day): day is number => day !== null)
+}
+
+export function normalizeCopilotEnterpriseUsersSnapshot(
+  raw: unknown,
+  metadata: FileMetadata
+): CopilotEnterpriseUsersSnapshot {
+  if (!isRecord(raw)) {
+    throw new Error('Copilot metrics file must contain a JSON object')
+  }
+
+  const users = readUsers(raw)
+  const generatedAt =
+    readString(raw, 'GeneratedAtUtc', 'generatedAtUtc', 'generatedAt', 'updatedAt', 'updated_at') ??
+    metadata.fileLastWriteTime
+
+  return {
+    generatedAt,
+    fileLastWriteTime: metadata.fileLastWriteTime,
+    sourceFile: metadata.sourceFile,
+    enterprise: readString(raw, 'Enterprise', 'enterprise') ?? '',
+    organization: readString(raw, 'Organization', 'organization', 'org') ?? '',
+    year: readNumber(raw, 'Year', 'year'),
+    month: readNumber(raw, 'Month', 'month'),
+    days: readDays(raw),
+    totalUsers: users.length,
+    activeUsers: users.filter(user => user.grossQuantity > 0).length,
+    users,
+  }
+}

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -192,13 +192,12 @@ function withRemainder(value: number, unit: string, remainder: number, rUnit: st
 
 export function formatUptime(ms: number): string {
   if (ms <= 0) return '0s'
-  const totalSeconds = Math.floor(ms / 1_000)
-  if (totalSeconds < 60) return `${totalSeconds}s`
-  const totalMinutes = Math.floor(ms / MINUTE)
-  if (totalMinutes < 60) return `${totalMinutes}m`
-  const hours = Math.floor(totalMinutes / 60)
-  if (hours < 24) return withRemainder(hours, 'h', totalMinutes % 60, 'm')
-  return withRemainder(Math.floor(hours / 24), 'd', hours % 24, 'h')
+  if (ms < MINUTE) return `${Math.floor(ms / 1_000)}s`
+  if (ms < HOUR) return `${Math.floor(ms / MINUTE)}m`
+  if (ms < DAY) {
+    return withRemainder(Math.floor(ms / HOUR), 'h', Math.floor((ms % HOUR) / MINUTE), 'm')
+  }
+  return withRemainder(Math.floor(ms / DAY), 'd', Math.floor((ms % DAY) / HOUR), 'h')
 }
 
 const FORMAT_TIME_DEFAULTS = {


### PR DESCRIPTION
## Summary
- Adds Copilot Usage org-total and personal usage projections with enterprise-user file loading.
- Wires the new metrics through Electron IPC/preload contracts and renderer hooks/components.
- Enforces LF line endings for `src` files so repo-wide Prettier checks pass on Windows checkouts.

## Verification
- bun run typecheck
- bun run lint
- bun run format:check
- git diff --check
- bun run test:coverage
- bun run test:electron
- pre-commit hook on 9b4ef180 passed format check, coverage, typecheck, and coverage ratchet