### PR TITLE
fix: remove redundant feature intake awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.829] - 2026-06-21
+
+### Fixed
+
+- Remove redundant feature intake awaits
+
 ## [0.1.828] - 2026-06-21
 
 ### Changed

--- a/convex/featureIntakes.ts
+++ b/convex/featureIntakes.ts
@@ -37,7 +37,7 @@ const intakeStatusValidator = v.union(
 export const list = query({
   args: {},
   handler: async ctx => {
-    return await ctx.db.query('featureIntakes').withIndex('by_created').order('desc').collect()
+    return ctx.db.query('featureIntakes').withIndex('by_created').order('desc').collect()
   },
 })
 
@@ -46,7 +46,7 @@ export const listByStatus = query({
     status: intakeStatusValidator,
   },
   handler: async (ctx, args) => {
-    return await ctx.db
+    return ctx.db
       .query('featureIntakes')
       .withIndex('by_status', q => q.eq('status', args.status))
       .order('desc')
@@ -59,7 +59,7 @@ export const get = query({
     id: v.id('featureIntakes'),
   },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id)
+    return ctx.db.get(args.id)
   },
 })
 
@@ -69,7 +69,7 @@ export const getBySourceExternal = query({
     externalId: v.string(),
   },
   handler: async (ctx, args) => {
-    return await ctx.db
+    return ctx.db
       .query('featureIntakes')
       .withIndex('by_source_external', q =>
         q.eq('source', args.source).eq('externalId', args.externalId)
@@ -125,11 +125,13 @@ function resolveRiskLabel(riskLabel: RiskLabel | undefined): RiskLabel {
   return riskLabel ?? 'risk:low'
 }
 
-function getExistingCanonicalFields(existingByCanonical: {
-  _id: Id<'featureIntakes'>
-  canonicalIssueNumber?: number
-  canonicalIssueUrl?: string
-} | null): {
+function getExistingCanonicalFields(
+  existingByCanonical: {
+    _id: Id<'featureIntakes'>
+    canonicalIssueNumber?: number
+    canonicalIssueUrl?: string
+  } | null
+): {
   duplicateOfId?: Id<'featureIntakes'>
   canonicalIssueNumber?: number
   canonicalIssueUrl?: string
@@ -310,7 +312,7 @@ export const normalize = mutation({
       ? normalizeWhitespace(args.requestedOutcome)
       : undefined
 
-    return await insertAndResolve(ctx, {
+    return insertAndResolve(ctx, {
       ...args,
       externalId,
       title,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.828",
+  "version": "0.1.829",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #193

## Summary
- Removed redundant `return await` usage from feature intake Convex query handlers.
- Removed the redundant direct await around the `insertAndResolve(...)` return in the normalize mutation.
- Preserved intermediate awaits used to compute values before branching or patching.
- Included the repo-managed revision/changelog update produced by the commit hook.

## Verification
- `bun run test:convex -- convex/__tests__/featureIntakes.test.ts` (14 tests passed)
- `bun x prettier --check convex/featureIntakes.ts`
- `git diff --check`
- Commit hook: `vitest run --coverage` (287 files, 6427 tests passed)
- Commit hook: `tsc --noEmit && tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.convex.json && tsc --noEmit -p tsconfig.apphost.json`
- Commit hook: `bun scripts/coverage-ratchet.ts`

## Risk
Trivial: this removes redundant promise awaits from direct returns without changing the returned operations or intermediate await ordering.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant awaits from feature intake query and mutation handlers
> Removes unnecessary `await` calls from several handlers in [featureIntakes.ts](https://github.com/HemSoft/hs-buddy/pull/209/files#diff-1933ef4bc50afc726b7c2af6ba9ade80f71818171df354af5566c38af8c97a53), including `list`, `listByStatus`, `get`, `getBySourceExternal`, and `normalize`. The return values are promises that Convex resolves correctly without explicit awaiting.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 075cc8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->