### PR TITLE
fix: remove redundant jobs query awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.832] - 2026-06-21
+
+### Fixed
+
+- Remove redundant jobs query awaits
+
 ## [0.1.831] - 2026-06-21
 
 ### Changed

--- a/convex/jobs.ts
+++ b/convex/jobs.ts
@@ -13,7 +13,7 @@ const workerTypeValidator = v.union(v.literal('exec'), v.literal('ai'), v.litera
 export const list = query({
   args: {},
   handler: async ctx => {
-    return await ctx.db.query('jobs').collect()
+    return ctx.db.query('jobs').collect()
   },
 })
 
@@ -23,7 +23,7 @@ export const listByType = query({
     workerType: workerTypeValidator,
   },
   handler: async (ctx, args) => {
-    return await ctx.db
+    return ctx.db
       .query('jobs')
       .withIndex('by_worker_type', q => q.eq('workerType', args.workerType))
       .collect()
@@ -34,7 +34,7 @@ export const listByType = query({
 export const get = query({
   args: { id: v.id('jobs') },
   handler: async (ctx, args) => {
-    return await ctx.db.get('jobs', args.id)
+    return ctx.db.get('jobs', args.id)
   },
 })
 
@@ -42,7 +42,7 @@ export const get = query({
 export const getByName = query({
   args: { name: v.string() },
   handler: async (ctx, args) => {
-    return await ctx.db
+    return ctx.db
       .query('jobs')
       .withIndex('by_name', q => q.eq('name', args.name))
       .first()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.831",
+  "version": "0.1.832",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
## Summary
- Remove redundant `return await` usage from the four direct-return jobs query handlers.
- Leave mutation behavior and validation unchanged.
- Add changelog entry for the simplification.

Fixes #194

## Verification
- `bun run test:convex -- convex/__tests__/jobs.test.ts` -> 14 tests passed
- `bun x prettier --check convex/jobs.ts CHANGELOG.md` -> passed
- `bun x markdownlint-cli2 CHANGELOG.md` -> 0 errors
- `git diff --check` -> passed
- Commit hook: `vitest run --coverage` -> 287 files / 6427 tests passed
- Commit hook: `tsc --noEmit` project suite -> passed
- Commit hook: `bun scripts/coverage-ratchet.ts` -> no threshold increase needed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `await` in `jobs` query handlers
> Removes unnecessary `await` from the return statements of four query handlers in [convex/jobs.ts](https://github.com/HemSoft/hs-buddy/pull/215/files#diff-f243a1b9e04693f3c76cdd351041a9fba93c139a8a35932dbd52a81185cd00a1): `list`, `listByType`, `get`, and `getByName`. Each handler now returns the promise directly rather than awaiting it before returning, which is functionally equivalent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e2a110e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->