### PR TITLE
fix: simplify repo bookmark queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.823] - 2026-06-13
+
+### Fixed
+
+- Simplify repo bookmark queries
+
 ## [0.1.822] - 2026-06-13
 
 ### Fixed

--- a/convex/repoBookmarks.ts
+++ b/convex/repoBookmarks.ts
@@ -10,7 +10,7 @@ import { notFoundError } from './lib/domain'
 export const list = query({
   args: {},
   handler: async ctx => {
-    return await ctx.db.query('repoBookmarks').collect()
+    return ctx.db.query('repoBookmarks').collect()
   },
 })
 
@@ -18,7 +18,7 @@ export const list = query({
 export const listByFolder = query({
   args: { folder: v.string() },
   handler: async (ctx, args) => {
-    return await ctx.db
+    return ctx.db
       .query('repoBookmarks')
       .withIndex('by_folder', q => q.eq('folder', args.folder))
       .collect()
@@ -29,7 +29,7 @@ export const listByFolder = query({
 export const get = query({
   args: { id: v.id('repoBookmarks') },
   handler: async (ctx, args) => {
-    return await ctx.db.get('repoBookmarks', args.id)
+    return ctx.db.get('repoBookmarks', args.id)
   },
 })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.822",
+  "version": "0.1.823",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #167

## Summary
- Remove redundant `await` from direct Convex DB returns in `list`, `listByFolder`, and `get`.
- Preserve the existing async handlers and returned Convex promises/results.

## Verification
- `rg -n "return await" convex/repoBookmarks.ts` (no matches)
- `bun run test:convex convex/__tests__/repoBookmarks.test.ts`
- `bun run test:convex`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run format:check`

## Risk
- Trivial: mechanical removal of redundant awaits in one Convex query module; no error handling or cleanup semantics depend on `await` here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unnecessary `await` from `repoBookmarks` query handlers
> Simplifies the `list`, `listByFolder`, and `get` handlers in [repoBookmarks.ts](https://github.com/HemSoft/hs-buddy/pull/178/files#diff-a573236a56723333c90151991b4fd6f4a557bbbd2b0744eb841c8d0b24d451a1) by directly returning the database query results instead of awaiting them first. No behavioral change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ff557.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->