### PR TITLE
fix: reduce moderate CRAP backlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.820] - 2026-06-13
+
+### Fixed
+
+- Reduce moderate CRAP backlog
+
 ## [0.1.819] - 2026-06-13
 
 ### Changed

--- a/docs/crap-score-log.md
+++ b/docs/crap-score-log.md
@@ -1,3 +1,41 @@
+## 2026-06-13 — CRAP Score Snapshot (TypeScript)
+
+| Metric | Value |
+|--------|-------|
+| Methods Analyzed | 2,659 (src/) |
+| Methods > 30 (Critical) | 0 |
+| Methods 16–30 (High) | 0 |
+| Methods 6–15 (Moderate) | 62 |
+| Methods >= 10 (Repo Threshold) | 0 |
+| Highest CRAP | 7.0 (multiple fully covered complexity-only functions) |
+| Overall Coverage | 99.90% lines / 99.35% branches / 99.97% functions / 99.82% statements |
+
+**Critical Methods (CRAP > 30):** None — repo passes Gold scorecard rule.
+
+**Threshold Rationale:**
+
+- Issue #94 allowed documenting why a repo threshold of 10 is more appropriate than 6 for fully covered complexity-only functions.
+- After this pass, the worst CRAP score is 7.0 and every function at the top of the report is at or near full branch coverage, so the remaining score is driven by modest cyclomatic complexity rather than poor tests.
+- `crap-report.ps1 -Threshold 10 -Top 20 -Format json -Stack ts -SkipCoverage` exits 0 with 0 findings.
+- Keep using threshold 6 for discovery, but treat threshold 10 as the actionable repo threshold unless coverage drops or CRAP exceeds 10.
+
+**Improvements This Session:**
+
+- `src/utils/cronUtils.ts` :: `enumerateCronOccurrences`, `parseSegment`, and `parseField`: CRAP 11.6 -> below threshold (split parsing/enumeration helpers and added malformed cron parser coverage)
+- `src/utils/copilotEnterpriseUsers.ts` :: `totalsFromUsageItems`: CRAP 9.3 -> below threshold (extracted usage item accumulation helpers)
+- `src/hooks/useCopilotUsage.ts` :: `computeAggregateSpend`: CRAP 9.0 -> below threshold (extracted dollar-spend eligibility and projection helpers)
+- `src/components/copilot-usage/TopUsersSection.tsx` :: `EnterpriseUsersContent` and `TopUsersSection`: CRAP 8.4/7.3 -> below threshold (split render states into focused components)
+- `src/hooks/useCopilotEnterpriseUsers.ts` :: `load`: CRAP 7.6 -> below threshold (extracted result-to-state conversion helpers)
+- `src/utils/copilotEnterpriseUsers.ts` :: `directTotalsFromRecord`: CRAP 7.2 -> below threshold (reused model quantity accumulation helpers)
+
+**Session Notes:**
+
+- Fresh coverage was generated with `bun run test:coverage -- --reporter=dot --silent`.
+- Fresh CRAP reports were generated with `crap-report.ps1 -Threshold 6` and `-Threshold 10` using the refreshed coverage summary.
+- The threshold-6 report still has 62 moderate findings; the threshold-10 report has 0 findings and worst CRAP 7.0.
+
+---
+
 ## 2026-06-07 — CRAP Score Snapshot (TypeScript)
 
 | Metric | Value |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.819",
+  "version": "0.1.820",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/copilot-usage/TopUsersSection.tsx
+++ b/src/components/copilot-usage/TopUsersSection.tsx
@@ -148,18 +148,37 @@ function EnterpriseUsersContent({
   filteredUsers,
   onSelectUser,
 }: EnterpriseUsersContentProps) {
-  if (data && filteredUsers.length > 0)
-    return <EnterpriseUsersTable users={filteredUsers} onSelectUser={onSelectUser} />
-  if (data && data.users.length > 0)
-    return <div className="enterprise-users-message">No users match this filter.</div>
+  if (data)
+    return (
+      <EnterpriseUsersDataContent
+        data={data}
+        filteredUsers={filteredUsers}
+        onSelectUser={onSelectUser}
+      />
+    )
   if (loading)
     return <div className="enterprise-users-message">Loading Copilot Enterprise users...</div>
   if (error)
     return <div className="enterprise-users-message enterprise-users-message-error">{error}</div>
-  if (data)
-    return <div className="enterprise-users-message">No Copilot Enterprise users found.</div>
 
   return null
+}
+
+function EnterpriseUsersDataContent({
+  data,
+  filteredUsers,
+  onSelectUser,
+}: {
+  data: CopilotEnterpriseUsersSnapshot
+  filteredUsers: CopilotEnterpriseUser[]
+  onSelectUser: (user: CopilotEnterpriseUser) => void
+}) {
+  if (filteredUsers.length > 0)
+    return <EnterpriseUsersTable users={filteredUsers} onSelectUser={onSelectUser} />
+  if (data.users.length > 0)
+    return <div className="enterprise-users-message">No users match this filter.</div>
+
+  return <div className="enterprise-users-message">No Copilot Enterprise users found.</div>
 }
 
 const FOCUSABLE_MODAL_SELECTOR =
@@ -176,6 +195,22 @@ function focusFirstModalElement(container: HTMLElement): void {
   ;(firstFocusableElement ?? container).focus()
 }
 
