### PR TITLE
Reduce CRAP quality debt

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -15,10 +15,11 @@ bun run format:check
 
 # copilot-hooks:begin markdown gate
 # Block commits on markdownlint violations for staged .md files
-if [ -f ".git/hooks/pre-commit-markdown.ps1" ]; then
-  pwsh -NoProfile -ExecutionPolicy Bypass -File ".git/hooks/pre-commit-markdown.ps1"
+MARKDOWN_HOOK="$(git rev-parse --git-common-dir)/hooks/pre-commit-markdown.ps1"
+if [ -f "$MARKDOWN_HOOK" ]; then
+  pwsh -NoProfile -ExecutionPolicy Bypass -File "$MARKDOWN_HOOK"
 else
-  echo "Missing .git/hooks/pre-commit-markdown.ps1. Reinstall copilot-hooks."
+  echo "Missing $MARKDOWN_HOOK. Reinstall copilot-hooks."
   exit 1
 fi
 # copilot-hooks:end markdown gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.800] - 2026-06-07
+
+### Fixed
+
+- Guard Copilot enterprise preload API
+
 ## [0.1.799] - 2026-06-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Remove Copilot token fallback from PR promoter
+- Reduce CRAP quality debt
 
 ## [0.1.798] - 2026-06-07
 

--- a/docs/crap-score-log.md
+++ b/docs/crap-score-log.md
@@ -1,3 +1,32 @@
+## 2026-06-07 — CRAP Score Snapshot (TypeScript)
+
+| Metric | Value |
+|--------|-------|
+| Methods Analyzed | 2,619 (src/) |
+| Methods > 30 (Critical) | 0 |
+| Methods 16–30 (High) | 0 |
+| Methods 6–15 (Moderate) | 70 |
+| Highest CRAP | 9.3 (`src/utils/copilotEnterpriseUsers.ts` :: `totalsFromUsageItems`) |
+| Average CRAP | Not reported by `crap-report.ps1` |
+| Overall Coverage | 99.89% lines / 99.44% branches / 99.97% functions / 99.84% statements |
+
+**Critical Methods (CRAP > 30):** None — repo passes Gold scorecard rule.
+
+**Improvements This Session:**
+
+- `src/hooks/useCopilotEnterpriseUsers.ts` :: `load`: CRAP 56 → 7.6 (added hook coverage for success, failure, unavailable preload API, thrown errors, and refresh reload)
+- `src/hooks/useCopilotEnterpriseUsers.ts` :: `loadEnterpriseUsers`: CRAP 12 → below threshold (covered preload availability and success paths)
+- `src/hooks/useCopilotUsage.ts` :: `selectOrgRepresentatives`: CRAP 10 → below threshold (extracted org grouping and representative selection helpers)
+- Targeted `lint:quality` first-tranche scan: 12 warnings → 5 warnings; `electron/services/ralphService.ts` :: `launchLoop` max-lines warning removed
+
+**Session Notes:**
+
+- Fresh report generated with `~/.agents/skills/crap/scripts/crap-report.ps1 -Threshold 6 -Top 20 -Format table -Stack ts`.
+- Remaining CRAP debt is moderate only; follow-up issue #94 tracks reducing worst CRAP below 6.
+- Remaining targeted lint warnings are max-lines-only items in `ralphService.ts`, `usePRThreadsPanel.ts`, `useTerminalPanel.ts`, and `useTerminalWorkspace.tsx`.
+
+---
+
 ## 2026-05-23 — CRAP Score Snapshot (Electron)
 
 | Metric | Value |

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -224,5 +224,7 @@ app.on('before-quit', event => {
   }
 
   const timeout = new Promise<void>(resolve => setTimeout(resolve, 5_000))
-  Promise.race([shutdownTelemetry(), timeout]).finally(() => app.quit())
+  Promise.race([shutdownTelemetry(), timeout]).finally(() => {
+    app.quit()
+  })
 })

