### PR TITLE
fix: consolidate task name collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.825] - 2026-06-14
+
+### Fixed
+
+- Consolidate task name collection
+
 ## [0.1.824] - 2026-06-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.824",
+  "version": "0.1.825",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/services/taskQueue.ts
+++ b/src/services/taskQueue.ts
@@ -213,18 +213,22 @@ export class TaskQueue {
    * Get names of all currently running tasks.
    */
   getRunningTaskNames(): string[] {
-    const names: string[] = []
-    for (const task of this.runningTasks.values()) {
-      if (task.name) names.push(task.name)
-    }
-    return names
+    return this.collectTaskNames(this.runningTasks.values())
   }
 
   /**
    * Get names of all pending tasks in queue order.
    */
   getPendingTaskNames(): string[] {
-    return this.pendingTasks.flatMap(task => (task.name ? [task.name] : []))
+    return this.collectTaskNames(this.pendingTasks)
+  }
+
+  private collectTaskNames(tasks: Iterable<Task>): string[] {
+    const names: string[] = []
+    for (const task of tasks) {
+      if (task.name) names.push(task.name)
+    }
+    return names
   }
 
   /**


### PR DESCRIPTION
Closes #180

## Summary
- Consolidates running and pending task-name extraction behind a shared `collectTaskNames` helper.
- Preserves filtering of missing/empty task names and existing task ordering.
- Includes the repo hook revision bump to `0.1.825` and changelog entry.

## Verification
- `bun run test src/services/taskQueue.test.ts` (baseline, 26 tests passed)
- `bun run test src/services/taskQueue.test.ts src/hooks/useRefreshIndicators.test.ts src/hooks/useTaskQueue.test.ts` (47 tests passed)
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run format:check`
- `bun run test` (full suite passed)
- commit hook: `prettier --check`, `vitest run --coverage`, TypeScript projects, `coverage-ratchet.ts`

## Risk
Low. This is an isolated refactor in `TaskQueue`; behavior remains covered by existing tests for running, pending, unnamed, and empty task names.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate task name collection in `TaskQueue` into a shared helper
> Extracts a private `collectTaskNames` method in [`taskQueue.ts`](https://github.com/HemSoft/hs-buddy/pull/185/files#diff-3195adbcd51fdb4a4094d44f27f01eee43ee6698c2fe9a698414bd1fc3be469e) that both `getRunningTaskNames` and `getPendingTaskNames` now delegate to, replacing their respective inline iteration logic with a single shared implementation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ff893f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->