### PR TITLE
fix: remove redundant bookmark awaits

### DIFF
--- a/convex/bookmarks.ts
+++ b/convex/bookmarks.ts
@@ -11,7 +11,7 @@ import {
 export const list = query({
   args: {},
   handler: async ctx => {
-    return await ctx.db.query('bookmarks').collect()
+    return ctx.db.query('bookmarks').collect()
   },
 })
 
@@ -19,7 +19,7 @@ export const list = query({
 export const listByCategory = query({
   args: { category: v.string() },
   handler: async (ctx, args) => {
-    return await ctx.db
+    return ctx.db
       .query('bookmarks')
       .withIndex('by_category', q => q.eq('category', args.category))
       .collect()
@@ -30,7 +30,7 @@ export const listByCategory = query({
 export const get = query({
   args: { id: v.id('bookmarks') },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id)
+    return ctx.db.get(args.id)
   },
 })
 
@@ -81,7 +81,7 @@ export const create = mutation({
       sortOrder = categoryBookmarks.length
     }
 
-    return await ctx.db.insert('bookmarks', {
+    return ctx.db.insert('bookmarks', {
       url: args.url,
       title: args.title,
       description: args.description,


### PR DESCRIPTION
Closes #200

## Summary
- Removed redundant direct `return await` usage from bookmark Convex query handlers.
- Returned the final bookmark insert promise directly while preserving intermediate awaits for duplicate checking and sort-order calculation.

## Verification
- `bun run test:convex -- convex/__tests__/bookmarks.test.ts` - passed (1 file, 19 tests)
- `bunx eslint convex/bookmarks.ts --max-warnings 0` - passed
- `bunx tsc --noEmit -p tsconfig.convex.json` - passed
- `bun run lint` - passed
- `bun run typecheck` - passed

## Risk
- Trivial: direct promise returns preserve resolved values and rejection behavior for these terminal Convex database calls.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `await` calls in bookmark query and mutation handlers
> Removes unnecessary `await` expressions from the `list`, `listByCategory`, `get`, and `create` handlers in [bookmarks.ts](https://github.com/HemSoft/hs-buddy/pull/221/files#diff-b58df6e1ea7a089d9ee0172817099340b8e1740cfc1c6664308f17c219f13818). Each handler now returns the promise directly rather than awaiting it before returning, which has no functional effect but cleans up the code.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 12e3f43.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->