### PR TITLE
test: expand axe accessibility coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.807] - 2026-06-08
+
+### Changed
+
+- Expand axe accessibility coverage
+
 ## [0.1.806] - 2026-06-08
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.806",
+  "version": "0.1.807",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/dashboard/DashboardConfigDropdown.test.tsx
+++ b/src/components/dashboard/DashboardConfigDropdown.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { axe } from '../../test/axe-helper'
 import { DashboardConfigDropdown } from './DashboardConfigDropdown'
 
 vi.mock('lucide-react', () => ({
@@ -34,6 +35,16 @@ describe('DashboardConfigDropdown', () => {
     )
     expect(screen.getByTitle('Configure dashboard cards')).toBeInTheDocument()
     expect(screen.getByText('Customize')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations with the menu open', async () => {
+    const { container } = render(
+      <DashboardConfigDropdown cards={sampleCards} isVisible={isVisible} toggleCard={toggleCard} />
+    )
+    fireEvent.click(screen.getByTitle('Configure dashboard cards'))
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 
   it('menu is closed by default', () => {

--- a/src/components/settings/SettingsAdvanced.test.tsx
+++ b/src/components/settings/SettingsAdvanced.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react'
+import { axe } from '../../test/axe-helper'
 import { SettingsAdvanced } from './SettingsAdvanced'
 
 const { mockUseConfig } = vi.hoisted(() => ({
@@ -31,6 +32,13 @@ describe('SettingsAdvanced', () => {
   it('renders Advanced heading', () => {
     render(<SettingsAdvanced />)
     expect(screen.getByText('Advanced')).toBeTruthy()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<SettingsAdvanced />)
+    await screen.findByText('/path/to/config.json')
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 
   it('renders Configuration File section', () => {

--- a/src/components/sidebar/TerminalSidebar.css
+++ b/src/components/sidebar/TerminalSidebar.css
@@ -105,6 +105,20 @@
   flex-shrink: 0;
 }
 
+.terminal-sidebar-folder-main {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  text-align: left;
+}
+
 .terminal-sidebar-folder-add {
   margin-left: auto;
   background: none;

--- a/src/components/sidebar/TerminalSidebar.test.tsx
+++ b/src/components/sidebar/TerminalSidebar.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from '../../test/axe-helper'
 import { TerminalSidebar } from './TerminalSidebar'
 import type { TerminalTreeNode } from '../terminal-workspace/types'
 
@@ -64,6 +65,20 @@ describe('TerminalSidebar', () => {
     workspace.loaded = true
     rerender(<TerminalSidebar onItemSelect={onItemSelect} selectedItem={null} />)
     expect(screen.getByRole('button', { name: '+ New Project' })).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    workspace.nodes = [
+      folder('folder-1', 'Project 1', 1, '#4ec9b0'),
+      terminal('terminal-1', 'Shell', 'folder-1', 1),
+    ]
+
+    const { container } = render(
+      <TerminalSidebar onItemSelect={onItemSelect} selectedItem="terminal-workspace" />
+    )
+
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 
   it('adds projects and terminals', () => {

--- a/src/components/sidebar/TerminalSidebar.tsx
+++ b/src/components/sidebar/TerminalSidebar.tsx
@@ -133,19 +133,12 @@ function TerminalFolderRow({
   handleAddTerminal,
   ...editableProps
 }: TerminalFolderRowProps) {
+  const isEditing = editableProps.editingId === folder.id
+
   return (
-    // react-doctor-disable-next-line react-doctor/prefer-tag-over-role -- Folder rows contain disclosure/add controls and inline rename input, so a native button wrapper would be invalid.
     <div
       className={selectedClass('terminal-sidebar-folder-row', selected)}
       style={folderRowStyle(folder)}
-      onClick={() => handleSelectTerminal(folder.id)}
-      onDoubleClick={() => startEditing(folder.id, folder.name)}
-      onContextMenu={e => handleContextMenu(e, folder.id)}
-      role="button"
-      tabIndex={0}
-      onKeyDown={onKeyboardActivate(() => handleSelectTerminal(folder.id))}
-      aria-label={`Project: ${folder.name}`}
-      aria-expanded={expanded}
     >
       <button
         type="button"
@@ -163,7 +156,22 @@ function TerminalFolderRow({
       ) : (
         <Folder size={14} className="terminal-sidebar-folder-icon" />
       )}
-      <EditableNodeName node={folder} {...editableProps} />
+      {isEditing ? (
+        <EditableNodeName node={folder} {...editableProps} />
+      ) : (
+        <button
+          type="button"
+          className="terminal-sidebar-folder-main"
+          onClick={() => handleSelectTerminal(folder.id)}
+          onDoubleClick={() => startEditing(folder.id, folder.name)}
+          onContextMenu={e => handleContextMenu(e, folder.id)}
+          onKeyDown={onKeyboardActivate(() => handleSelectTerminal(folder.id))}
+          aria-label={`Project: ${folder.name}`}
+          aria-expanded={expanded}
+        >
+          <EditableNodeName node={folder} {...editableProps} />
+        </button>
+      )}
       <button
         type="button"
         className="terminal-sidebar-folder-add"

--- a/src/components/tempo/TempoDashboardHeader.test.tsx
+++ b/src/components/tempo/TempoDashboardHeader.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { fireEvent, render, screen } from '@testing-library/react'
+import { axe } from '../../test/axe-helper'
 import { TempoDashboardHeader } from './TempoDashboardHeader'
 
 vi.mock('lucide-react', () => ({
@@ -33,6 +34,12 @@ describe('TempoDashboardHeader', () => {
   it('renders the title', () => {
     render(<TempoDashboardHeader {...defaultProps} />)
     expect(screen.getByText('Tempo Tracking')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<TempoDashboardHeader {...defaultProps} />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 
   it('renders month label', () => {

--- a/src/components/tempo/TempoWorklogEditor.test.tsx
+++ b/src/components/tempo/TempoWorklogEditor.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vite
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import type { ComponentProps } from 'react'
 import type { TempoWorklog } from '../../types/tempo'
+import { axe } from '../../test/axe-helper'
 import { TempoWorklogEditor } from './TempoWorklogEditor'
 
 const getAccounts = vi.fn()
@@ -95,6 +96,15 @@ describe('TempoWorklogEditor', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Create' }))
 
     expect(screen.getByText('Issue key is required')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    const { container } = render(<TempoWorklogEditor {...buildEditorProps({})} />)
+    await waitFor(() => {
+      expect(screen.getByRole('option', { name: 'Operations (OPS)' })).toBeInTheDocument()
+    })
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 
   it('loads project accounts after the issue key debounce and auto-selects the default', async () => {

--- a/src/components/tempo/TempoWorklogEditor.tsx
+++ b/src/components/tempo/TempoWorklogEditor.tsx
@@ -334,6 +334,7 @@ export function TempoWorklogEditor({
             className="tempo-editor-close"
             onClick={onCancel}
             disabled={state.saving}
+            aria-label="Dismiss worklog editor"
           >
             <X size={16} />
           </button>

--- a/src/components/terminal/TerminalPane.test.tsx
+++ b/src/components/terminal/TerminalPane.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { axe } from '../../test/axe-helper'
 
 // Mock terminalSessions before importing the component
 vi.mock('./terminalSessions', () => ({
@@ -136,6 +137,13 @@ describe('TerminalPane', () => {
   it('renders the terminal pane container', () => {
     const { container } = render(<TerminalPane viewKey="test-key" />)
     expect(container.querySelector('.terminal-pane')).toBeInTheDocument()
+  })
+
+  it('has no accessibility violations', async () => {
+    vi.useRealTimers()
+    const { container } = render(<TerminalPane viewKey="test-key" />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
   })
 
   it('registers and unregisters terminal paste handler for the view', () => {


### PR DESCRIPTION
## Summary
- Adds axe coverage to six high-value UI suites: TerminalPane, SettingsAdvanced, TempoWorklogEditor, TempoDashboardHeader, DashboardConfigDropdown, and TerminalSidebar.
- Fixes violations surfaced by the new coverage by labeling the Tempo worklog close button and removing nested interactive semantics from TerminalSidebar project rows.
- Keeps the existing keyboard activation behavior for terminal project selection while making the selectable project label its own control.

Closes #91

## Risk
Medium. This changes interactive sidebar markup and a modal close button label; reviewers should verify keyboard and screen-reader behavior for terminal project rows and the Tempo worklog editor.

## Verification
- `bun run test:a11y` -> exit 0, 15 passed / 6400 skipped
- `bunx vitest run src/components/terminal/TerminalPane.test.tsx src/components/settings/SettingsAdvanced.test.tsx src/components/tempo/TempoWorklogEditor.test.tsx src/components/tempo/TempoDashboardHeader.test.tsx src/components/dashboard/DashboardConfigDropdown.test.tsx src/components/sidebar/TerminalSidebar.test.tsx` -> exit 0, 116 passed
- `bun run test` -> exit 0, 287 files / 6415 tests passed
- `bun run typecheck` -> exit 0
- `bun run lint` -> exit 0
- `bun run format:check` -> exit 0
- `git diff --check` -> exit 0

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Expand axe accessibility test coverage across sidebar, terminal, and dashboard components
> - Adds axe accessibility assertions to tests for `DashboardConfigDropdown`, `SettingsAdvanced`, `TerminalSidebar`, `TempoDashboardHeader`, `TempoWorklogEditor`, and `TerminalPane`.
> - Refactors `TerminalFolderRow` in [TerminalSidebar.tsx](https://github.com/HemSoft/hs-buddy/pull/109/files#diff-bad221cbdc1841efe59517b05c9e257b114baf4b42278578c1e6cb6e0dcfa935) to use a native `<button>` for the folder activation area instead of a `div` with interactive role, fixing an axe violation.
> - Adds `aria-label='Dismiss worklog editor'` to the close button in [TempoWorklogEditor.tsx](https://github.com/HemSoft/hs-buddy/pull/109/files#diff-70c43a9017d21284b10445788dc06198e7de83f1356fa4c70cd6d3939704d479) to give it an accessible name.
> - Behavioral Change: the folder row outer container is no longer focusable; keyboard and click interactions now route through the inner button element.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 56be594.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->