+function shouldWrapFocusBackward(
+  event: KeyboardEvent<HTMLDialogElement>,
+  activeElement: Element | null,
+  firstFocusableElement: HTMLElement
+): boolean {
+  return event.shiftKey && activeElement === firstFocusableElement
+}
+
+function shouldWrapFocusForward(
+  event: KeyboardEvent<HTMLDialogElement>,
+  activeElement: Element | null,
+  lastFocusableElement: HTMLElement
+): boolean {
+  return !event.shiftKey && activeElement === lastFocusableElement
+}
+
 function handleModalTabKey(event: KeyboardEvent<HTMLDialogElement>): void {
   const focusableElements = getFocusableModalElements(event.currentTarget)
   if (focusableElements.length === 0) {
@@ -188,10 +223,10 @@ function handleModalTabKey(event: KeyboardEvent<HTMLDialogElement>): void {
   const lastFocusableElement = focusableElements[focusableElements.length - 1]
   const activeElement = document.activeElement
 
-  if (event.shiftKey && activeElement === firstFocusableElement) {
+  if (shouldWrapFocusBackward(event, activeElement, firstFocusableElement)) {
     event.preventDefault()
     lastFocusableElement.focus()
-  } else if (!event.shiftKey && activeElement === lastFocusableElement) {
+  } else if (shouldWrapFocusForward(event, activeElement, lastFocusableElement)) {
     event.preventDefault()
     firstFocusableElement.focus()
   }
@@ -272,16 +307,86 @@ interface TopUsersSectionProps {
   refreshToken?: number
 }
 
+function getFilteredUsers(
+  data: CopilotEnterpriseUsersSnapshot | null,
+  filterText: string
+): CopilotEnterpriseUser[] {
+  if (!data) return []
+
+  return filterUsers(data.users, filterText)
+}
+
+function EnterpriseUsersControls({
+  data,
+  filterText,
+  visibleUsers,
+  onFilterChange,
+}: {
+  data: CopilotEnterpriseUsersSnapshot | null
+  filterText: string
+  visibleUsers: number
+  onFilterChange: (value: string) => void
+}) {
+  if (!data) return null
+
+  return (
+    <>
+      <SnapshotMeta snapshot={data} />
+      <EnterpriseUsersFilterPanel
+        data={data}
+        filterText={filterText}
+        visibleUsers={visibleUsers}
+        onFilterChange={onFilterChange}
+      />
+    </>
+  )
+}
+
+function EnterpriseUsersFilterPanel({
+  data,
+  filterText,
+  visibleUsers,
+  onFilterChange,
+}: {
+  data: CopilotEnterpriseUsersSnapshot
+  filterText: string
+  visibleUsers: number
+  onFilterChange: (value: string) => void
+}) {
+  if (data.users.length === 0) return null
+
+  return (
+    <EnterpriseUsersFilter
+      value={filterText}
+      totalUsers={data.users.length}
+      visibleUsers={visibleUsers}
+      onChange={onFilterChange}
+    />
+  )
+}
+
+function SelectedUserSourceModal({
+  data,
+  selectedUser,
+  onClose,
+}: {
+  data: CopilotEnterpriseUsersSnapshot | null
+  selectedUser: CopilotEnterpriseUser | null
+  onClose: () => void
+}) {
+  if (!selectedUser || !data) return null
+
+  return <SourceJsonModal user={selectedUser} sourceFile={data.sourceFile} onClose={onClose} />
+}
+
 export function TopUsersSection({ refreshToken = 0 }: TopUsersSectionProps) {
   const enterpriseUsers = useCopilotEnterpriseUsers(refreshToken)
   const { data } = enterpriseUsers
   const [filterText, setFilterText] = useState('')
   const [selectedUser, setSelectedUser] = useState<CopilotEnterpriseUser | null>(null)
-  const filteredUsers = useMemo(
-    () => (data ? filterUsers(data.users, filterText) : []),
-    [data, filterText]
-  )
+  const filteredUsers = useMemo(() => getFilteredUsers(data, filterText), [data, filterText])
   const visibleUsers = filteredUsers.length
+  const closeSourceModal = () => setSelectedUser(null)
 
   return (
     <div className="top-users-section">
@@ -289,27 +394,18 @@ export function TopUsersSection({ refreshToken = 0 }: TopUsersSectionProps) {
         <Users size={14} />
         Copilot Enterprise Users
       </h3>
-      {data ? <SnapshotMeta snapshot={data} /> : null}
-      {data && data.users.length > 0 ? (
-        <EnterpriseUsersFilter
-          value={filterText}
-          totalUsers={data.users.length}
-          visibleUsers={visibleUsers}
-          onChange={setFilterText}
-        />
-      ) : null}
+      <EnterpriseUsersControls
+        data={data}
+        filterText={filterText}
+        visibleUsers={visibleUsers}
+        onFilterChange={setFilterText}
+      />
       <EnterpriseUsersContent
         {...enterpriseUsers}
         filteredUsers={filteredUsers}
         onSelectUser={setSelectedUser}
       />
-      {selectedUser && data ? (
-        <SourceJsonModal
-          user={selectedUser}
-          sourceFile={data.sourceFile}
-          onClose={() => setSelectedUser(null)}
-        />
-      ) : null}
+      <SelectedUserSourceModal data={data} selectedUser={selectedUser} onClose={closeSourceModal} />
     </div>
   )
 }

--- a/src/hooks/useCopilotEnterpriseUsers.ts
+++ b/src/hooks/useCopilotEnterpriseUsers.ts
@@ -32,6 +32,31 @@ async function loadEnterpriseUsers(): Promise<CopilotEnterpriseUsersResponse> {
   return getCopilotEnterpriseUsers()
 }
 
+function loadingState(previous: CopilotEnterpriseUsersState): CopilotEnterpriseUsersState {
+  return { ...previous, loading: true, error: null }
+}
+
+function successState(data: CopilotEnterpriseUsersSnapshot): CopilotEnterpriseUsersState {
+  return { data, loading: false, error: null }
+}
+
+function failureState(error?: string): CopilotEnterpriseUsersState {
+  return {
+    data: null,
+    loading: false,
+    error: error ?? 'Failed to read Copilot Enterprise users.',
+  }
+}
+
+function stateFromEnterpriseUsersResult(
+  result: CopilotEnterpriseUsersResponse
+): CopilotEnterpriseUsersState {
+  if (!result.success) return failureState(result.error)
+  if (!result.data) return failureState(result.error)
+
+  return successState(result.data)
+}
+
 export function useCopilotEnterpriseUsers(refreshToken = 0): CopilotEnterpriseUsersState {
   const [state, setState] = useState<CopilotEnterpriseUsersState>(EMPTY_STATE)
 
@@ -39,25 +64,16 @@ export function useCopilotEnterpriseUsers(refreshToken = 0): CopilotEnterpriseUs
     let canceled = false
 
     async function load(): Promise<void> {
-      setState(prev => ({ ...prev, loading: true, error: null }))
+      setState(loadingState)
 
       try {
         const result = await loadEnterpriseUsers()
         if (canceled) return
 
-        if (!result.success || !result.data) {
-          setState({
-            data: null,
-            loading: false,
-            error: result.error ?? 'Failed to read Copilot Enterprise users.',
-          })
-          return
-        }
-
-        setState({ data: result.data, loading: false, error: null })
+        setState(stateFromEnterpriseUsersResult(result))
       } catch (error: unknown) {
         if (canceled) return
-        setState({ data: null, loading: false, error: getErrorMessage(error) })
+        setState(failureState(getErrorMessage(error)))
       }
     }
 

--- a/src/hooks/useCopilotUsage.ts
+++ b/src/hooks/useCopilotUsage.ts
@@ -166,20 +166,43 @@ function computeAggregateSpend(
   let hasAny = false
 
   for (const state of Object.values(orgBudgets)) {
-    const d = state.data
-    if (!d || d.useQuotaOverage || d.spentUnavailable) continue
-    if (typeof d.spent !== 'number' || !Number.isFinite(d.spent)) continue
+    const data = getDollarSpendData(state)
+    if (!data) continue
 
     hasAny = true
-    totalSpent += d.spent
-
-    const projection = computeBudgetProjection(d.spent, d.billingYear, d.billingMonth, d.fetchedAt)
-    projectedSpend += projection ? projection.projectedSpend : d.spent
+    totalSpent += data.spent
+    projectedSpend += computeProjectedSpend(data)
   }
 
   if (!hasAny) return null
 
   return { totalSpent, projectedSpend }
+}
+
+function getDollarSpendData(state: OrgBudgetState): (BudgetData & { spent: number }) | null {
+  const data = state.data
+  if (!data) return null
+  if (!isDollarSpendData(data)) return null
+
+  return data
+}
+
+function isDollarSpendData(data: BudgetData): data is BudgetData & { spent: number } {
+  return !data.useQuotaOverage && !data.spentUnavailable && isFiniteNumber(data.spent)
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+function computeProjectedSpend(data: BudgetData & { spent: number }): number {
+  const projection = computeBudgetProjection(
+    data.spent,
+    data.billingYear,
+    data.billingMonth,
+    data.fetchedAt
+  )
+  return projection ? projection.projectedSpend : data.spent
 }
 
 function needsMonthRolloverRefresh(orgBudgets: Record<string, OrgBudgetState>): boolean {
@@ -194,14 +217,89 @@ function needsMonthRolloverRefresh(orgBudgets: Record<string, OrgBudgetState>): 
 
 type QuotaSetter = Dispatch<SetStateAction<Record<string, AccountQuotaState>>>
 type BudgetSetter = Dispatch<SetStateAction<Record<string, OrgBudgetState>>>
+type BudgetData = NonNullable<OrgBudgetState['data']>
+type CopilotUsageResult = Awaited<ReturnType<(typeof window.github)['getCopilotUsage']>>
+type CopilotUsageData = NonNullable<CopilotUsageResult['data']>
 
 const NO_ORG_POOL_ERROR = 'Per-account AI Credit data requires an organization with Copilot seats.'
+
+function setQuotaLoading(setQuotas: QuotaSetter, username: string): void {
+  setQuotas(prev => ({
+    ...prev,
+    [username]: {
+      data: prev[username]?.data ?? null,
+      loading: true,
+      error: null,
+      fetchedAt: prev[username]?.fetchedAt ?? null,
+    },
+  }))
+}
 
 function setQuotaError(setQuotas: QuotaSetter, username: string, error: string): void {
   setQuotas(prev => ({
     ...prev,
     [username]: { data: null, loading: false, error, fetchedAt: null },
   }))
+}
+
+function setQuotaData(
+  setQuotas: QuotaSetter,
+  username: string,
+  data: AccountQuotaState['data']
+): void {
+  setQuotas(prev => ({
+    ...prev,
+    [username]: { data, loading: false, error: null, fetchedAt: Date.now() },
+  }))
+}
+
+function getSuccessfulUsageData(result: CopilotUsageResult): CopilotUsageData | null {
+  if (!result.success) return null
+
+  return result.data ?? null
+}
+
+function usageResultError(result: CopilotUsageResult): string {
+  return result.error || 'Unknown error'
+}
+
+function quotaDataFromUsage(
+  username: string,
+  org: string,
+  data: CopilotUsageData
+): AccountQuotaState['data'] {
+  return synthesizeQuotaData({
+    login: username,
+    plan: data.seatPlan,
+    org,
+    usedCredits: data.premiumRequests,
+    grossCost: data.grossCost,
+    netCost: data.netCost,
+    seats: data.seats,
+    billingYear: data.billingYear,
+    billingMonth: data.billingMonth,
+    userCredits: data.userCredits,
+  })
+}
+
+function handleQuotaResult(
+  setQuotas: QuotaSetter,
+  username: string,
+  org: string,
+  result: CopilotUsageResult
+): void {
+  const data = getSuccessfulUsageData(result)
+  if (!data) {
+    setQuotaError(setQuotas, username, usageResultError(result))
+    return
+  }
+
+  if (data.seats <= 0) {
+    setQuotaError(setQuotas, username, NO_ORG_POOL_ERROR)
+    return
+  }
+
+  setQuotaData(setQuotas, username, quotaDataFromUsage(username, org, data))
 }
 
 /**
@@ -214,15 +312,7 @@ function setQuotaError(setQuotas: QuotaSetter, username: string, error: string):
 async function doFetchQuota(account: GitHubAccount, setQuotas: QuotaSetter): Promise<void> {
   const { username, org } = account
 
-  setQuotas(prev => ({
-    ...prev,
-    [username]: {
-      data: prev[username]?.data ?? null,
-      loading: true,
-      error: null,
-      fetchedAt: prev[username]?.fetchedAt ?? null,
-    },
-  }))
+  setQuotaLoading(setQuotas, username)
 
   if (!org) {
     setQuotaError(setQuotas, username, NO_ORG_POOL_ERROR)
@@ -231,33 +321,7 @@ async function doFetchQuota(account: GitHubAccount, setQuotas: QuotaSetter): Pro
 
   try {
     const result = await window.github.getCopilotUsage(org, username)
-    if (!result.success || !result.data) {
-      setQuotaError(setQuotas, username, result.error || 'Unknown error')
-      return
-    }
-
-    const d = result.data
-    if (d.seats <= 0) {
-      setQuotaError(setQuotas, username, NO_ORG_POOL_ERROR)
-      return
-    }
-
-    const data = synthesizeQuotaData({
-      login: username,
-      plan: d.seatPlan,
-      org,
-      usedCredits: d.premiumRequests,
-      grossCost: d.grossCost,
-      netCost: d.netCost,
-      seats: d.seats,
-      billingYear: d.billingYear,
-      billingMonth: d.billingMonth,
-      userCredits: d.userCredits,
-    })
-    setQuotas(prev => ({
-      ...prev,
-      [username]: { data, loading: false, error: null, fetchedAt: Date.now() },
-    }))
+    handleQuotaResult(setQuotas, username, org, result)
   } catch (error: unknown) {
     setQuotaError(setQuotas, username, getErrorMessage(error))
   }

--- a/src/utils/copilotEnterpriseUsers.ts
+++ b/src/utils/copilotEnterpriseUsers.ts
@@ -26,6 +26,10 @@ const EMPTY_TOTALS: UsageTotals = {
   models: new Map<string, number>(),
 }
 
+function createEmptyTotals(): UsageTotals {
+  return { ...EMPTY_TOTALS, models: new Map<string, number>() }
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
@@ -95,45 +99,56 @@ function collectUsageItemsFromValue(value: unknown): unknown[] {
 }
 
 function totalsFromUsageItems(items: unknown[]): UsageTotals {
-  const totals: UsageTotals = { ...EMPTY_TOTALS, models: new Map<string, number>() }
+  const totals = createEmptyTotals()
 
   for (const item of items) {
-    if (!isRecord(item)) continue
-
-    const grossQuantity = readNumber(item, 'grossQuantity', 'GrossQuantity', 'gross_quantity') ?? 0
-    const grossAmount = readNumber(item, 'grossAmount', 'GrossAmount', 'gross_amount') ?? 0
-    const netAmount = readNumber(item, 'netAmount', 'NetAmount', 'net_amount') ?? 0
-    const model = readString(item, 'model', 'Model')
-
-    totals.grossQuantity += grossQuantity
-    totals.grossAmount += grossAmount
-    totals.netAmount += netAmount
-    if (model && grossQuantity > 0) {
-      totals.models.set(model, (totals.models.get(model) ?? 0) + grossQuantity)
-    }
+    if (isRecord(item)) addUsageItemTotals(totals, item)
   }
 
   return totals
+}
+
+function addUsageItemTotals(totals: UsageTotals, item: Record<string, unknown>): void {
+  const grossQuantity = readNumber(item, 'grossQuantity', 'GrossQuantity', 'gross_quantity') ?? 0
+  totals.grossQuantity += grossQuantity
+  totals.grossAmount += readNumber(item, 'grossAmount', 'GrossAmount', 'gross_amount') ?? 0
+  totals.netAmount += readNumber(item, 'netAmount', 'NetAmount', 'net_amount') ?? 0
+  addModelQuantity(totals.models, readString(item, 'model', 'Model'), grossQuantity)
+}
+
+function addModelQuantity(
+  models: Map<string, number>,
+  model: string | null,
+  quantity: number
+): void {
+  if (!model || quantity <= 0) return
+
+  models.set(model, (models.get(model) ?? 0) + quantity)
 }
 
 function directTotalsFromRecord(record: Record<string, unknown>): UsageTotals | null {
   const grossQuantity = readNumber(record, 'grossQuantity', 'GrossQuantity', 'gross_quantity')
   if (grossQuantity === null) return null
 
-  const totals: UsageTotals = {
-    grossQuantity,
-    grossAmount: readNumber(record, 'grossAmount', 'GrossAmount', 'gross_amount') ?? 0,
-    netAmount: readNumber(record, 'netAmount', 'NetAmount', 'net_amount') ?? 0,
-    models: new Map<string, number>(),
-  }
+  const totals = createEmptyTotals()
+  totals.grossQuantity = grossQuantity
+  totals.grossAmount = readNumber(record, 'grossAmount', 'GrossAmount', 'gross_amount') ?? 0
+  totals.netAmount = readNumber(record, 'netAmount', 'NetAmount', 'net_amount') ?? 0
+  addDirectTopModel(record, totals.models, grossQuantity)
 
+  return totals
+}
+
+function addDirectTopModel(
+  record: Record<string, unknown>,
+  models: Map<string, number>,
+  grossQuantity: number
+): void {
   const topModel = readString(record, 'topModel', 'TopModel', 'top_model')
   const topModelQuantity =
     readNumber(record, 'topModelQuantity', 'TopModelQuantity', 'top_model_quantity') ??
     grossQuantity
-  if (topModel && topModelQuantity > 0) totals.models.set(topModel, topModelQuantity)
-
-  return totals
+  addModelQuantity(models, topModel, topModelQuantity)
 }
 
 function resolveTopModel(models: Map<string, number>): {
@@ -157,7 +172,7 @@ function normalizeUserRecord(record: Record<string, unknown>): CopilotEnterprise
   const login = readString(record, 'User', 'user', 'login', 'Login', 'memberLogin', 'member_login')
   if (!login) return null
 
-  const totals: UsageTotals = { ...EMPTY_TOTALS, models: new Map<string, number>() }
+  const totals = createEmptyTotals()
   const directTotals = directTotalsFromRecord(record)
   if (directTotals) {
     mergeTotals(totals, directTotals)

--- a/src/utils/cronUtils.test.ts
+++ b/src/utils/cronUtils.test.ts
@@ -60,6 +60,13 @@ describe('enumerateCronOccurrences', () => {
     expect(result).toEqual([])
   })
 
+  it('returns empty array when timezone parsing fails', () => {
+    const from = new Date('2025-01-01T00:00:00Z').getTime()
+    const to = new Date('2025-01-01T01:00:00Z').getTime()
+    const result = enumerateCronOccurrences('0 * * * *', 'Not/A_Timezone', from, to)
+    expect(result).toEqual([])
+  })
+
   it('supports common predefined expressions', () => {
     const from = new Date('2025-01-01T00:00:00Z').getTime()
     const to = new Date('2025-01-01T03:00:00Z').getTime()
@@ -104,6 +111,20 @@ describe('enumerateCronOccurrences', () => {
     const result = enumerateCronOccurrences('* * * * *', 'UTC', from, to)
     expect(result).toEqual([])
   })
+
+  it('normalizes day-of-week 7 to Sunday', () => {
+    const from = new Date('2025-01-05T00:00:00Z').getTime()
+    const to = new Date('2025-01-05T00:01:00Z').getTime()
+    const result = enumerateCronOccurrences('0 0 * * 7', 'UTC', from, to)
+    expect(result).toEqual([from])
+  })
+
+  it('matches either day field when both day fields are restricted', () => {
+    const from = new Date('2025-01-15T00:00:00Z').getTime()
+    const to = new Date('2025-01-15T00:01:00Z').getTime()
+    const result = enumerateCronOccurrences('0 0 15 * 1', 'UTC', from, to)
+    expect(result).toEqual([from])
+  })
 })
 
 describe('validateCronExpression', () => {
@@ -125,5 +146,20 @@ describe('validateCronExpression', () => {
 
   it('accepts common predefined expressions', () => {
     expect(() => validateCronExpression('@daily')).not.toThrow()
+  })
+
+  it('accepts aliases, question wildcards, ranges, and stepped ranges', () => {
+    expect(() => validateCronExpression('*/15 9-17 ? jan mon-fri')).not.toThrow()
+  })
+
+  it.each([
+    '*/0 * * * *',
+    '*/*/2 * * * *',
+    '5-3 * * * *',
+    '0,,15 * * * *',
+    '61 * * * *',
+    '0 0 * nope *',
+  ])('throws for malformed parser segment %s', cronExpression => {
+    expect(() => validateCronExpression(cronExpression)).toThrow()
   })
 })

--- a/src/utils/cronUtils.ts
+++ b/src/utils/cronUtils.ts
@@ -41,6 +41,8 @@ const PREDEFINED_EXPRESSIONS: Record<string, string> = {
   '@weekends': '0 0 * * 0,6',
 }
 
+const CRON_FIELD_KEYS = ['minute', 'hour', 'dayOfMonth', 'month', 'dayOfWeek'] as const
+
 interface CronField {
   values: Set<number>
   wildcard: boolean
@@ -52,6 +54,10 @@ interface ParsedCron {
   dayOfMonth: CronField
   month: CronField
   dayOfWeek: CronField
+}
+
+type ParsedCronFields = {
+  [Field in keyof ParsedCron]: CronField | null
 }
 
 interface TimeParts {
@@ -72,14 +78,33 @@ function parseValue(
   max: number,
   aliases?: Record<string, number>
 ): number | null {
-  const normalized = rawValue.toLowerCase()
-  const aliasValue = aliases?.[normalized.slice(0, 3)]
-  if (aliasValue !== undefined) return aliasValue
+  const aliasValue = resolveAliasValue(rawValue, aliases)
+  if (aliasValue !== null) return aliasValue
 
+  const parsed = parseNumericValue(rawValue)
+  if (parsed === null) return null
+
+  return isInRange(parsed, min, max) ? parsed : null
+}
+
+function resolveAliasValue(rawValue: string, aliases?: Record<string, number>): number | null {
+  if (!aliases) return null
+
+  return aliases[rawValue.toLowerCase().slice(0, 3)] ?? null
+}
+
+function parseNumericValue(rawValue: string): number | null {
   if (!/^\d+$/.test(rawValue)) return null
 
-  const parsed = Number.parseInt(rawValue, 10)
-  return parsed >= min && parsed <= max ? parsed : null
+  return Number.parseInt(rawValue, 10)
+}
+
+function isInRange(value: number, min: number, max: number): boolean {
+  return value >= min && value <= max
+}
+
+function identityValue(value: number): number {
+  return value
 }
 
 function parseSegment(
@@ -89,20 +114,39 @@ function parseSegment(
   aliases?: Record<string, number>,
   wildcardMax = max
 ): number[] | null {
-  const [rangePart, stepPart, extraPart] = segment.split('/')
-  if (extraPart !== undefined) return null
+  const parts = segment.split('/')
+  if (parts.length > 2) return null
 
-  const step = stepPart === undefined ? 1 : Number.parseInt(stepPart, 10)
-  if (!Number.isInteger(step) || step < 1 || stepPart === '') return null
+  const [rangePart, stepPart] = parts
+  const step = parseStep(stepPart)
+  if (step === null) return null
 
-  const rangeValues =
-    rangePart === '*' || rangePart === '?'
-      ? numberRange(min, wildcardMax)
-      : parseExplicitRange(rangePart, min, max, aliases)
-
-  if (!rangeValues) return null
+  const rangeValues = parseSegmentRange(rangePart, min, max, aliases, wildcardMax)
+  if (rangeValues === null) return null
 
   return rangeValues.filter((_value, index) => index % step === 0)
+}
+
+function parseStep(rawStep?: string): number | null {
+  if (rawStep === undefined) return 1
+  if (rawStep === '') return null
+
+  const step = Number.parseInt(rawStep, 10)
+  return Number.isInteger(step) && step >= 1 ? step : null
+}
+
+function parseSegmentRange(
+  rangePart: string,
+  min: number,
+  max: number,
+  aliases?: Record<string, number>,
+  wildcardMax = max
+): number[] | null {
+  if (rangePart === '*' || rangePart === '?') {
+    return numberRange(min, wildcardMax)
+  }
+
+  return parseExplicitRange(rangePart, min, max, aliases)
 }
 
 function parseExplicitRange(
@@ -111,18 +155,32 @@ function parseExplicitRange(
   max: number,
   aliases?: Record<string, number>
 ): number[] | null {
-  const [startRaw, endRaw, extraPart] = rangePart.split('-')
-  if (extraPart !== undefined) return null
+  const parts = rangePart.split('-')
+  if (parts.length > 2) return null
 
+  const [startRaw, endRaw] = parts
   const start = parseValue(startRaw, min, max, aliases)
   if (start === null) return null
 
-  if (endRaw === undefined) return [start]
-
-  const end = parseValue(endRaw, min, max, aliases)
-  if (end === null || start > end) return null
+  const end = parseRangeEnd(endRaw, start, min, max, aliases)
+  if (end === null) return null
 
   return numberRange(start, end)
+}
+
+function parseRangeEnd(
+  endRaw: string | undefined,
+  start: number,
+  min: number,
+  max: number,
+  aliases?: Record<string, number>
+): number | null {
+  if (endRaw === undefined) return start
+
+  const end = parseValue(endRaw, min, max, aliases)
+  if (end === null) return null
+
+  return start <= end ? end : null
 }
 
 function parseField(
@@ -130,24 +188,58 @@ function parseField(
   min: number,
   max: number,
   aliases?: Record<string, number>,
-  normalizeValue: (value: number) => number = value => value,
+  normalizeValue: (value: number) => number = identityValue,
   wildcardMax = max
 ): CronField | null {
   if (!rawField) return null
 
+  const values = parseFieldValues(rawField, min, max, aliases, normalizeValue, wildcardMax)
+  if (!values) return null
+
+  return { values, wildcard: isWildcardField(rawField) }
+}
+
+function parseFieldValues(
+  rawField: string,
+  min: number,
+  max: number,
+  aliases: Record<string, number> | undefined,
+  normalizeValue: (value: number) => number,
+  wildcardMax = max
+): Set<number> | null {
   const values = new Set<number>()
-  const wildcard = rawField === '*' || rawField === '?'
-
   for (const segment of rawField.split(',')) {
-    if (segment === '') return null
-
-    const segmentValues = parseSegment(segment, min, max, aliases, wildcardMax)
-    if (!segmentValues) return null
-
-    for (const value of segmentValues) values.add(normalizeValue(value))
+    if (!addSegmentValues(values, segment, min, max, aliases, normalizeValue, wildcardMax))
+      return null
   }
 
-  return values.size > 0 ? { values, wildcard } : null
+  return hasValues(values) ? values : null
+}
+
+function isWildcardField(rawField: string): boolean {
+  return rawField === '*' || rawField === '?'
+}
+
+function addSegmentValues(
+  values: Set<number>,
+  segment: string,
+  min: number,
+  max: number,
+  aliases: Record<string, number> | undefined,
+  normalizeValue: (value: number) => number,
+  wildcardMax = max
+): boolean {
+  if (segment === '') return false
+
+  const segmentValues = parseSegment(segment, min, max, aliases, wildcardMax)
+  if (!segmentValues) return false
+
+  for (const value of segmentValues) values.add(normalizeValue(value))
+  return true
+}
+
+function hasValues(values: Set<number>): boolean {
+  return values.size > 0
 }
 
 function parseCronExpression(cronExpression: string): ParsedCron | null {
@@ -155,20 +247,28 @@ function parseCronExpression(cronExpression: string): ParsedCron | null {
   const parts = expression.trim().split(/\s+/)
   if (parts.length !== 5) return null
 
+  return parseCronParts(parts)
+}
+
+function parseCronParts(parts: string[]): ParsedCron | null {
   const [minute, hour, dayOfMonth, month, dayOfWeek] = parts
-  const parsed = {
+  const parsed: ParsedCronFields = {
     minute: parseField(minute, 0, 59),
     hour: parseField(hour, 0, 23),
     dayOfMonth: parseField(dayOfMonth, 1, 31),
     month: parseField(month, 1, 12, MONTH_ALIASES),
-    dayOfWeek: parseField(dayOfWeek, 0, 7, WEEKDAY_ALIASES, value => (value === 7 ? 0 : value), 6),
+    dayOfWeek: parseField(dayOfWeek, 0, 7, WEEKDAY_ALIASES, normalizeDayOfWeek, 6),
   }
 
-  if (!parsed.minute || !parsed.hour || !parsed.dayOfMonth || !parsed.month || !parsed.dayOfWeek) {
-    return null
-  }
+  return hasAllCronFields(parsed) ? parsed : null
+}
 
-  return parsed as ParsedCron
+function normalizeDayOfWeek(value: number): number {
+  return value === 7 ? 0 : value
+}
+
+function hasAllCronFields(parsed: ParsedCronFields): parsed is ParsedCron {
+  return CRON_FIELD_KEYS.every(field => parsed[field])
 }
 
 function getTimezoneFormatter(timezone: string): Intl.DateTimeFormat {
@@ -273,25 +373,76 @@ export function enumerateCronOccurrences(
   maxRuns = 100,
   includeStart = true
 ): number[] {
-  if (fromTimestamp >= toTimestamp || maxRuns <= 0) return []
+  if (!canEnumerateCron(fromTimestamp, toTimestamp, maxRuns)) return []
 
+  return safelyEnumerateCron(
+    cronExpression,
+    timezone,
+    fromTimestamp,
+    toTimestamp,
+    maxRuns,
+    includeStart
+  )
+}
+
+function safelyEnumerateCron(
+  cronExpression: string,
+  timezone: string,
+  fromTimestamp: number,
+  toTimestamp: number,
+  maxRuns: number,
+  includeStart: boolean
+): number[] {
   try {
-    const parsed = parseCronExpression(cronExpression)
-    if (!parsed) return []
-
-    const results: number[] = []
-    for (
-      let timestamp = firstCandidateTimestamp(fromTimestamp, includeStart);
-      timestamp <= toTimestamp && results.length < maxRuns;
-      timestamp += MS_PER_MINUTE
-    ) {
-      if (matchesCron(parsed, new Date(timestamp), timezone)) {
-        results.push(timestamp)
-      }
-    }
-
-    return results
+    return enumerateParsedCron(
+      cronExpression,
+      timezone,
+      fromTimestamp,
+      toTimestamp,
+      maxRuns,
+      includeStart
+    )
   } catch (_: unknown) {
     return []
   }
+}
+
+function enumerateParsedCron(
+  cronExpression: string,
+  timezone: string,
+  fromTimestamp: number,
+  toTimestamp: number,
+  maxRuns: number,
+  includeStart: boolean
+): number[] {
+  const parsed = parseCronExpression(cronExpression)
+  if (!parsed) return []
+
+  return collectCronOccurrences(parsed, timezone, fromTimestamp, toTimestamp, maxRuns, includeStart)
+}
+
+function canEnumerateCron(fromTimestamp: number, toTimestamp: number, maxRuns: number): boolean {
+  return fromTimestamp < toTimestamp && maxRuns > 0
+}
+
+function collectCronOccurrences(
+  parsed: ParsedCron,
+  timezone: string,
+  fromTimestamp: number,
+  toTimestamp: number,
+  maxRuns: number,
+  includeStart: boolean
+): number[] {
+  const results: number[] = []
+  for (
+    let timestamp = firstCandidateTimestamp(fromTimestamp, includeStart);
+    timestamp <= toTimestamp && results.length < maxRuns;
+    timestamp += MS_PER_MINUTE
+  ) {
+    if (matchesCron(parsed, new Date(timestamp), timezone)) {
+      results.push(timestamp)
+    }
+  }
+
+  return results
 }


### PR DESCRIPTION
Closes #94

## Summary
- Reduced the current TypeScript CRAP hotspots by splitting cron parsing/enumeration, Copilot Enterprise usage aggregation, aggregate spend, and Enterprise users render-state logic into smaller helpers.
- Added focused cron parser edge-case coverage for malformed segments, timezone failures, weekday normalization, and day-field matching.
- Refreshed `docs/crap-score-log.md` with the current 2026-06-13 snapshot and documented the issue-approved threshold-10 rationale.

## Verification
- `bun run typecheck`
- `bun run lint`
- `bun run format:check`
- `bun run test -- --reporter=dot --silent` (6427 passed)
- `bun run test:coverage -- --reporter=dot --silent`
- `bunx markdownlint-cli2 docs/crap-score-log.md`
- `git diff --check` (only LF-to-CRLF warning for touched Markdown/package metadata)
- `bun run knip`
- `bunx vite build`
- `crap-report.ps1 -Threshold 10 -Top 20 -Format json -Stack ts -SkipCoverage` (exit 0, 0 findings, worst CRAP 7)
- `crap-report.ps1 -Threshold 6 -Top 20 -Format json -Stack ts -SkipCoverage` (exit 1 by design for 62 moderate discovery findings, worst CRAP 7)

## Known verification note
- `bun run e18e` still fails before analysis in the external temp `@e18e/cli` install with `ERR_MODULE_NOT_FOUND` for `@e18e/web-features-codemods/lib/main.js`; this matches the existing TODO note that e18e recheck is blocked by an external CLI module failure.

## Risk
Risk: medium. This touches Copilot metrics aggregation/display paths and cron preview parsing; focused tests and full suite coverage passed, but reviewers should scrutinize representative org aggregation, enterprise-user totals, and cron expression semantics.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce CRAP scores by extracting small utility functions across copilot hooks and components
> - Refactors [`TopUsersSection.tsx`](https://github.com/HemSoft/hs-buddy/pull/172/files#diff-6ffba62a3fe9ff04cb0f76e2d2aa76173f9108082276c59afb456a9333062e3b) by splitting rendering into focused sub-components (`EnterpriseUsersDataContent`, `EnterpriseUsersControls`, `EnterpriseUsersFilterPanel`, `SelectedUserSourceModal`) and extracting focus-trap helpers.
> - Refactors [`useCopilotEnterpriseUsers.ts`](https://github.com/HemSoft/hs-buddy/pull/172/files#diff-dc6a877df1577012a5379c472690466173d501dc05763099df050904a6964858) and [`useCopilotUsage.ts`](https://github.com/HemSoft/hs-buddy/pull/172/files#diff-dbb7ff1e4798ec1f006209082ad154bc2a96d243ad6ae0086cd052b5ca1503c2) by extracting state-transition helpers (`loadingState`, `successState`, `failureState`, `setQuotaLoading`, etc.) to reduce complexity in hook bodies.
> - Refactors [`cronUtils.ts`](https://github.com/HemSoft/hs-buddy/pull/172/files#diff-f453218c64c7f046574963d532031a368e7da1539d91f7a193da8a95e7233fc0) by decomposing large parsing functions into small, single-purpose helpers and adds edge-case tests in [`cronUtils.test.ts`](https://github.com/HemSoft/hs-buddy/pull/172/files#diff-f37fafcbc89d1a14e05bf3c5a1ffbbb5144c0bf19d8e990aa8e3af5afe9f05e5) covering timezone failures, day-of-week normalization, and malformed segments.
> - Refactors [`copilotEnterpriseUsers.ts`](https://github.com/HemSoft/hs-buddy/pull/172/files#diff-3f0ab7c4b8118d9a3b32d736db846a0c001c99a6d0f729093f82e59a1e6dd225) by extracting `createEmptyTotals`, `addUsageItemTotals`, `addModelQuantity`, and related helpers to simplify totals accumulation logic.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07ac2aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->