--- a/electron/services/ralphService.ts
+++ b/electron/services/ralphService.ts
@@ -384,6 +384,35 @@ function buildArgs(config: RalphLaunchConfig, scriptPath: string): string[] {
   return args
 }
 
+function createRunInfo(runId: string, config: RalphLaunchConfig, proc: ChildProcess): RalphRunInfo {
+  const now = Date.now()
+  return {
+    runId,
+    config,
+    status: 'running',
+    phase: 'initializing',
+    pid: proc.pid ?? null,
+    currentIteration: 0,
+    totalIterations: config.iterations ?? null,
+    startedAt: now,
+    updatedAt: now,
+    completedAt: null,
+    exitCode: null,
+    error: null,
+    logBuffer: [],
+    stats: {
+      checks: 0,
+      agentTurns: 0,
+      reviews: 0,
+      copilotPRs: 0,
+      issuesCreated: 0,
+      scanIterations: 0,
+      totalCost: null,
+      totalPremium: 0,
+    },
+  }
+}
+
 export function launchLoop(config: RalphLaunchConfig): RalphLaunchResult {
   const validationError = validateLaunchConfig(config)
   if (validationError) return { success: false, error: validationError }
@@ -406,31 +435,7 @@ export function launchLoop(config: RalphLaunchConfig): RalphLaunchResult {
     env: { ...process.env },
   })
 
-  const run: RalphRunInfo = {
-    runId,
-    config,
-    status: 'running',
-    phase: 'initializing',
-    pid: proc.pid ?? null,
-    currentIteration: 0,
-    totalIterations: config.iterations ?? null,
-    startedAt: Date.now(),
-    updatedAt: Date.now(),
-    completedAt: null,
-    exitCode: null,
-    error: null,
-    logBuffer: [],
-    stats: {
-      checks: 0,
-      agentTurns: 0,
-      reviews: 0,
-      copilotPRs: 0,
-      issuesCreated: 0,
-      scanIterations: 0,
-      totalCost: null,
-      totalPremium: 0,
-    },
-  }
+  const run = createRunInfo(runId, config, proc)
 
   activeRuns.set(runId, run)
   activeProcesses.set(runId, proc)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.799",
