### PR TITLE
fix: harden Electron webview usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.806] - 2026-06-08
+
+### Fixed
+
+- Address webview guardrail review comments
+
 ## [0.1.805] - 2026-06-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.805] - 2026-06-08
+
+### Fixed
+
+- Harden Electron webview usage
+
 ## [0.1.804] - 2026-06-08
 
 ### Fixed

--- a/docs/WEBVIEW-SECURITY.md
+++ b/docs/WEBVIEW-SECURITY.md
@@ -1,0 +1,37 @@
+# Webview Security
+
+Buddy keeps Electron `webviewTag` enabled for the Bookmarks in-app browser.
+The feature is user-facing and documented in `README.md` and `docs/VISION.md`.
+
+`webviewTag` is intentionally limited to browser tabs that load public `http`
+or `https` URLs in the `persist:browser` partition. It must not be used for
+privileged app UI or local/internal resources.
+
+## Guardrails
+
+The main process registers these controls before creating app windows:
+
+- Deny browser webview permission prompts by default.
+- Deny `window.open` popups by default.
+- Block webview attachment unless the requested partition is `persist:browser`.
+- Block webview attachment unless the initial `src` is a public `http` or
+  `https` URL accepted by `validateUrl`.
+- Strip guest preload settings from webviews.
+- Force guest preferences to keep `nodeIntegration` off, `contextIsolation` on,
+  `sandbox` on, `webSecurity` on, plugins off, insecure content off, and
+  subframe Node integration off.
+
+Navigation to local, loopback, private, and internal hostnames should stay
+blocked at the app URL-validation boundary. Future changes that broaden allowed
+URLs or enable webview permissions must be treated as security-sensitive.
+
+## Verification
+
+Run these checks after changing browser or Electron window behavior:
+
+```powershell
+bun run security:electron
+bunx vitest run --config vitest.electron.config.ts electron/main.test.ts
+bunx vitest run src/components/BrowserTabView.test.tsx
+bun run typecheck
+```

--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -264,6 +264,16 @@ describe('main process lifecycle', () => {
       }
     )
     expect(missingPartitionEvent.preventDefault).toHaveBeenCalled()
