### PR TITLE
fix: simplify github account queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.824] - 2026-06-14
+
+### Fixed
+
+- Simplify github account queries
+
 ## [0.1.823] - 2026-06-13
 
 ### Fixed

--- a/convex/githubAccounts.ts
+++ b/convex/githubAccounts.ts
@@ -7,7 +7,7 @@ import { query, mutation, internalQuery } from './_generated/server'
 export const listForSnapshotRun = internalQuery({
   args: {},
   handler: async ctx => {
-    return await ctx.db.query('githubAccounts').collect()
+    return ctx.db.query('githubAccounts').collect()
   },
 })
 
@@ -17,7 +17,7 @@ export const listForSnapshotRun = internalQuery({
 export const list = query({
   args: {},
   handler: async ctx => {
-    return await ctx.db.query('githubAccounts').collect()
+    return ctx.db.query('githubAccounts').collect()
   },
 })
 
@@ -27,7 +27,7 @@ export const list = query({
 export const get = query({
   args: { id: v.id('githubAccounts') },
   handler: async (ctx, { id }) => {
-    return await ctx.db.get('githubAccounts', id)
+    return ctx.db.get('githubAccounts', id)
   },
 })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.823",
+  "version": "0.1.824",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #179

## Summary
- Remove redundant `await` from direct Convex DB returns in `listForSnapshotRun`, `list`, and `get`.
- Preserve existing async handlers and returned Convex promises/results.

## Verification
- `rg -n "return await ctx\\.db\\.(query|get)" convex/githubAccounts.ts` (no matches)
- `bun run test:convex convex/__tests__/githubAccounts.test.ts`
- `bun run test:convex`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run format:check`

## Risk
- Trivial: mechanical removal of redundant awaits in one Convex query module; no error handling or cleanup semantics depend on `await` here.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove unnecessary `await` from `githubAccounts` query handlers
> Drops redundant `await` from the `list`, `listForSnapshotRun`, and `get` query handlers in [githubAccounts.ts](https://github.com/HemSoft/hs-buddy/pull/184/files#diff-34adc2ec23cc0c3d8f41e784ab9b01683f110d0df7eb9337bea40309dbd185eb), returning the promises directly instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f8df3c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->