### PR TITLE
fix: remove redundant prefetch awaits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.833] - 2026-06-21
+
+### Fixed
+
+- Remove redundant prefetch awaits
+
 ## [0.1.832] - 2026-06-21
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.832",
+  "version": "0.1.833",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/hooks/usePrefetch.ts
+++ b/src/hooks/usePrefetch.ts
@@ -25,14 +25,14 @@ import { isAbortError } from '../utils/errorUtils'
 async function fetchPrefetchPRs(client: GitHubClient, mode: string): Promise<PullRequest[]> {
   switch (mode) {
     case 'needs-review':
-      return await client.fetchNeedsReview()
+      return client.fetchNeedsReview()
     case 'recently-merged':
-      return await client.fetchRecentlyMerged()
+      return client.fetchRecentlyMerged()
     case 'need-a-nudge':
-      return await client.fetchNeedANudge()
+      return client.fetchNeedANudge()
     case 'my-prs':
     default:
-      return await client.fetchMyPRs()
+      return client.fetchMyPRs()
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove redundant `return await` usage from each `fetchPrefetchPRs` switch branch.
- Preserve the same PR mode to GitHub client method mapping.
- Add changelog entry for the simplification.

Fixes #199

## Verification
- `bun run test -- src/hooks/usePrefetch.test.ts` -> 24 tests passed
- `bun x prettier --check src/hooks/usePrefetch.ts CHANGELOG.md` -> passed
- `bun x markdownlint-cli2 CHANGELOG.md` -> 0 errors
- `git diff --check` -> passed
- Commit hook: `vitest run --coverage` -> 287 files / 6427 tests passed
- Commit hook: `tsc --noEmit` project suite -> passed
- Commit hook: `bun scripts/coverage-ratchet.ts` -> no threshold increase needed

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `await` from return statements in `fetchPrefetchPRs`
> In [usePrefetch.ts](https://github.com/HemSoft/hs-buddy/pull/216/files#diff-3e43893783927c11497db034ce42aafe76acb361814230c7e46d0823fd352e61), each switch branch was unnecessarily awaiting the promise before returning it. The promises from `GitHubClient` methods are now returned directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3ac7a2f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->