+
+    const missingSrcEvent = { preventDefault: vi.fn() }
+    attachHandler!(
+      missingSrcEvent,
+      {},
+      {
+        partition: 'persist:browser',
+      }
+    )
+    expect(missingSrcEvent.preventDefault).toHaveBeenCalled()
   })
 
   it('denies browser webview permission prompts by default', async () => {

--- a/electron/main.test.ts
+++ b/electron/main.test.ts
@@ -9,9 +9,11 @@
 import { describe, it, expect, vi } from 'vitest'
 
 // Track lifecycle callbacks registered with app.on / app.whenReady
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const appOnCalls: [string, (...args: any[]) => any][] = []
+const appOnCalls: [string, (...args: unknown[]) => unknown][] = []
 let whenReadyCb: (() => void) | null = null
+let browserSessionPermissionHandler:
+  | ((webContents: unknown, permission: string, callback: (allowed: boolean) => void) => void)
+  | null = null
 
 const mockWin = {
   webContents: { on: vi.fn(), send: vi.fn() },
@@ -48,6 +50,21 @@ vi.mock('electron', () => ({
     getAllDisplays: vi.fn(() => []),
     getPrimaryDisplay: vi.fn(() => ({ workArea: { x: 0, y: 0, width: 1920, height: 1040 } })),
     getDisplayMatching: vi.fn(() => ({ id: 1, bounds: {}, workArea: {} })),
+  },
+  session: {
+    fromPartition: vi.fn(() => ({
+      setPermissionRequestHandler: vi.fn(
+        (
+          handler: (
+            webContents: unknown,
+            permission: string,
+            callback: (allowed: boolean) => void
+          ) => void
+        ) => {
+          browserSessionPermissionHandler = handler
+        }
+      ),
+    })),
   },
 }))
 
@@ -126,6 +143,139 @@ describe('main process lifecycle', () => {
     expect(Menu.setApplicationMenu).toHaveBeenCalled()
     expect(registerAllHandlers).toHaveBeenCalled()
     expect(initRalphService).toHaveBeenCalled()
+  })
+
+  it('registers webview attach and popup guardrails', async () => {
+    await import('./main')
+    const { session } = await import('electron')
+
+    expect(whenReadyCb).not.toBeNull()
+    whenReadyCb!()
+    expect(session.fromPartition).toHaveBeenCalledWith('persist:browser')
+
+    const webContentsCreatedCb = appOnCalls.find(([e]) => e === 'web-contents-created')?.[1]
+    expect(webContentsCreatedCb).toBeDefined()
+
+    const webContentsListeners = new Map<string, (...args: unknown[]) => void>()
+    const setWindowOpenHandler = vi.fn()
+    webContentsCreatedCb!(
+      {},
+      {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          webContentsListeners.set(event, handler)
+        }),
+        setWindowOpenHandler,
+      }
+    )
+
+    expect(setWindowOpenHandler).toHaveBeenCalled()
+    expect(setWindowOpenHandler.mock.calls[0][0]({ url: 'https://example.com/popup' })).toEqual({
+      action: 'deny',
+    })
+
+    const attachHandler = webContentsListeners.get('will-attach-webview')
+    expect(attachHandler).toBeDefined()
+
+    const event = { preventDefault: vi.fn() }
+    const webPreferences = {
+      allowRunningInsecureContent: true,
+      contextIsolation: false,
+      nodeIntegration: true,
+      nodeIntegrationInSubFrames: true,
+      partition: 'persist:untrusted',
+      plugins: true,
+      preload: 'file:///tmp/preload.js',
+      preloadURL: 'file:///tmp/preload.js',
+      sandbox: false,
+      webSecurity: false,
+    }
+
+    attachHandler!(event, webPreferences, {
+      partition: 'persist:browser',
+      src: 'https://example.com',
+    })
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(webPreferences).toMatchObject({
+      allowRunningInsecureContent: false,
+      contextIsolation: true,
+      nodeIntegration: false,
+      nodeIntegrationInSubFrames: false,
+      partition: 'persist:browser',
+      plugins: false,
+      sandbox: true,
+      webSecurity: true,
+    })
+    expect('preload' in webPreferences).toBe(false)
+    expect('preloadURL' in webPreferences).toBe(false)
+  })
+
+  it('blocks webviews with unsafe source or partition', async () => {
+    await import('./main')
+
+    expect(whenReadyCb).not.toBeNull()
+    whenReadyCb!()
+
+    const webContentsCreatedCb = appOnCalls.find(([e]) => e === 'web-contents-created')?.[1]
+    expect(webContentsCreatedCb).toBeDefined()
+
+    const webContentsListeners = new Map<string, (...args: unknown[]) => void>()
+    webContentsCreatedCb!(
+      {},
+      {
+        on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+          webContentsListeners.set(event, handler)
+        }),
+        setWindowOpenHandler: vi.fn(),
+      }
+    )
+
+    const attachHandler = webContentsListeners.get('will-attach-webview')
+    expect(attachHandler).toBeDefined()
+
+    const unsafeSourceEvent = { preventDefault: vi.fn() }
+    attachHandler!(
+      unsafeSourceEvent,
+      {},
+      {
+        partition: 'persist:browser',
+        src: 'file:///etc/passwd',
+      }
+    )
+    expect(unsafeSourceEvent.preventDefault).toHaveBeenCalled()
+
+    const unsafePartitionEvent = { preventDefault: vi.fn() }
+    attachHandler!(
+      unsafePartitionEvent,
+      {},
+      {
+        partition: 'persist:other',
+        src: 'https://example.com',
+      }
+    )
+    expect(unsafePartitionEvent.preventDefault).toHaveBeenCalled()
+
+    const missingPartitionEvent = { preventDefault: vi.fn() }
+    attachHandler!(
+      missingPartitionEvent,
+      {},
+      {
+        src: 'https://example.com',
+      }
+    )
+    expect(missingPartitionEvent.preventDefault).toHaveBeenCalled()
+  })
+
+  it('denies browser webview permission prompts by default', async () => {
+    await import('./main')
+
+    expect(whenReadyCb).not.toBeNull()
+    whenReadyCb!()
+    expect(browserSessionPermissionHandler).toBeTypeOf('function')
+
+    const callback = vi.fn()
+    browserSessionPermissionHandler!({}, 'camera', callback)
+    expect(callback).toHaveBeenCalledWith(false)
   })
 
   it('window-all-closed handler calls app.quit on non-darwin', async () => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,12 @@
-import { app, BrowserWindow, Menu, screen } from 'electron'
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  screen,
+  session,
+  type WebContents,
+  type WebPreferences,
+} from 'electron'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import windowStateKeeper from 'electron-window-state'
@@ -12,6 +20,7 @@ import { runOfflineSync } from './workers/offlineSync'
 import { stopSharedClient } from './services/copilotClient'
 import { initRalphService, shutdownRalphService } from './services/ralphService'
 import { IPC_PUSH } from '../src/ipc/contracts'
