### PR TITLE
fix: stabilize Lighthouse CI baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.804] - 2026-06-08
+
+### Fixed
+
+- Stabilize Lighthouse CI baseline
+
 ## [0.1.803] - 2026-06-08
 
 ### Changed

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 | ------ | -------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 📋     | Medium   | [Refresh CRAP baseline and reduce quality-warning debt](#refresh-crap-baseline-and-reduce-quality-warning-debt) | #87 — Current CRAP log has no critical/high methods, but `bun run lint:quality` reports 1,567 warnings |
 | 📋     | Medium   | [Improve React Doctor score](#improve-react-doctor-score)                          | #88 — Current React Doctor score is 63/100 with 154 issues |
-| 📋     | Medium   | [Stabilize Lighthouse CI](#stabilize-lighthouse-ci)                                | #89 — LHCI is installed/wired, but local `bun run lhci` fails and needs a stable baseline |
+| ✅     | Medium   | Stabilize Lighthouse CI                                                            | 2026-06-08: Fixed local LHCI readiness/cleanup and documented the baseline in `docs/lighthouse-baseline.md` (#89) |
 | 📋     | Medium   | [Harden or replace Electron webviewTag usage](#harden-or-replace-electron-webviewtag-usage) | #90 — `security:electron` has 0 high/medium findings, but `webviewTag: true` remains an info risk |
 | 📋     | Medium   | [Expand axe accessibility coverage](#expand-axe-accessibility-coverage)            | #91 — Tooling exists; add coverage for terminal, settings, Tempo, dashboard, and sidebar surfaces |
 | 📋     | Low      | [Fix remaining markdownlint MD040 failure](#fix-remaining-markdownlint-md040-failure) | #92 — One remaining MD040 in `.sfl/governance/policy.md` |
@@ -102,7 +102,7 @@
 
 ## Progress
 
-**Remaining: 7** | **Completed: 90** (93%)
+**Remaining: 6** | **Completed: 91** (94%)
 
 ---
 
@@ -133,19 +133,6 @@
 - 78 bugs, 33 performance warnings, 2 accessibility warnings, 41 maintainability warnings
 
 **Approach:** Fix high-count categories first: derived state/effect logic, parent synchronization effects, changing-callback re-subscriptions, sequential awaits, array index keys, and non-interactive handlers.
-
----
-
-### Stabilize Lighthouse CI
-
-**Issue:** #89
-
-**Current state** (2026-06-07 audit):
-
-- `@lhci/cli`, `lighthouserc.cjs`, `package.json` `lhci`, and the CI Lighthouse step all exist.
-- Local `bun run lhci` failed because LHCI timed out waiting for Vite readiness, then Lighthouse failed and hit a Windows temp cleanup EPERM.
-
-**Approach:** Fix LHCI readiness/cleanup locally, confirm CI stays green, then capture stable baseline scores.
 
 ---
 

--- a/docs/lighthouse-baseline.md
+++ b/docs/lighthouse-baseline.md
@@ -1,0 +1,39 @@
+# Lighthouse CI Baseline
+
+This baseline captures the Electron renderer route that Lighthouse CI audits
+through the browser-safe Vite entry point.
+
+## Configuration
+
+- Command: `bun run lhci`
+- Server: `node ./node_modules/vite/bin/vite.js --mode e2e --host 127.0.0.1 --port 9222 --strictPort`
+- Readiness pattern: `ready in`
+- URL: `http://127.0.0.1:9222/`
+- Reports: `.lighthouseci/` filesystem upload target
+
+`127.0.0.1` and `--strictPort` keep the audited URL deterministic. The
+`ready in` pattern avoids matching Vite's ANSI-styled `Local:` label, which can
+split the text that LHCI receives on Windows.
+
+## Baseline Run
+
+Captured on 2026-06-08 on Windows with `VITE_CONVEX_URL` set to the LHCI
+placeholder Convex URL.
+
+| Run | URL | Performance | Accessibility | Best Practices |
+| --- | --- | ---: | ---: | ---: |
+| 1 | `http://127.0.0.1:9222/` | 48 | 85 | 100 |
+| 2 | `http://127.0.0.1:9222/` | 49 | 85 | 100 |
+| 3 | `http://127.0.0.1:9222/` | 49 | 85 | 100 |
+| Average | `http://127.0.0.1:9222/` | 49 | 85 | 100 |
+
+## Threshold Policy
+
+Current assertions are intentionally warnings:
+
+- Performance: warn below 60
+- Accessibility: warn below 80
+- Best Practices: warn below 80
+
+Keep these informational until the baseline stabilizes across local Windows and
+GitHub-hosted Ubuntu runs.

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -3,9 +3,10 @@
 module.exports = {
   ci: {
     collect: {
-      startServerCommand: 'npx vite --mode e2e --port 9222',
-      startServerReadyPattern: 'Local:',
-      url: ['http://localhost:9222/'],
+      startServerCommand:
+        'node ./node_modules/vite/bin/vite.js --mode e2e --host 127.0.0.1 --port 9222 --strictPort',
+      startServerReadyPattern: 'ready in',
+      url: ['http://127.0.0.1:9222/'],
       numberOfRuns: 3,
       settings: {
         chromeFlags: '--no-sandbox --headless --disable-gpu --disable-dev-shm-usage',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.803",
+  "version": "0.1.804",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary

Closes #89.

- Stabilizes LHCI local autorun by launching Vite through the repo-local Vite entry point with `node` instead of the `npx` wrapper.
- Pins the audited server to `127.0.0.1:9222` with `--strictPort` so Lighthouse does not silently audit a drifted port.
- Uses Vite's `ready in` output as the LHCI readiness signal to avoid ANSI-styled `Local:` matching issues on Windows.
- Documents the current baseline scores in `docs/lighthouse-baseline.md`.

## Verification

- `bun run lhci` exit 0; no readiness timeout; no listener left on port 9222 after completion.
- `node --check lighthouserc.cjs` exit 0.
- `bunx markdownlint-cli2 docs/lighthouse-baseline.md TODO.md` exit 0.
- `bun run typecheck` exit 0.
- `git diff --check` exit 0.

## Risk

Medium: this changes CI/performance tooling. Thresholds remain warnings and the CI `lighthouse` job remains `continue-on-error: true` while the baseline stabilizes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Lighthouse CI baseline by stabilizing Vite server startup and URL config
> - Updates [lighthouserc.cjs](https://github.com/HemSoft/hs-buddy/pull/103/files#diff-f9aaf8f16bb7a0b11fb2babc21dcedc9c1e092b07ee80c9a70b4a5547219c315) to start Vite via `node` with `--host 127.0.0.1`, `--port 9222`, and `--strictPort`, replacing the previous implicit invocation
> - Changes the server readiness pattern from `'Local:'` to `'ready in'` and updates the audit URL from `http://localhost:9222/` to `http://127.0.0.1:9222/`
> - Adds [docs/lighthouse-baseline.md](https://github.com/HemSoft/hs-buddy/pull/103/files#diff-aa3f6b39638eb5e9e06b4c1bc2ff074592874138191b9f611dd0b6b950cdd594) documenting configuration, recorded scores across three runs, and threshold policy
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 59bd9b3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->