### PR TITLE
fix: remove redundant awaits in copilot result queries

### DIFF
--- a/convex/copilotResults.ts
+++ b/convex/copilotResults.ts
@@ -14,7 +14,7 @@ export const listRecent = query({
   },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 50
-    return await ctx.db.query('copilotResults').withIndex('by_created').order('desc').take(limit)
+    return ctx.db.query('copilotResults').withIndex('by_created').order('desc').take(limit)
   },
 })
 
@@ -26,7 +26,7 @@ export const listByCategory = query({
   },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 50
-    return await ctx.db
+    return ctx.db
       .query('copilotResults')
       .withIndex('by_category', q => q.eq('category', args.category))
       .order('desc')
@@ -42,7 +42,7 @@ export const listByStatus = query({
   },
   handler: async (ctx, args) => {
     const limit = args.limit ?? 50
-    return await ctx.db
+    return ctx.db
       .query('copilotResults')
       .withIndex('by_status', q => q.eq('status', args.status))
       .order('desc')
@@ -54,7 +54,7 @@ export const listByStatus = query({
 export const get = query({
   args: { id: v.id('copilotResults') },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id)
+    return ctx.db.get(args.id)
   },
 })
 


### PR DESCRIPTION
## Summary
- Remove redundant `return await` from the four Copilot result query return paths named in #201.
- Leave `countActive`, mutations, and intermediate awaits unchanged.

## Verification
- `bun install --frozen-lockfile` (exit 0)
- `bun run test:convex -- convex/__tests__/copilotResults.test.ts` (exit 0; 1 file, 15 tests passed)
- `bun run lint` (exit 0)
- `bun run typecheck` (exit 0)
- `git diff --check` (exit 0; line-ending warning only)
- `bun run knip` (exit 0)
- `bun run e18e` (exit 1; pre-existing package-health findings: `pkg.main` points to missing `dist-electron/main.js` before build, plus duplicate dependency warnings)
- Commit hook full `vitest run --coverage` before scoped recommit (exit 0; 287 files, 6427 tests passed)

Closes #201

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove redundant `await` calls in copilot result query handlers
> Removes unnecessary `await` keywords when returning database promises in [convex/copilotResults.ts](https://github.com/HemSoft/hs-buddy/pull/222/files#diff-9571659316b51a063f95544e06f0a1aaf03e0b05f6b85eb01a9bebca3b6097a5). The `listRecent`, `listByCategory`, `listByStatus`, and `get` handlers now return the promise directly instead of awaiting it before returning.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 186e308.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->