### PR TITLE
fix: simplify pending task names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.822] - 2026-06-13
+
+### Fixed
+
+- Simplify pending task names
+
 ## [0.1.821] - 2026-06-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.821",
+  "version": "0.1.822",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/services/taskQueue.test.ts
+++ b/src/services/taskQueue.test.ts
@@ -359,14 +359,18 @@ describe('TaskQueue', () => {
       const { promise: bp } = queue.enqueue(async () => {
         await blocker
       })
+      const { promise: unnamedPending } = queue.enqueue(async () => {})
       const { promise: ap } = queue.enqueue(async () => {}, { name: 'alpha' })
+      const { promise: emptyNamePending } = queue.enqueue(async () => {}, { name: '' })
       const { promise: btp } = queue.enqueue(async () => {}, { name: 'beta' })
 
       expect(queue.getPendingTaskNames()).toEqual(['alpha', 'beta'])
 
       queue.cancelAll()
       unblock!()
+      await expect(unnamedPending).rejects.toThrow()
       await expect(ap).rejects.toThrow()
+      await expect(emptyNamePending).rejects.toThrow()
       await expect(btp).rejects.toThrow()
       await expect(bp).rejects.toThrow()
     })

--- a/src/services/taskQueue.ts
+++ b/src/services/taskQueue.ts
@@ -224,7 +224,7 @@ export class TaskQueue {
    * Get names of all pending tasks in queue order.
    */
   getPendingTaskNames(): string[] {
-    return this.pendingTasks.map(t => t.name).filter((n): n is string => !!n)
+    return this.pendingTasks.flatMap(task => (task.name ? [task.name] : []))
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace `getPendingTaskNames` map/filter extraction with a single `flatMap` pass
- Preserve queue order and truthy-name filtering for missing or empty task names
- Extend `TaskQueue` coverage for unnamed and empty-name pending tasks

## Verification

- `rg -n "pendingTasks\.map" src/services/taskQueue.ts` exits 1 with no matches
- `git diff --check`
- `bun run test src/services/taskQueue.test.ts src/hooks/useRefreshIndicators.test.ts src/hooks/useTaskQueue.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run format:check`
- `bun run test`

Fixes #168

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `TaskQueue.getPendingTaskNames` to exclude unnamed tasks
> Replaces the `map(...).filter(!!)` pattern in `getPendingTaskNames` with a `flatMap` that only emits a task's name when it is a non-empty string. Tests are extended to cover unnamed and empty-string-named tasks, asserting they are excluded from the returned list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 662dcd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->