### PR TITLE
docs: fix markdown fence language

### DIFF
--- a/.sfl/governance/policy.md
+++ b/.sfl/governance/policy.md
@@ -63,7 +63,7 @@ All agent-generated issues and PRs must carry exactly **one** agent lifecycle la
 
 ### Label lifecycle state machine
 
-```
+```text
 # Report issue (no automation ever touches this)
 [report created] → type:report  (permanent — no further transitions)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.809] - 2026-06-11
+
+### Changed
+
+- Fix markdown fence language
+
 ## [0.1.808] - 2026-06-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.808",
+  "version": "0.1.809",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Fixes #92
- Marks the label lifecycle state-machine fence in .sfl/governance/policy.md as 	ext.
- Keeps the policy content unchanged and limits the manual docs change to the failing MD040 fence.

## Verification
- un run lint:md -> 0 errors
- un run lint -> passed
- un run typecheck -> passed
- un run test -> 287 files / 6415 tests passed
- commit hook un run test:coverage -> 287 files / 6415 tests passed, coverage thresholds satisfied

## Notes
- Repo hooks intentionally bumped package.json to 

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix markdown fence language identifier in policy.md
> Adds the `text` language identifier to a bare triple-backtick code fence in [policy.md](.sfl/governance/policy.md). Also bumps the package version to 0.1.809 and records the change in CHANGELOG.md.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4bdf157.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->