### PR TITLE
fix: stabilize Aspire debug startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.810] - 2026-06-11
+
+### Fixed
+
+- Stabilize Aspire debug startup
+
 ## [0.1.809] - 2026-06-11
 
 ### Changed

--- a/apphost.ts
+++ b/apphost.ts
@@ -11,11 +11,15 @@ import 'vscode-jsonrpc'
 const builder = await createBuilder()
 
 // Convex local dev server (backend on port 3210, dashboard on 6790)
-const convex = await builder.addJavaScriptApp('convex', '.').withNpm().withRunScript('convex:dev')
+const convex = await builder
+  .addJavaScriptApp('convex', '.')
+  .withBun({ install: false })
+  .withRunScript('convex:dev')
 
 // Vite dev server + Electron (vite-plugin-electron handles Electron launch)
 await builder
   .addViteApp('buddy', '.')
+  .withBun({ install: false })
   .withReference(convex)
   .waitFor(convex)
   .withExternalHttpEndpoints()

--- a/aspire.config.json
+++ b/aspire.config.json
@@ -4,7 +4,7 @@
     "language": "typescript/nodejs"
   },
   "sdk": {
-    "version": "13.2.2"
+    "version": "13.5.0-preview.1.26310.3"
   },
   "channel": "daily",
   "profiles": {
@@ -17,6 +17,6 @@
     }
   },
   "packages": {
-    "Aspire.Hosting.JavaScript": "13.2.2"
+    "Aspire.Hosting.JavaScript": "13.5.0-preview.1.26310.3"
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -50,6 +50,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
+        "@types/node": "^22",
         "@types/react": "^19.2.3",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -730,7 +731,7 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
-    "@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+    "@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@types/plist": ["@types/plist@3.0.5", "", { "dependencies": { "@types/node": "*", "xmlbuilder": ">=11.0.1" } }, "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA=="],
 
@@ -2442,7 +2443,7 @@
 
     "undici": ["undici@7.25.0", "", {}, "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "unicorn-magic": ["unicorn-magic@0.4.0", "", {}, "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw=="],
 
@@ -2660,6 +2661,20 @@
 
     "@tybys/wasm-util/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@types/cacheable-request/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/fs-extra/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/keyv/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/plist/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/responselike/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/ws/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
+    "@types/yauzl/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.59.2", "", { "dependencies": { "@typescript-eslint/types": "8.59.2", "@typescript-eslint/visitor-keys": "8.59.2" } }, "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.59.2", "", { "dependencies": { "@typescript-eslint/types": "8.59.2", "@typescript-eslint/typescript-estree": "8.59.2", "@typescript-eslint/utils": "8.59.2", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ=="],
@@ -2704,6 +2719,8 @@
 
     "chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "chrome-launcher/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
+
     "chrome-launcher/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "chromium-bidi/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -2737,6 +2754,8 @@
     "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "dir-compare/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "electron/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "electron-builder/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -2785,6 +2804,8 @@
     "fs-extra/jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
 
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
+    "happy-dom/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "hosted-git-info/lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
@@ -2864,9 +2885,9 @@
 
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
-    "png-to-ico/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
-
     "postject/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
+
+    "protobufjs/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "puppeteer-core/devtools-protocol": ["devtools-protocol@0.0.1608973", "", {}, "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ=="],
 
@@ -2891,6 +2912,8 @@
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "speedline-core/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
@@ -2982,6 +3005,20 @@
 
     "@puppeteer/browsers/yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "@types/cacheable-request/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/fs-extra/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/keyv/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/plist/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/responselike/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/ws/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "@types/yauzl/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "@typescript-eslint/eslint-plugin/@typescript-eslint/scope-manager/@typescript-eslint/types": ["@typescript-eslint/types@8.59.2", "", {}, "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q=="],
 
     "@typescript-eslint/eslint-plugin/@typescript-eslint/type-utils/@typescript-eslint/types": ["@typescript-eslint/types@8.59.2", "", {}, "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q=="],
@@ -3001,6 +3038,8 @@
     "app-builder-lib/@electron/get/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "body-parser/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "chrome-launcher/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
@@ -3078,6 +3117,8 @@
 
     "electron-winstaller/fs-extra/universalify": ["universalify@0.1.2", "", {}, "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="],
 
+    "electron/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "eslint-plugin-jsx-a11y/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
     "eslint-plugin-react-dom/@typescript-eslint/utils/@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.59.4", "", { "dependencies": { "@typescript-eslint/project-service": "8.59.4", "@typescript-eslint/tsconfig-utils": "8.59.4", "@typescript-eslint/types": "8.59.4", "@typescript-eslint/visitor-keys": "8.59.4", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag=="],
@@ -3104,6 +3145,8 @@
 
     "glob/minimatch/brace-expansion": ["brace-expansion@1.1.14", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g=="],
 
+    "happy-dom/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
     "hosted-git-info/lru-cache/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "iconv-corefoundation/cli-truncate/slice-ansi": ["slice-ansi@3.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "astral-regex": "^2.0.0", "is-fullwidth-code-point": "^3.0.0" } }, "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ=="],
@@ -3119,6 +3162,8 @@
     "inquirer/string-width/strip-ansi": ["strip-ansi@4.0.0", "", { "dependencies": { "ansi-regex": "^3.0.0" } }, "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow=="],
 
     "lighthouse-logger/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "lighthouse/chrome-launcher/@types/node": ["@types/node@24.12.2", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g=="],
 
     "lighthouse/yargs/cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -3144,9 +3189,11 @@
 
     "ora/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "png-to-ico/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "protobufjs/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "send/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
+
+    "speedline-core/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
@@ -3289,6 +3336,8 @@
     "inquirer/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
 
     "inquirer/string-width/strip-ansi/ansi-regex": ["ansi-regex@3.0.1", "", {}, "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw=="],
+
+    "lighthouse/chrome-launcher/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "lighthouse/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,2 @@
+[install]
+linker = "isolated"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.809",
+  "version": "0.1.810",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",
@@ -109,6 +109,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/node": "^22",
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",

--- a/scripts/runAspire.debug.ps1
+++ b/scripts/runAspire.debug.ps1
@@ -16,6 +16,9 @@ param(
 
 . "$PSScriptRoot/lib/PortUtils.ps1"
 
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$exitCode = 0
+
 $InformationPreference = 'Continue'
 $esc = [char]27
 $Cyan = "${esc}[36m"
@@ -23,6 +26,9 @@ $DGray = "${esc}[90m"
 $Red = "${esc}[31m"
 $Yellow = "${esc}[33m"
 $Reset = "${esc}[0m"
+
+Push-Location $repoRoot
+try {
 
 # -- Preflight: Aspire CLI --
 Initialize-DotnetRoot
@@ -67,11 +73,21 @@ if ($portInUse) {
 
 # -- Set debug environment and launch via Aspire --
 $env:BUDDY_DEBUG_PORT = $Port
+if (-not $env:ASPIRE_CLI_START_TIMEOUT) {
+    $env:ASPIRE_CLI_START_TIMEOUT = '300'
+}
 
 Write-Information ""
 Write-Information "${Cyan}Starting hs-buddy with Aspire orchestration (DEBUG mode)${Reset}"
+Write-Information "${DGray}  AppHost timeout: $($env:ASPIRE_CLI_START_TIMEOUT)s${Reset}"
 Write-Information "${DGray}  CDP port:   http://127.0.0.1:$Port${Reset}"
 Write-Information "${DGray}  Connect:    npx -y chrome-devtools-mcp@latest --browserUrl http://127.0.0.1:$Port${Reset}"
 Write-Information ""
 
 & $aspireCmd run
+$exitCode = $LASTEXITCODE
+} finally {
+    Pop-Location
+}
+
+exit $exitCode

--- a/src/utils/cronUtils.test.ts
+++ b/src/utils/cronUtils.test.ts
@@ -60,6 +60,19 @@ describe('enumerateCronOccurrences', () => {
     expect(result).toEqual([])
   })
 
+  it('supports common predefined expressions', () => {
+    const from = new Date('2025-01-01T00:00:00Z').getTime()
+    const to = new Date('2025-01-01T03:00:00Z').getTime()
+    const result = enumerateCronOccurrences('@hourly', 'UTC', from, to)
+
+    expect(result).toEqual([
+      new Date('2025-01-01T00:00:00Z').getTime(),
+      new Date('2025-01-01T01:00:00Z').getTime(),
+      new Date('2025-01-01T02:00:00Z').getTime(),
+      new Date('2025-01-01T03:00:00Z').getTime(),
+    ])
+  })
+
   it('supports timezone parameter', () => {
     // Daily at midnight: "0 0 * * *"
     const from = new Date('2025-06-01T00:00:00-04:00').getTime()
@@ -108,5 +121,9 @@ describe('validateCronExpression', () => {
 
   it('accepts cron without timezone parameter', () => {
     expect(() => validateCronExpression('*/5 * * * *')).not.toThrow()
+  })
+
+  it('accepts common predefined expressions', () => {
+    expect(() => validateCronExpression('@daily')).not.toThrow()
   })
 })

--- a/src/utils/cronUtils.ts
+++ b/src/utils/cronUtils.ts
@@ -1,62 +1,269 @@
 /**
- * Cron enumeration helpers — pure functions extracted from electron/workers/offlineSync.ts.
+ * Browser-safe cron enumeration helpers for schedule previews.
  */
 
-import { CronExpressionParser, type CronExpressionOptions } from 'cron-parser'
+const MS_PER_MINUTE = 60_000
+
+const MONTH_ALIASES: Record<string, number> = {
+  jan: 1,
+  feb: 2,
+  mar: 3,
+  apr: 4,
+  may: 5,
+  jun: 6,
+  jul: 7,
+  aug: 8,
+  sep: 9,
+  oct: 10,
+  nov: 11,
+  dec: 12,
+}
+
+const WEEKDAY_ALIASES: Record<string, number> = {
+  sun: 0,
+  mon: 1,
+  tue: 2,
+  wed: 3,
+  thu: 4,
+  fri: 5,
+  sat: 6,
+}
+
+const PREDEFINED_EXPRESSIONS: Record<string, string> = {
+  '@yearly': '0 0 1 1 *',
+  '@annually': '0 0 1 1 *',
+  '@monthly': '0 0 1 * *',
+  '@weekly': '0 0 * * 0',
+  '@daily': '0 0 * * *',
+  '@hourly': '0 * * * *',
+  '@minutely': '* * * * *',
+  '@weekdays': '0 0 * * 1-5',
+  '@weekends': '0 0 * * 0,6',
+}
+
+interface CronField {
+  values: Set<number>
+  wildcard: boolean
+}
+
+interface ParsedCron {
+  minute: CronField
+  hour: CronField
+  dayOfMonth: CronField
+  month: CronField
+  dayOfWeek: CronField
+}
+
+interface TimeParts {
+  minute: number
+  hour: number
+  dayOfMonth: number
+  month: number
+  dayOfWeek: number
+}
+
+function numberRange(start: number, end: number): number[] {
+  return Array.from({ length: end - start + 1 }, (_, index) => start + index)
+}
+
+function parseValue(
+  rawValue: string,
+  min: number,
+  max: number,
+  aliases?: Record<string, number>
+): number | null {
+  const normalized = rawValue.toLowerCase()
+  const aliasValue = aliases?.[normalized.slice(0, 3)]
+  if (aliasValue !== undefined) return aliasValue
+
+  if (!/^\d+$/.test(rawValue)) return null
+
+  const parsed = Number.parseInt(rawValue, 10)
+  return parsed >= min && parsed <= max ? parsed : null
+}
+
+function parseSegment(
+  segment: string,
+  min: number,
+  max: number,
+  aliases?: Record<string, number>,
+  wildcardMax = max
+): number[] | null {
+  const [rangePart, stepPart, extraPart] = segment.split('/')
+  if (extraPart !== undefined) return null
+
+  const step = stepPart === undefined ? 1 : Number.parseInt(stepPart, 10)
+  if (!Number.isInteger(step) || step < 1 || stepPart === '') return null
+
+  const rangeValues =
+    rangePart === '*' || rangePart === '?'
+      ? numberRange(min, wildcardMax)
+      : parseExplicitRange(rangePart, min, max, aliases)
+
+  if (!rangeValues) return null
+
+  return rangeValues.filter((_value, index) => index % step === 0)
+}
+
+function parseExplicitRange(
+  rangePart: string,
+  min: number,
+  max: number,
+  aliases?: Record<string, number>
+): number[] | null {
+  const [startRaw, endRaw, extraPart] = rangePart.split('-')
+  if (extraPart !== undefined) return null
+
+  const start = parseValue(startRaw, min, max, aliases)
+  if (start === null) return null
+
+  if (endRaw === undefined) return [start]
+
+  const end = parseValue(endRaw, min, max, aliases)
+  if (end === null || start > end) return null
+
+  return numberRange(start, end)
+}
+
+function parseField(
+  rawField: string,
+  min: number,
+  max: number,
+  aliases?: Record<string, number>,
+  normalizeValue: (value: number) => number = value => value,
+  wildcardMax = max
+): CronField | null {
+  if (!rawField) return null
+
+  const values = new Set<number>()
+  const wildcard = rawField === '*' || rawField === '?'
+
+  for (const segment of rawField.split(',')) {
+    if (segment === '') return null
+
+    const segmentValues = parseSegment(segment, min, max, aliases, wildcardMax)
+    if (!segmentValues) return null
+
+    for (const value of segmentValues) values.add(normalizeValue(value))
+  }
+
+  return values.size > 0 ? { values, wildcard } : null
+}
+
+function parseCronExpression(cronExpression: string): ParsedCron | null {
+  const expression = PREDEFINED_EXPRESSIONS[cronExpression.trim().toLowerCase()] ?? cronExpression
+  const parts = expression.trim().split(/\s+/)
+  if (parts.length !== 5) return null
+
+  const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
+  const parsed = {
+    minute: parseField(minute, 0, 59),
+    hour: parseField(hour, 0, 23),
+    dayOfMonth: parseField(dayOfMonth, 1, 31),
+    month: parseField(month, 1, 12, MONTH_ALIASES),
+    dayOfWeek: parseField(dayOfWeek, 0, 7, WEEKDAY_ALIASES, value => (value === 7 ? 0 : value), 6),
+  }
+
+  if (!parsed.minute || !parsed.hour || !parsed.dayOfMonth || !parsed.month || !parsed.dayOfWeek) {
+    return null
+  }
+
+  return parsed as ParsedCron
+}
+
+function getTimezoneFormatter(timezone: string): Intl.DateTimeFormat {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: timezone,
+    month: 'numeric',
+    day: 'numeric',
+    weekday: 'short',
+    hour: 'numeric',
+    minute: 'numeric',
+    hourCycle: 'h23',
+  })
+}
+
+function getTimezoneParts(date: Date, timezone: string): TimeParts {
+  const formatter = getTimezoneFormatter(timezone)
+  const parts = Object.fromEntries(
+    formatter.formatToParts(date).map(part => [part.type, part.value])
+  )
+  const weekday = WEEKDAY_ALIASES[parts.weekday.toLowerCase().slice(0, 3)]
+
+  return {
+    minute: Number.parseInt(parts.minute, 10),
+    hour: Number.parseInt(parts.hour, 10) % 24,
+    dayOfMonth: Number.parseInt(parts.day, 10),
+    month: Number.parseInt(parts.month, 10),
+    dayOfWeek: weekday,
+  }
+}
+
+function getLocalParts(date: Date): TimeParts {
+  return {
+    minute: date.getMinutes(),
+    hour: date.getHours(),
+    dayOfMonth: date.getDate(),
+    month: date.getMonth() + 1,
+    dayOfWeek: date.getDay(),
+  }
+}
+
+function getTimeParts(date: Date, timezone: string): TimeParts {
+  return timezone ? getTimezoneParts(date, timezone) : getLocalParts(date)
+}
+
+function fieldMatches(field: CronField, value: number): boolean {
+  return field.values.has(value)
+}
+
+function dayMatches(parsed: ParsedCron, parts: TimeParts): boolean {
+  const dayOfMonthMatches = fieldMatches(parsed.dayOfMonth, parts.dayOfMonth)
+  const dayOfWeekMatches = fieldMatches(parsed.dayOfWeek, parts.dayOfWeek)
+
+  if (!parsed.dayOfMonth.wildcard && !parsed.dayOfWeek.wildcard) {
+    return dayOfMonthMatches || dayOfWeekMatches
+  }
+
+  return dayOfMonthMatches && dayOfWeekMatches
+}
+
+function matchesCron(parsed: ParsedCron, date: Date, timezone: string): boolean {
+  const parts = getTimeParts(date, timezone)
+
+  return (
+    fieldMatches(parsed.minute, parts.minute) &&
+    fieldMatches(parsed.hour, parts.hour) &&
+    fieldMatches(parsed.month, parts.month) &&
+    dayMatches(parsed, parts)
+  )
+}
+
+function firstCandidateTimestamp(fromTimestamp: number, includeStart: boolean): number {
+  if (includeStart) {
+    return Math.ceil(fromTimestamp / MS_PER_MINUTE) * MS_PER_MINUTE
+  }
+
+  return Math.floor(fromTimestamp / MS_PER_MINUTE) * MS_PER_MINUTE + MS_PER_MINUTE
+}
 
 /**
- * Validate a cron expression (and optional timezone).
- * Throws if the expression cannot be parsed — use this when callers need to
- * distinguish "invalid input" from "no occurrences in range".
+ * Validate a cron expression and optional timezone.
+ * Throws when the expression or timezone cannot be parsed.
  */
 export function validateCronExpression(cronExpression: string, timezone?: string): void {
-  const options: CronExpressionOptions = {}
-  if (timezone) options.tz = timezone
-  CronExpressionParser.parse(cronExpression, options)
-}
-
-/** Collect up to `maxRuns` timestamps from a parsed cron expression, stopping at `toTimestamp`. */
-function collectOccurrences(
-  expression: ReturnType<typeof CronExpressionParser.parse>,
-  toTimestamp: number,
-  maxRuns: number
-): number[] {
-  const results: number[] = []
-  while (results.length < maxRuns) {
-    try {
-      const next = expression.next()
-      /* v8 ignore start — endDate prevents this; belt-and-suspenders guard */
-      if (next.getTime() > toTimestamp) break
-      /* v8 ignore stop */
-      results.push(next.getTime())
-    } catch (_: unknown) {
-      break
-    }
+  if (!parseCronExpression(cronExpression)) {
+    throw new Error(`Invalid cron expression: ${cronExpression}`)
   }
-  return results
-}
 
-function buildCronOptions(
-  fromTimestamp: number,
-  toTimestamp: number,
-  timezone: string,
-  includeStart: boolean
-): CronExpressionOptions {
-  const options: CronExpressionOptions = {
-    currentDate: new Date(includeStart ? fromTimestamp - 1 : fromTimestamp),
-    endDate: new Date(toTimestamp),
+  if (timezone) {
+    getTimezoneFormatter(timezone)
   }
-  if (timezone) options.tz = timezone
-  return options
 }
 
 /**
  * Enumerate cron occurrences between two timestamps.
  * Returns timestamps for each occurrence, capped at maxRuns.
- *
- * By default, the start boundary is inclusive: if an occurrence lands exactly
- * on fromTimestamp, it is included in the result set. Pass includeStart = false
- * to preserve strict "after fromTimestamp" semantics.
  */
 export function enumerateCronOccurrences(
   cronExpression: string,
@@ -66,12 +273,24 @@ export function enumerateCronOccurrences(
   maxRuns = 100,
   includeStart = true
 ): number[] {
-  if (fromTimestamp >= toTimestamp) return []
+  if (fromTimestamp >= toTimestamp || maxRuns <= 0) return []
 
   try {
-    const options = buildCronOptions(fromTimestamp, toTimestamp, timezone, includeStart)
-    const expression = CronExpressionParser.parse(cronExpression, options)
-    return collectOccurrences(expression, toTimestamp, maxRuns)
+    const parsed = parseCronExpression(cronExpression)
+    if (!parsed) return []
+
+    const results: number[] = []
+    for (
+      let timestamp = firstCandidateTimestamp(fromTimestamp, includeStart);
+      timestamp <= toTimestamp && results.length < maxRuns;
+      timestamp += MS_PER_MINUTE
+    ) {
+      if (matchesCron(parsed, new Date(timestamp), timezone)) {
+        results.push(timestamp)
+      }
+    }
+
+    return results
   } catch (_: unknown) {
     return []
   }


### PR DESCRIPTION
## Summary
- Stabilizes Aspire debug startup after the local blank-window/startup investigation.
- Runs Aspire apphost commands from the repo root and gives AppHost a 300s default startup timeout.
- Uses Bun resources with install disabled in pphost.ts to avoid redundant npm install work under Aspire.
- Adds unfig.toml with isolated linker mode and keeps cron preview parsing browser-safe.

## Verification
- un run lint:md -> passed
- un run lint -> passed
- un run typecheck -> passed
- un test src/utils/cronUtils.test.ts -> 17 passed
- commit hook itest run --coverage -> 287 files / 6417 tests passed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Aspire debug startup stability by correcting working directory and timeout handling
> - [runAspire.debug.ps1](https://github.com/HemSoft/hs-buddy/pull/164/files#diff-62b4a54ac24e4158cbeac0e1784a268e455ebc34097a732dae5a0b7fcc891b5c) now resolves and sets the working directory to the repo root, sets a default `ASPIRE_CLI_START_TIMEOUT` of 300s, and propagates the Aspire process exit code.
> - [apphost.ts](https://github.com/HemSoft/hs-buddy/pull/164/files#diff-a69073a03981210742cd96e06cfc94504656f91fc0a42f95d4a0e3bb40627780) switches the `convex` and `buddy` app registrations to use Bun with install disabled.
> - Replaces `cron-parser` in [cronUtils.ts](https://github.com/HemSoft/hs-buddy/pull/164/files#diff-f453218c64c7f046574963d532031a368e7da1539d91f7a193da8a95e7233fc0) with a custom browser-safe implementation supporting predefined expressions (`@hourly`, `@daily`) and timezone evaluation via `Intl.DateTimeFormat`.
> - [bunfig.toml](https://github.com/HemSoft/hs-buddy/pull/164/files#diff-d20a1d3c8f2bd65984a8a4aa51992df69e00dc2d9af53508fab7a080ad526e58) sets Bun's linker to `isolated` mode.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3830d8b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->