### PR TITLE
docs: fix agent entrypoint guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Copilot Instructions for hs-buddy
 
-> **Start here → [GOAL-AND-GUIDING-PRINCIPLES.md](GOAL-AND-GUIDING-PRINCIPLES.md)** — the goal and guiding principles
+> **Start here → [GOAL-AND-GUIDING-PRINCIPLES.md](docs/GOAL-AND-GUIDING-PRINCIPLES.md)** — the goal and guiding principles
 > for this repository. Everything in this file serves that goal.
 >
 > **This file should ideally be empty until the architecture changes.**
@@ -23,20 +23,22 @@ code retrieval with significantly lower token usage than brute-force grep.
   Fall back to grep/glob only if Code Index returns no results or is offline.
 
 <!-- lean-ctx -->
+
 ## lean-ctx — Tool preference
 
 ALWAYS use lean-ctx MCP tools instead of native equivalents. This saves
 tokens and provides caching, compression, and persistent context.
 
-| Use this | Instead of | Why |
-|----------|------------|-----|
-| `ctx_read` | `cat`, `view`, `Read` | Cached reads, 10 compression modes |
-| `ctx_search` | `grep`, `rg`, `Select-String` | Compact, token-efficient results |
-| `ctx_shell` | `bash`, `powershell` | Pattern compression on output |
-| `ctx_tree` | `ls`, `dir`, `find`, `glob` | Compact directory maps |
-| `ctx_knowledge` | ad-hoc notes | Persistent cross-session memory |
+| Use this        | Instead of                    | Why                                |
+| --------------- | ----------------------------- | ---------------------------------- |
+| `ctx_read`      | `cat`, `view`, `Read`         | Cached reads, 10 compression modes |
+| `ctx_search`    | `grep`, `rg`, `Select-String` | Compact, token-efficient results   |
+| `ctx_shell`     | `bash`, `powershell`          | Pattern compression on output      |
+| `ctx_tree`      | `ls`, `dir`, `find`, `glob`   | Compact directory maps             |
+| `ctx_knowledge` | ad-hoc notes                  | Persistent cross-session memory    |
 
 Full rules: @LEAN-CTX.md
+
 <!-- /lean-ctx -->
 
 ## Agentic Loop — Standing Orders

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.831] - 2026-06-21
+
+### Changed
+
+- Fix agent entrypoint guidance
+
 ## [0.1.830] - 2026-06-21
 
 ### Fixed

--- a/LEAN-CTX.md
+++ b/LEAN-CTX.md
@@ -1,0 +1,37 @@
+# lean-ctx Usage
+
+This repository prefers lean-ctx MCP tools for substantive agent sessions.
+
+## Session Start
+
+- Load continuity with `ctx_session(action: "load")` or inspect status with
+  `ctx_session(action: "status")`.
+- Recall relevant repository knowledge with
+  `ctx_knowledge(action: "recall", query: "<task/repo/topic>")`.
+- Use `ctx_overview(path: "<repo-root>", task: "<task>")` for non-trivial
+  repository work.
+
+## Tool Mapping
+
+| Use this        | Instead of                    | Why                                |
+| --------------- | ----------------------------- | ---------------------------------- |
+| `ctx_read`      | `cat`, `view`, `Read`         | Cached reads and compression modes |
+| `ctx_search`    | `grep`, `rg`, `Select-String` | Compact, token-efficient matches   |
+| `ctx_shell`     | `bash`, `powershell`          | Pattern-compressed command output  |
+| `ctx_tree`      | `ls`, `dir`, `find`, `glob`   | Compact directory maps             |
+| `ctx_knowledge` | ad hoc notes                  | Persistent repository knowledge    |
+
+## During Work
+
+- Record resumable state with
+  `ctx_session(action: "task" | "finding" | "decision", value: "...")`.
+- Keep entries concise and tied to the current repository or worktree.
+- If lean-ctx is unavailable or scoped too narrowly for a required file, use the
+  narrowest direct tool fallback and record the limitation.
+
+## Closeout
+
+- Save meaningful continuity with `ctx_session(action: "save")`.
+- Promote stable, verified repository facts with `ctx_knowledge(action:
+"remember", category: "<category>", key: "<slug>", value: "...")`.
+- Do not store secrets, transient command noise, or speculation.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.830",
+  "version": "0.1.831",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #211

## Summary
- Fixed the `AGENTS.md` start-here link so it points to `docs/GOAL-AND-GUIDING-PRINCIPLES.md`.
- Added the missing root `LEAN-CTX.md` referenced by `AGENTS.md`.
- Documented the lean-ctx session lifecycle, tool mapping, fallback behavior, and closeout expectations.
- Included the repo-managed revision/changelog update produced by the commit hook.

## Verification
- Verified `docs/GOAL-AND-GUIDING-PRINCIPLES.md` exists.
- Verified `LEAN-CTX.md` exists.
- `bun x markdownlint-cli2 AGENTS.md LEAN-CTX.md`
- `git diff --check`
- Commit hook: Markdown quality checks for `AGENTS.md` and `LEAN-CTX.md`
- Commit hook: `vitest run --coverage` (287 files, 6427 tests passed)
- Commit hook: `tsc --noEmit && tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.scripts.json && tsc --noEmit -p tsconfig.convex.json && tsc --noEmit -p tsconfig.apphost.json`
- Commit hook: `bun scripts/coverage-ratchet.ts`

## Risk
Low: documentation-only change to make existing agent guidance resolvable from the repository checkout.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix agent entrypoint link and add lean-ctx usage documentation
> - Fixes a broken 'Start here' link in [AGENTS.md](https://github.com/HemSoft/hs-buddy/pull/214/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) by correcting the path from `GOAL-AND-GUIDING-PRINCIPLES.md` to `docs/GOAL-AND-GUIDING-PRINCIPLES.md`.
> - Adds [LEAN-CTX.md](https://github.com/HemSoft/hs-buddy/pull/214/files#diff-3a813652bdcd6b816a61dc330b05730193c6cffaca0cbba935af589e45d10e1d), a new doc describing preferred usage of lean-ctx MCP tools, including session start, tool mapping, in-session practices, and closeout steps.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b73b4c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->