+  "version": "0.1.800",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/hooks/useCopilotEnterpriseUsers.test.ts
+++ b/src/hooks/useCopilotEnterpriseUsers.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import type {
+  CopilotEnterpriseUsersResponse,
+  CopilotEnterpriseUsersSnapshot,
+} from '../types/copilotEnterpriseUsers'
+
+const mockGetCopilotEnterpriseUsers = vi.fn<() => Promise<CopilotEnterpriseUsersResponse>>()
+type EnterpriseUsersGithub = typeof window.github & {
+  getCopilotEnterpriseUsers?: () => Promise<CopilotEnterpriseUsersResponse>
+}
+
+Object.defineProperty(window, 'github', {
+  value: { getCopilotEnterpriseUsers: mockGetCopilotEnterpriseUsers },
+  writable: true,
+  configurable: true,
+})
+
+import { useCopilotEnterpriseUsers } from './useCopilotEnterpriseUsers'
+
+const snapshot: CopilotEnterpriseUsersSnapshot = {
+  generatedAt: '2026-06-02T02:30:20.000Z',
+  fileLastWriteTime: '2026-06-02T02:30:20.000Z',
+  sourceFile: 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json',
+  enterprise: 'bertelsmann',
+  organization: 'Relias-Engineering',
+  year: 2026,
+  month: 6,
+  days: [1, 2],
+  totalUsers: 1,
+  activeUsers: 1,
+  users: [
+    {
+      login: 'fhemmerrelias',
+      grossQuantity: 11540.58,
+      grossAmount: 115.41,
+      netAmount: 0,
+      modelCount: 2,
+      topModel: 'Claude Opus 4.8',
+      topModelQuantity: 7000,
+      success: true,
+      errorMessage: null,
+      sourceJson: '{ "User": "fhemmerrelias", "Success": true }',
+    },
+  ],
+}
+
+describe('useCopilotEnterpriseUsers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const github = window.github as EnterpriseUsersGithub
+    github.getCopilotEnterpriseUsers = mockGetCopilotEnterpriseUsers
+    mockGetCopilotEnterpriseUsers.mockResolvedValue({ success: true, data: snapshot })
+  })
+
+  it('loads enterprise users on mount', async () => {
+    const { result } = renderHook(() => useCopilotEnterpriseUsers())
+
+    expect(result.current.loading).toBe(true)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(mockGetCopilotEnterpriseUsers).toHaveBeenCalledTimes(1)
+    expect(result.current.data).toEqual(snapshot)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('reloads when refresh token changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ refreshToken }) => useCopilotEnterpriseUsers(refreshToken),
+      { initialProps: { refreshToken: 1 } }
+    )
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    rerender({ refreshToken: 2 })
+    await waitFor(() => expect(mockGetCopilotEnterpriseUsers).toHaveBeenCalledTimes(2))
+
+    expect(result.current.data).toEqual(snapshot)
+  })
+
+  it('reports API failures', async () => {
+    mockGetCopilotEnterpriseUsers.mockResolvedValue({ success: false, error: 'No file' })
+
+    const { result } = renderHook(() => useCopilotEnterpriseUsers())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('No file')
+  })
+
+  it('reports unavailable preload API', async () => {
+    window.github = {} as typeof window.github
+
+    const { result } = renderHook(() => useCopilotEnterpriseUsers())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('Copilot Enterprise users source is unavailable.')
+  })
+
+  it('reports thrown loader errors', async () => {
+    mockGetCopilotEnterpriseUsers.mockRejectedValue(new Error('Disk unavailable'))
+
+    const { result } = renderHook(() => useCopilotEnterpriseUsers())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('Disk unavailable')
+  })
+})

--- a/src/hooks/useCopilotEnterpriseUsers.test.ts
+++ b/src/hooks/useCopilotEnterpriseUsers.test.ts
@@ -6,9 +6,6 @@ import type {
 } from '../types/copilotEnterpriseUsers'
 
 const mockGetCopilotEnterpriseUsers = vi.fn<() => Promise<CopilotEnterpriseUsersResponse>>()
