### PR TITLE
fix: remove redundant tempo ipc awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.830] - 2026-06-21
+
+### Fixed
+
+- Remove redundant tempo ipc awaits
+
 ## [0.1.829] - 2026-06-21
 
 ### Fixed

--- a/electron/ipc/tempoHandlers.ts
+++ b/electron/ipc/tempoHandlers.ts
@@ -21,70 +21,70 @@ export function registerTempoHandlers(): void {
     IPC_INVOKE.TEMPO_GET_TODAY,
     ipcHandler(async (_event, date?: string) => {
       const d = date || formatDateKey(new Date())
-      return await getWorklogsForDate(d)
+      return getWorklogsForDate(d)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_GET_RANGE,
     ipcHandler(async (_event, args: { from: string; to: string }) => {
-      return await getWorklogsForRange(args.from, args.to)
+      return getWorklogsForRange(args.from, args.to)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_GET_WEEK,
     ipcHandler(async (_event, args: { weekStart: string; weekEnd: string }) => {
-      return await getWeekSummary(args.weekStart, args.weekEnd)
+      return getWeekSummary(args.weekStart, args.weekEnd)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_CREATE_WORKLOG,
     ipcHandler(async (_event, payload: CreateWorklogPayload) => {
-      return await createWorklog(payload)
+      return createWorklog(payload)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_UPDATE_WORKLOG,
     ipcHandler(async (_event, args: { worklogId: number; payload: UpdateWorklogPayload }) => {
-      return await updateWorklog(args.worklogId, args.payload)
+      return updateWorklog(args.worklogId, args.payload)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_DELETE_WORKLOG,
     ipcHandler(async (_event, worklogId: number) => {
-      return await deleteWorklog(worklogId)
+      return deleteWorklog(worklogId)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_GET_ACCOUNTS,
     ipcHandler(async () => {
-      return await getAccounts()
+      return getAccounts()
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_GET_PROJECT_ACCOUNTS,
     ipcHandler(async (_event, projectKey: string) => {
-      return await getProjectAccountLinks(projectKey)
+      return getProjectAccountLinks(projectKey)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_GET_CAPEX_MAP,
     ipcHandler(async (_event, issueKeys: string[]) => {
-      return await getCapexMap(issueKeys)
+      return getCapexMap(issueKeys)
     })
   )
 
   ipcMain.handle(
     IPC_INVOKE.TEMPO_GET_SCHEDULE,
     ipcHandler(async (_event, args: { from: string; to: string }) => {
-      return await getUserSchedule(args.from, args.to)
+      return getUserSchedule(args.from, args.to)
     })
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.829",
+  "version": "0.1.830",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #195

## Summary
- Removed redundant `return await` usage from Tempo IPC handler service calls.
- Kept argument normalization and handler registration structure unchanged.
- Left `ipcHandler` as the shared async error boundary.
- Included the repo-managed revision/changelog update produced by the commit hook.

## Verification
- `bun run test:electron -- electron/ipc/tempoHandlers.test.ts` (18 tests passed)
- `bun x prettier --check electron/ipc/tempoHandlers.ts`
- `git diff --check`
- Commit hook: `vitest run --coverage` (287 files, 6427 tests passed)
- Commit hook: `tsc --noEmit && tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.convex.json && tsc --noEmit -p tsconfig.apphost.json`
- Commit hook: `bun scripts/coverage-ratchet.ts`

## Risk
Low: Tempo IPC still returns the same service promises through `ipcHandler`, which remains responsible for awaiting and catching rejections.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `await` from Tempo IPC handler return statements
> In [tempoHandlers.ts](https://github.com/HemSoft/hs-buddy/pull/210/files#diff-41f1861c1ac1360191598a902b1952718bfcd2bfa828b4906d0528b7df819dc6), `ipcMain.handle` callbacks for all 10 Tempo IPC channels were unnecessarily double-awaiting promises. This removes the redundant `await` from each return statement, returning the underlying promises directly instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b32ec64.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->