+import { validateUrl } from '../src/utils/networkSecurity'
 import {
   resolveWindowBounds as resolveWindowBoundsPure,
   type DisplayInfo,
@@ -54,6 +63,68 @@ process.env.VITE_PUBLIC = VITE_DEV_SERVER_URL
   : RENDERER_DIST
 
 let win: BrowserWindow | null
+
+const BROWSER_WEBVIEW_PARTITION = 'persist:browser'
+
+type WebviewAttachParams = {
+  src?: string
+  partition?: string
+}
+
+type MutableWebviewPreferences = WebPreferences & {
+  preload?: string
+  preloadURL?: string
+}
+
+function isAllowedWebviewSource(src: string | undefined): boolean {
+  if (!src) return false
+  try {
+    validateUrl(src)
+    return true
+  } catch (_: unknown) {
+    return false
+  }
+}
+
+function hardenWebviewPreferences(webPreferences: MutableWebviewPreferences): void {
+  delete webPreferences.preload
+  delete webPreferences.preloadURL
+
+  Object.assign(webPreferences, {
+    allowRunningInsecureContent: false,
+    contextIsolation: true,
+    nodeIntegration: false,
+    nodeIntegrationInSubFrames: false,
+    partition: BROWSER_WEBVIEW_PARTITION,
+    plugins: false,
+    sandbox: true,
+    webSecurity: true,
+  })
+}
+
+function registerWebviewSecurityGuards(): void {
+  session
+    .fromPartition(BROWSER_WEBVIEW_PARTITION)
+    .setPermissionRequestHandler((_webContents, _permission, callback) => callback(false))
+
+  app.on('web-contents-created', (_event, contents: WebContents) => {
+    contents.setWindowOpenHandler(() => ({ action: 'deny' }))
+
+    contents.on('will-attach-webview', (event, webPreferences, params) => {
+      const attachParams = params as WebviewAttachParams
+
+      if (
+        attachParams.partition !== BROWSER_WEBVIEW_PARTITION ||
+        !isAllowedWebviewSource(attachParams.src)
+      ) {
+        event.preventDefault()
+        return
+      }
+
+      hardenWebviewPreferences(webPreferences as MutableWebviewPreferences)
+    })
+  })
+}
 
 function resolveWindowBounds(state: { x?: number; y?: number; width: number; height: number }): {
   x?: number
@@ -112,6 +183,7 @@ function createWindow() {
       preload: path.join(__dirname, 'preload.mjs'),
       contextIsolation: true,
       nodeIntegration: false,
+      // Required for the Bookmarks in-app browser. See docs/WEBVIEW-SECURITY.md.
       webviewTag: true,
       // Use isolated partition to prevent zoom level bleeding to other Electron apps
       partition: 'persist:buddy',
@@ -171,6 +243,8 @@ app.on('activate', () => {
 
 app.whenReady().then(() => {
   startupTimer.mark('app-ready')
+
+  registerWebviewSecurityGuards()
 
   // Initialize config manager and attempt migration from env vars
   configManager.migrateFromEnv()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.805",
+  "version": "0.1.806",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.804",
+  "version": "0.1.805",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/check-electron-security.ts
+++ b/scripts/check-electron-security.ts
@@ -148,6 +148,10 @@ const securityRules: SecurityRule[] = [
     message: 'setWindowOpenHandler should validate URLs before loading them into BrowserWindow',
     contextSize: 50,
     contextCheck: ctx => {
+      // A deny-all handler never loads the requested URL.
+      if (/setWindowOpenHandler\s*\(\s*\(\)\s*=>\s*\(\{\s*action:\s*['"]deny['"]/.test(ctx)) {
+        return false
+      }
       // Require that the handler either directly validates URLs or delegates
       // to guardedNavigate (which itself performs DNS validation).
       // The check requires guardedNavigate to co-exist with validateUrlWithDns
@@ -158,6 +162,15 @@ const securityRules: SecurityRule[] = [
     },
   },
 ]
+
+function hasDocumentedWebviewException(content: string): boolean {
+  return (
+    content.includes('docs/WEBVIEW-SECURITY.md') &&
+    content.includes('registerWebviewSecurityGuards') &&
+    content.includes('will-attach-webview') &&
+    content.includes('setPermissionRequestHandler')
+  )
+}
 
 /** Returns true when the line is a comment (single-line, block-continuation, or inline block). */
 function isCommentLine(line: string): boolean {
@@ -185,12 +198,14 @@ function checkFile(filePath: string): void {
   const content = readFileSync(filePath, 'utf-8')
   const lines = content.split('\n')
   const rel = relative(process.cwd(), filePath)
+  const documentedWebviewException = hasDocumentedWebviewException(content)
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]
     const lineNum = i + 1
 
     for (const rule of securityRules) {
+      if (rule.rule === 'no-webview-tag' && documentedWebviewException) continue
       if (!matchesRule(rule, line, lines, i)) continue
       findings.push({
         file: rel,
@@ -277,6 +292,9 @@ function checkBrowserWindowBlocks(filePath: string): void {
     const lineNum = content.slice(0, match.index).split('\n').length
 
     for (const setting of insecureSettings) {
+      if (setting.rule === 'no-webview-tag-multiline' && hasDocumentedWebviewException(content)) {
+        continue
+      }
       if (setting.pattern.test(block) && !isEntireBlockComment(block, setting.keyword)) {
         findings.push({
           file: rel,

--- a/scripts/check-electron-security.ts
+++ b/scripts/check-electron-security.ts
@@ -64,6 +64,11 @@ interface SecurityRule {
   contextCheck?: (context: string) => boolean
 }
 
+const windowOpenHandlerArgsPattern = String.raw`(?:\([^)]*\)|[$A-Z_a-z][$\w]*)`
+const denyAllWindowOpenHandlerPattern = new RegExp(
+  String.raw`setWindowOpenHandler\s*\(\s*${windowOpenHandlerArgsPattern}\s*=>\s*(?:\(\s*\{\s*action:\s*['"]deny['"]|\{\s*return\s*\{\s*action:\s*['"]deny['"])`
+)
+
 const securityRules: SecurityRule[] = [
   {
     pattern: /nodeIntegration\s*:\s*true/,
@@ -149,7 +154,7 @@ const securityRules: SecurityRule[] = [
     contextSize: 50,
     contextCheck: ctx => {
       // A deny-all handler never loads the requested URL.
-      if (/setWindowOpenHandler\s*\(\s*\(\)\s*=>\s*\(\{\s*action:\s*['"]deny['"]/.test(ctx)) {
+      if (denyAllWindowOpenHandlerPattern.test(ctx)) {
         return false
       }
       // Require that the handler either directly validates URLs or delegates


### PR DESCRIPTION
## Summary
- Retains the Bookmarks in-app browser webview because it is a documented product feature.
- Adds main-process webview guardrails for attach validation, explicit `persist:browser` partitioning, permission denial, popup denial, preload stripping, and hardened guest preferences.
- Documents the webview security contract and teaches `security:electron` to accept only the documented guardrail exception.

Closes #90

## Risk
High. This keeps `webviewTag` enabled, but narrows its allowed use to public http/https browser tabs in the `persist:browser` partition and blocks broader guest capabilities in the main process.

## Verification
- `bun run security:electron` -> exit 0, 0 high / 0 medium / 0 info findings
- `bunx eslint electron/main.ts electron/main.test.ts scripts/check-electron-security.ts --max-warnings 0` -> exit 0
- `bunx vitest run --config vitest.electron.config.ts electron/main.test.ts` -> exit 0, 7 passed
- `bunx vitest run src/components/BrowserTabView.test.tsx` -> exit 0, 32 passed
- `bun run test:electron` -> exit 0, 44 files / 854 tests passed
- `bun run typecheck` -> exit 0
- `bun run lint` -> exit 0
- `bunx markdownlint-cli2 docs/WEBVIEW-SECURITY.md` -> exit 0
- `bun run format:check` -> exit 0
- `git diff --check` -> exit 0

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Electron webview usage with security guards and permission denial
> - Adds `registerWebviewSecurityGuards()` in [electron/main.ts](https://github.com/HemSoft/hs-buddy/pull/104/files#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfd) that denies all permission requests from the `persist:browser` partition, blocks `window.open` popups, and rejects `will-attach-webview` events unless the partition is `persist:browser` and the `src` passes URL validation
> - Allowed webviews have preferences hardened via `hardenWebviewPreferences()`: Node integration, plugins, and insecure content are disabled; `contextIsolation`, `sandbox`, and `webSecurity` are enforced; preload scripts are stripped
> - Enables `webviewTag: true` on the main `BrowserWindow`, relying on the guards above rather than blocking the tag entirely
> - Updates [scripts/check-electron-security.ts](https://github.com/HemSoft/hs-buddy/pull/104/files#diff-43de95142c5a20a60fbb7e0b40e244943cfac416d90b2b0731bfc57a644b6005) to recognize deny-all `window.open` handlers as compliant and to skip `no-webview-tag` violations when the documented guardrail pattern is detected
> - Adds [docs/WEBVIEW-SECURITY.md](https://github.com/HemSoft/hs-buddy/pull/104/files#diff-4f569c33c0bba1e92434209f29573499460bb9569ee1ca9ec63fe5b135f21fed) documenting allowed partitions, URL sources, and verification steps
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 484b2cf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->