-type EnterpriseUsersGithub = typeof window.github & {
-  getCopilotEnterpriseUsers?: () => Promise<CopilotEnterpriseUsersResponse>
-}
 
 Object.defineProperty(window, 'github', {
   value: { getCopilotEnterpriseUsers: mockGetCopilotEnterpriseUsers },
@@ -48,8 +45,11 @@ const snapshot: CopilotEnterpriseUsersSnapshot = {
 describe('useCopilotEnterpriseUsers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    const github = window.github as EnterpriseUsersGithub
-    github.getCopilotEnterpriseUsers = mockGetCopilotEnterpriseUsers
+    Object.defineProperty(window, 'github', {
+      value: { getCopilotEnterpriseUsers: mockGetCopilotEnterpriseUsers },
+      writable: true,
+      configurable: true,
+    })
     mockGetCopilotEnterpriseUsers.mockResolvedValue({ success: true, data: snapshot })
   })
 
@@ -89,6 +89,20 @@ describe('useCopilotEnterpriseUsers', () => {
 
   it('reports unavailable preload API', async () => {
     window.github = {} as typeof window.github
+
+    const { result } = renderHook(() => useCopilotEnterpriseUsers())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.data).toBeNull()
+    expect(result.current.error).toBe('Copilot Enterprise users source is unavailable.')
+  })
+
+  it('reports unavailable preload API when window.github is absent', async () => {
+    Object.defineProperty(window, 'github', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    })
 
     const { result } = renderHook(() => useCopilotEnterpriseUsers())
     await waitFor(() => expect(result.current.loading).toBe(false))

--- a/src/hooks/useCopilotEnterpriseUsers.ts
+++ b/src/hooks/useCopilotEnterpriseUsers.ts
@@ -18,9 +18,12 @@ const EMPTY_STATE: CopilotEnterpriseUsersState = {
 }
 
 async function loadEnterpriseUsers(): Promise<CopilotEnterpriseUsersResponse> {
-  const { getCopilotEnterpriseUsers } = window.github as typeof window.github & {
-    getCopilotEnterpriseUsers?: () => Promise<CopilotEnterpriseUsersResponse>
-  }
+  const github = window.github as
+    | (typeof window.github & {
+        getCopilotEnterpriseUsers?: () => Promise<CopilotEnterpriseUsersResponse>
+      })
+    | undefined
+  const getCopilotEnterpriseUsers = github?.getCopilotEnterpriseUsers
 
   if (!getCopilotEnterpriseUsers) {
     return { success: false, error: 'Copilot Enterprise users source is unavailable.' }

--- a/src/hooks/useCopilotEnterpriseUsers.ts
+++ b/src/hooks/useCopilotEnterpriseUsers.ts
@@ -18,15 +18,15 @@ const EMPTY_STATE: CopilotEnterpriseUsersState = {
 }
 
 async function loadEnterpriseUsers(): Promise<CopilotEnterpriseUsersResponse> {
-  const github = window.github as typeof window.github & {
+  const { getCopilotEnterpriseUsers } = window.github as typeof window.github & {
     getCopilotEnterpriseUsers?: () => Promise<CopilotEnterpriseUsersResponse>
   }
 
-  if (!github?.getCopilotEnterpriseUsers) {
+  if (!getCopilotEnterpriseUsers) {
     return { success: false, error: 'Copilot Enterprise users source is unavailable.' }
   }
 
-  return github.getCopilotEnterpriseUsers()
+  return getCopilotEnterpriseUsers()
 }
 
 export function useCopilotEnterpriseUsers(refreshToken = 0): CopilotEnterpriseUsersState {

--- a/src/hooks/useCopilotUsage.ts
+++ b/src/hooks/useCopilotUsage.ts
@@ -19,6 +19,11 @@ import type { GitHubAccount } from '../types/config'
 import { MS_PER_MINUTE } from '../constants'
 import { getErrorMessage } from '../utils/errorUtils'
 
+interface OrgAccountGroup {
+  org: string
+  usernames: string[]
+}
+
 function getPremiumInteractions(state: AccountQuotaState | undefined) {
   return state?.data?.quota_snapshots?.premium_interactions ?? null
 }
@@ -38,6 +43,34 @@ function getQuotaProjection(state: AccountQuotaState) {
   return computeProjection(premium, state.data.quota_reset_date_utc)
 }
 
+function groupAccountsByOrg(accounts: { username: string; org: string }[]): OrgAccountGroup[] {
+  const groups = new Map<string, OrgAccountGroup>()
+  for (const account of accounts) {
+    if (!account.org) continue
+    let group = groups.get(account.org)
+    if (!group) {
+      group = { org: account.org, usernames: [] }
+      groups.set(account.org, group)
+    }
+    group.usernames.push(account.username)
+  }
+  return [...groups.values()]
+}
+
+function selectRepresentativeState(
+  usernames: string[],
+  quotas: Partial<Record<string, AccountQuotaState>>
+): AccountQuotaState | undefined {
+  let fallback: AccountQuotaState | undefined
+  for (const username of usernames) {
+    const state = quotas[username]
+    if (!state) continue
+    if (state.data) return state
+    fallback ??= state
+  }
+  return fallback
+}
+
 /**
  * One representative quota state per unique org.
  *
@@ -55,29 +88,9 @@ function selectOrgRepresentatives(
   accounts: { username: string; org: string }[],
   quotas: Record<string, AccountQuotaState>
 ): { org: string; state: AccountQuotaState }[] {
-  const orderedOrgs: string[] = []
-  const usernamesByOrg = new Map<string, string[]>()
-  for (const account of accounts) {
-    if (!account.org) continue
-    if (!usernamesByOrg.has(account.org)) {
-      usernamesByOrg.set(account.org, [])
-      orderedOrgs.push(account.org)
-    }
-    usernamesByOrg.get(account.org)!.push(account.username)
-  }
-
   const reps: { org: string; state: AccountQuotaState }[] = []
-  for (const org of orderedOrgs) {
-    let chosen: AccountQuotaState | undefined
-    for (const username of usernamesByOrg.get(org)!) {
-      const state = quotas[username]
-      if (!state) continue
-      if (state.data) {
-        chosen = state
-        break
-      }
-      chosen ??= state
-    }
+  for (const { org, usernames } of groupAccountsByOrg(accounts)) {
+    const chosen = selectRepresentativeState(usernames, quotas)
     if (chosen) reps.push({ org, state: chosen })
   }
   return reps
@@ -334,7 +347,9 @@ export function useCopilotUsage() {
       if (needsMonthRolloverRefresh(orgBudgets)) refreshAll()
     }, 5 * MS_PER_MINUTE)
 
-    return () => clearInterval(refreshInterval)
+    return () => {
+      clearInterval(refreshInterval)
+    }
   }, [orgBudgets, refreshAll])
 
   const orgRepresentatives = useMemo(

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -318,8 +318,12 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
       selectOrAddTabForContext(
         terminalTabsRef.current,
         repoContext,
-        id => setActiveTerminalTabId(id),
-        ctx => void addTerminalTab(ctx)
+        id => {
+          setActiveTerminalTabId(id)
+        },
+        ctx => {
+          void addTerminalTab(ctx)
+        }
       )
     },
     [addTerminalTab]
@@ -388,7 +392,9 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
       }
     }
     window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+    }
   }, [toggleTerminal])
 
   // Kill all terminal sessions on unmount (app close)

--- a/src/hooks/useTerminalWorkspace.tsx
+++ b/src/hooks/useTerminalWorkspace.tsx
@@ -128,7 +128,9 @@ function useTerminalWorkspaceInternal(): UseTerminalWorkspaceReturn {
           setLoaded(true)
         }
       }, 2000)
-      return () => clearTimeout(timeout)
+      return () => {
+        clearTimeout(timeout)
+      }
     }
 
     restoredRef.current = true
@@ -165,7 +167,9 @@ function useTerminalWorkspaceInternal(): UseTerminalWorkspaceReturn {
         saveWorkspaceMutation({
           nodes: payload,
           activeNodeId: data.activeNodeId ?? undefined,
-        }).catch(err => console.warn('Failed to persist terminal workspace:', err))
+        }).catch(err => {
+          console.warn('Failed to persist terminal workspace:', err)
+        })
       }, SAVE_DEBOUNCE_MS)
     },
     [saveWorkspaceMutation, clearSaveTimeout]
@@ -183,8 +187,9 @@ function useTerminalWorkspaceInternal(): UseTerminalWorkspaceReturn {
       setNodes(prev => {
         const next = transform(prev)
         nodesRef.current = next
-        const activeId = newActiveNodeId !== undefined ? newActiveNodeId : activeNodeIdRef.current
-        if (newActiveNodeId !== undefined) {
+        const hasNewActiveNodeId = newActiveNodeId !== undefined
+        const activeId = hasNewActiveNodeId ? newActiveNodeId : activeNodeIdRef.current
+        if (hasNewActiveNodeId) {
           setActiveNodeId(activeId)
           activeNodeIdRef.current = activeId
         }

--- a/src/utils/copilotEnterpriseUsers.test.ts
+++ b/src/utils/copilotEnterpriseUsers.test.ts
@@ -103,6 +103,84 @@ describe('normalizeCopilotEnterpriseUsersSnapshot', () => {
     expect(snapshot.generatedAt).toBe('2026-06-02T03:00:00.000Z')
   })
 
+  it('normalizes direct aggregate totals when usage items are absent', () => {
+    const snapshot = normalizeCopilotEnterpriseUsersSnapshot(
+      {
+        users: [
+          {
+            login: 'direct-user',
+            grossQuantity: 42,
+            grossAmount: 0.42,
+            netAmount: 0.1,
+            topModel: 'Claude Sonnet 4.5',
+          },
+        ],
+      },
+      {
+        sourceFile: 'D:\\\\github\\\\HemSoft\\\\codexbar\\\\data\\\\copilot-metrics.json',
+        fileLastWriteTime: '2026-06-02T03:00:00.000Z',
+      }
+    )
+
+    expect(snapshot.users[0]).toMatchObject({
+      login: 'direct-user',
+      grossQuantity: 42,
+      grossAmount: 0.42,
+      netAmount: 0.1,
+      modelCount: 1,
+      topModel: 'Claude Sonnet 4.5',
+      topModelQuantity: 42,
+    })
+  })
+
+  it('ignores malformed usage entries and supports alternate usage key casing', () => {
+    const snapshot = normalizeCopilotEnterpriseUsersSnapshot(
+      {
+        members: [
+          {
+            memberLogin: 'mixed-user',
+            success: false,
+            error_message: 'partial data',
+            data: {
+              Items: [
+                null,
+                'ignored',
+                {
+                  Model: 'Claude Opus 4.8',
+                  GrossQuantity: 12,
+                  GrossAmount: 0.12,
+                  NetAmount: 0.03,
+                },
+                {
+                  model: 'Zero Usage Model',
+                  gross_quantity: 0,
+                  gross_amount: 0,
+                  net_amount: 0,
+                },
+              ],
+            },
+          },
+        ],
+      },
+      {
+        sourceFile: 'D:\\\\github\\\\HemSoft\\\\codexbar\\\\data\\\\copilot-metrics.json',
+        fileLastWriteTime: '2026-06-02T03:00:00.000Z',
+      }
+    )
+
+    expect(snapshot.users[0]).toMatchObject({
+      login: 'mixed-user',
+      grossQuantity: 12,
+      grossAmount: 0.12,
+      netAmount: 0.03,
+      modelCount: 1,
+      topModel: 'Claude Opus 4.8',
+      topModelQuantity: 12,
+      success: false,
+      errorMessage: 'partial data',
+    })
+  })
+
   it('parses metrics content with a UTF-8 BOM', () => {
     expect(parseCopilotEnterpriseUsersContent('\uFEFF{"GeneratedAtUtc":"now","Users":[]}')).toEqual(
       {


### PR DESCRIPTION
## Summary

- Refreshes the TypeScript CRAP baseline in `docs/crap-score-log.md`.
- Adds focused coverage for `useCopilotEnterpriseUsers` and Copilot enterprise-user parser edge cases.
- Extracts `useCopilotUsage` org representative selection helpers to reduce CRAP.
- Removes the `launchLoop` max-lines warning and cleans first-tranche void-expression quality warnings.

## Results

- First-tranche `lint:quality` scan: 12 warnings -> 5 warnings.
- Fresh CRAP snapshot: 2,619 functions analyzed, 0 critical, 0 high, 70 moderate, worst CRAP 9.3.
- Remaining moderate CRAP backlog is tracked in #94.

## Validation

- `bun run typecheck`
- `bun run test src/hooks/useCopilotUsage.test.ts src/hooks/useCopilotEnterpriseUsers.test.ts src/utils/copilotEnterpriseUsers.test.ts`
- `bunx markdownlint-cli2 docs/crap-score-log.md`
- `~/.agents/skills/crap/scripts/crap-report.ps1 -Threshold 6 -Top 20 -Format table -Stack ts`

Note: the CRAP report exits nonzero while threshold-6 moderate findings remain, but critical and high counts are 0 and follow-up #94 tracks the remaining backlog.

Closes #87.