### PR TITLE
docs: refresh sfl workflow references

### DIFF
--- a/.github/prompts/health.prompt.md
+++ b/.github/prompts/health.prompt.md
@@ -18,13 +18,15 @@ Run these queries in parallel:
 1. **Open issues** with any agent label: `agent:fixable`, `agent:in-progress`, `agent:pause`, `agent:human-required`
 2. **All open PRs** (including draft) with branch names matching `agent-fix/*`
 3. **Recent workflow runs** (last 5) for each of:
-   - `sfl-auditor.lock.yml`
-   - `sfl-gate.yml`
-   - `sfl-implement.lock.yml`
+   - `sfl-auditor.yml`
+   - `sfl-dispatcher.yml`
+   - `issue-processor.lock.yml`
    - `repo-audit.lock.yml`
-   - `sfl-analyzer-a.lock.yml`
-   - `sfl-analyzer-b.lock.yml`
-   - `sfl-analyzer-c.lock.yml`
+   - `pr-analyzer-a.lock.yml`
+   - `pr-analyzer-b.lock.yml`
+   - `pr-analyzer-c.lock.yml`
+   - `pr-fixer.lock.yml`
+   - `pr-promoter.lock.yml`
 4. **Open issues** with labels `agent:pause` or `agent:escalated` that mention workflow failures
 
 ---
@@ -51,7 +53,7 @@ For each check, state: ✅ Pass / ❌ Fail / ⚠️ Warning — and list the spe
 
 ## Step 3 — Evaluate SFL Auditor health
 
-The SFL Auditor (`sfl-auditor.lock.yml`) is the health guardian. Evaluate:
+The SFL Auditor (`sfl-auditor.yml`) is the health guardian. Evaluate:
 
 - Did the last run **succeed** (conclusion: `success`)?
 - Did it produce **safe outputs** (no "no safe outputs" warning in associated issues)?
@@ -64,8 +66,9 @@ State: ✅ Healthy / ❌ Failing / ⚠️ Degraded — with specific run IDs and
 
 ## Step 4 — Evaluate other workflow health
 
-For each of `sfl-gate.yml`, `sfl-implement.lock.yml`, `repo-audit.lock.yml`,
-`sfl-analyzer-a.lock.yml`, `sfl-analyzer-b.lock.yml`, and `sfl-analyzer-c.lock.yml`:
+For each of `sfl-dispatcher.yml`, `issue-processor.lock.yml`,
+`repo-audit.lock.yml`, `pr-analyzer-a.lock.yml`, `pr-analyzer-b.lock.yml`,
+`pr-analyzer-c.lock.yml`, `pr-fixer.lock.yml`, and `pr-promoter.lock.yml`:
 
 - Last run conclusion (success/failure/cancelled)
 - Last run timestamp
@@ -104,6 +107,10 @@ Produce a concise health report in this format:
 - Last run: <run ID> at <time> — <conclusion>
 - Open failure issues: none | #<numbers>
 
+### SFL Dispatcher
+- Last run: <run ID> at <time> — <conclusion>
+- Open failure issues: none | #<numbers>
+
 ### Repo Audit
 - Last run: <run ID> at <time> — <conclusion>
 - Open failure issues: none | #<numbers>
@@ -114,11 +121,11 @@ Produce a concise health report in this format:
 - Analyzer C last run: <run ID> at <time> — <conclusion>
 - Open failure issues: none | #<numbers>
 
-### PR Router
+### PR Fixer
 - Last run: <run ID> at <time> — <conclusion>
 - Open failure issues: none | #<numbers>
 
-### PR Label Actions
+### PR Promoter
 - Last run: <run ID> at <time> — <conclusion>
 - Open failure issues: none | #<numbers>
 

--- a/.github/prompts/sfl-add-issue.prompt.md
+++ b/.github/prompts/sfl-add-issue.prompt.md
@@ -6,8 +6,8 @@ description: Create a pipeline-ready issue for the Set it Free Loop.
 # SFL — Add Issue to Pipeline
 
 Interactively help the user create a well-formed issue that the SFL Issue
-Processor can pick up immediately when it is created with `agent:fixable`.
-The 30-minute cron remains a backstop if the immediate path does not fire.
+Processor can pick up when it is created with `agent:fixable` and
+`action-item`.
 
 ---
 
@@ -76,7 +76,7 @@ passes", "export is no longer referenced anywhere">
 `risk:<trivial|low|medium|high>` — <one-line justification>
 ```
 
-**Labels**: `agent:fixable`, `enhancement`, `risk:<trivial|low|medium|high>`
+**Labels**: `agent:fixable`, `action-item`, `enhancement`, `risk:<trivial|low|medium|high>`
 
 ---
 
@@ -100,6 +100,7 @@ gh issue create --repo "<owner>/<repo>" \
   --title "[sfl] <title>" \
   --body "<body>" \
   --label "agent:fixable" \
+  --label "action-item" \
   --label "enhancement" \
   --label "risk:<trivial|low|medium|high>"
 ```
@@ -107,8 +108,8 @@ gh issue create --repo "<owner>/<repo>" \
 After creation, confirm the issue number and tell the user:
 
 > Issue #N created. The dispatcher should kick off the Issue Processor
-> immediately because the issue was created with `agent:fixable`. The 30-minute
-> cron is still there as a fallback.
+> when it runs because the issue was created with `agent:fixable` and
+> `action-item`.
 
 ---
 

--- a/.github/prompts/status.prompt.md
+++ b/.github/prompts/status.prompt.md
@@ -25,13 +25,15 @@ Run these queries:
 1. **All open issues** with any `agent:*` label — get number, title, labels
 2. **All open PRs** — get number, title, draft status, head branch name
 3. **Workflow runs since `LAST_CHECK`** for each of:
-   - `sfl-auditor.lock.yml`
-   - `sfl-gate.yml`
-   - `sfl-implement.lock.yml`
+   - `sfl-auditor.yml`
+   - `sfl-dispatcher.yml`
+   - `issue-processor.lock.yml`
    - `repo-audit.lock.yml`
-   - `sfl-analyzer-a.lock.yml`
-   - `sfl-analyzer-b.lock.yml`
-   - `sfl-analyzer-c.lock.yml`
+   - `pr-analyzer-a.lock.yml`
+   - `pr-analyzer-b.lock.yml`
+   - `pr-analyzer-c.lock.yml`
+   - `pr-fixer.lock.yml`
+   - `pr-promoter.lock.yml`
 
    Get their conclusion (success / failure / cancelled) and timestamp.
 
@@ -54,13 +56,14 @@ Print a concise report:
 | Workflow | Runs | Failed |
 |----------|------|--------|
 | SFL Auditor | N | 0 or list |
+| SFL Dispatcher | N | 0 or list |
 | Issue Processor | N | 0 or list |
 | Repo Audit | N | 0 or list |
 | PR Analyzer A | N | 0 or list |
 | PR Analyzer B | N | 0 or list |
 | PR Analyzer C | N | 0 or list |
-| PR Router | N | 0 or list |
-| PR Label Actions | N | 0 or list |
+| PR Fixer | N | 0 or list |
+| PR Promoter | N | 0 or list |
 
 ### Verdict: ✅ ALL GOOD | ⚠️ ISSUES FOUND
 <one-line summary>

--- a/.sfl/INTAKE.md
+++ b/.sfl/INTAKE.md
@@ -33,12 +33,12 @@ GitHub Actions three months ago.
 
 ## What Happens Next
 
-1. `sfl-loop` claims the issue and starts the fix workflow
-2. `sfl-implement` opens or updates a Draft PR with the proposed fix
-3. Three independent analyzers (A, B, C) review the PR in parallel
-4. If changes are requested, `sfl-loop` routes the feedback back to `sfl-implement`, updates the PR, and runs the analyzers again
-5. If the analyzers pass, the PR is marked `human:ready-for-review`
-6. A human reviews and merges
+1. `sfl-dispatcher` sees eligible queued work and dispatches the next useful workflow
+2. `issue-processor` claims the issue and opens a draft PR with the proposed fix
+3. `pr-analyzer-a`, `pr-analyzer-b`, and `pr-analyzer-c` review the PR sequentially
+4. If changes are requested, `pr-fixer` applies the feedback and advances the review cycle
+5. If all analyzers pass, `pr-promoter` marks the PR `human:ready-for-review`
+6. A human reviews the ready PR; `pr-promoter` can squash-merge approved ready PRs
 
 ---
 

--- a/.sfl/INTAKE.md
+++ b/.sfl/INTAKE.md
@@ -6,16 +6,17 @@
 
 ## Quick Start
 
-Create a GitHub issue with the label `agent:fixable` and the loop takes over:
+Create a GitHub issue with the labels `agent:fixable` and `action-item`, and
+the loop takes over:
 
 1. **Title**: Start with `[agent-fix]` followed by a clear description
-2. **Labels**: Apply `agent:fixable` + a risk label (`risk:low`, `risk:medium`, `risk:high`)
+2. **Labels**: Apply `agent:fixable` + `action-item` + a risk label (`risk:low`, `risk:medium`, `risk:high`)
 3. **Body**: Describe what needs to change and the acceptance criteria
 
 ### Example
 
 **Title**: `[agent-fix] Update README badges to reflect new CI pipeline`
-**Labels**: `agent:fixable`, `risk:low`
+**Labels**: `agent:fixable`, `action-item`, `risk:low`
 **Body**:
 
 ```markdown
@@ -55,6 +56,7 @@ Add the `no-agent` label to any issue to exclude it from SFL processing.
 | Label | When to use |
 |-------|------------|
 | `agent:fixable` | Agent can auto-fix this |
+| `action-item` | Eligible for the SFL dispatcher and Issue Processor |
 | `agent:blocked` | Agent stopped — human intervention required |
 | `no-agent` | Opt out entirely |
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.836] - 2026-06-22
+
+### Changed
+
+- Align sfl intake and analyzer triggers
+
 ## [0.1.835] - 2026-06-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.835] - 2026-06-22
+
+### Changed
+
+- Refresh sfl workflow references
+
 ## [0.1.834] - 2026-06-22
 
 ### Changed

--- a/docs/GOAL-AND-GUIDING-PRINCIPLES.md
+++ b/docs/GOAL-AND-GUIDING-PRINCIPLES.md
@@ -36,9 +36,9 @@ The happy path from issue to human-ready PR. Every handoff is deterministic.
 |---|---|---|---|---|---|---|
 | 0 | `repo-audit` / `simplisticate` | Repository state | GitHub Issue | `workflow_dispatch` | Adds `agent:fixable`, `action-item`, and risk label to new action items | Produces focused, agent-fixable follow-up issues from audit findings |
 | 1 | `issue-processor` | Issue with `agent:fixable` + `action-item` | Draft PR | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:fixable`; adds `agent:in-progress` to issue, `agent:pr` to PR | Claims the issue, implements the fix, and creates a draft PR |
-| 2 | `pr-analyzer-a` | Draft PR | PR review/comment marker | `pull_request: opened` / dispatch | Reads `agent:pr`, `pr:cycle-N` | First full-spectrum review pass. Writes `[MARKER:pr-analyzer-a cycle:N]` + verdict and dispatches Analyzer B |
-| 3 | `pr-analyzer-b` | Analyzer A dispatch | PR review/comment marker | `workflow_dispatch` | Reads `agent:pr`, `pr:cycle-N` | Second full-spectrum review pass. Writes `[MARKER:pr-analyzer-b cycle:N]` + verdict and dispatches Analyzer C |
-| 4 | `pr-analyzer-c` | Analyzer B dispatch | PR review/comment marker | `workflow_dispatch` | Reads `agent:pr`, `pr:cycle-N` | Final review pass. Writes `[MARKER:pr-analyzer-c cycle:N]` + verdict |
+| 2 | `pr-analyzer-a` | Draft PR | PR review/comment marker | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:pr`, `pr:cycle-N` | First full-spectrum review pass. Writes `[MARKER:pr-analyzer-a cycle:N]` + verdict |
+| 3 | `pr-analyzer-b` | Draft PR | PR review/comment marker | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:pr`, `pr:cycle-N` | Second full-spectrum review pass. Writes `[MARKER:pr-analyzer-b cycle:N]` + verdict |
+| 4 | `pr-analyzer-c` | Draft PR | PR review/comment marker | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:pr`, `pr:cycle-N` | Final review pass. Writes `[MARKER:pr-analyzer-c cycle:N]` + verdict |
 | 5 | `pr-fixer` | Draft PR with analyzer findings | Updated draft PR | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:pr`, `pr:cycle-N`; advances cycle labels when fixes are applied | Applies analyzer feedback on the PR branch and leaves promotion to `pr-promoter` |
 | 6 | `pr-promoter` | Draft PR with all analyzer PASS verdicts | Ready PR or merged PR | `workflow_dispatch` via `sfl-dispatcher` | Adds `human:ready-for-review` after promotion; merges approved ready PRs | Converts clean draft PRs to ready-for-review and squash-merges approved ready PRs |
 

--- a/docs/GOAL-AND-GUIDING-PRINCIPLES.md
+++ b/docs/GOAL-AND-GUIDING-PRINCIPLES.md
@@ -34,14 +34,16 @@ The happy path from issue to human-ready PR. Every handoff is deterministic.
 
 | # | Workflow Name | Source | Destination | Trigger Mechanism | Label(s) | Description |
 |---|---|---|---|---|---|---|
-| 0 | `discussion-processor` | Audit/Doctor/Simplisticate discussion | GitHub Issue | `discussion: labeled` | Adds `agent:fixable` + risk label to new issue | Groups agent-fixable findings from audit discussions into categorized issues |
-| 1 | `sfl-issue-processor` | Issue with `agent:fixable` | Draft PR | `issues: opened/reopened` | Reads `agent:fixable`; adds `agent:in-progress` to issue, `agent:pr` + `pr:cycle-0` to PR | Claims the issue, implements the fix, creates a draft PR, dispatches Analyzer A |
-| 2 | `sfl-analyzer-a` | Draft PR | PR comment marker | `pull_request: opened` / dispatch | Reads `agent:pr`, `pr:cycle-N` | Claude Sonnet reviews for correctness, security, performance, style. Writes `<!-- MARKER:sfl-analyzer-a -->` + verdict to PR comment. Dispatches Analyzer B |
-| 3 | `sfl-analyzer-b` | Analyzer A dispatch | PR comment marker | `workflow_dispatch` | Reads `agent:pr`, `pr:cycle-N` | Claude Opus 4.6 reviews (different model than A). Writes `<!-- MARKER:sfl-analyzer-b -->` + verdict. Dispatches Analyzer C |
-| 4 | `sfl-analyzer-c` | Analyzer B dispatch | PR comment marker + label | `workflow_dispatch` | Reads `agent:pr`, `pr:cycle-N`; adds `analyzer:blocked` if BLOCKING | GPT reviews (third model). Writes `<!-- MARKER:sfl-analyzer-c -->` + verdict. Dispatches label-actions |
-| 5 | `sfl-pr-label-actions` | Analyzer C dispatch | Ready PR or fix cycle | `workflow_dispatch` | Reads `analyzer:blocked`, `human:ready-for-review` | Deterministic aggregator: if `analyzer:blocked` → removes label, dispatches issue-processor for fix. If all PASS → adds `human:ready-for-review`, flips draft → ready |
+| 0 | `repo-audit` / `simplisticate` | Repository state | GitHub Issue | `workflow_dispatch` | Adds `agent:fixable`, `action-item`, and risk label to new action items | Produces focused, agent-fixable follow-up issues from audit findings |
+| 1 | `issue-processor` | Issue with `agent:fixable` + `action-item` | Draft PR | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:fixable`; adds `agent:in-progress` to issue, `agent:pr` to PR | Claims the issue, implements the fix, and creates a draft PR |
+| 2 | `pr-analyzer-a` | Draft PR | PR review/comment marker | `pull_request: opened` / dispatch | Reads `agent:pr`, `pr:cycle-N` | First full-spectrum review pass. Writes `[MARKER:pr-analyzer-a cycle:N]` + verdict and dispatches Analyzer B |
+| 3 | `pr-analyzer-b` | Analyzer A dispatch | PR review/comment marker | `workflow_dispatch` | Reads `agent:pr`, `pr:cycle-N` | Second full-spectrum review pass. Writes `[MARKER:pr-analyzer-b cycle:N]` + verdict and dispatches Analyzer C |
+| 4 | `pr-analyzer-c` | Analyzer B dispatch | PR review/comment marker | `workflow_dispatch` | Reads `agent:pr`, `pr:cycle-N` | Final review pass. Writes `[MARKER:pr-analyzer-c cycle:N]` + verdict |
+| 5 | `pr-fixer` | Draft PR with analyzer findings | Updated draft PR | `workflow_dispatch` via `sfl-dispatcher` | Reads `agent:pr`, `pr:cycle-N`; advances cycle labels when fixes are applied | Applies analyzer feedback on the PR branch and leaves promotion to `pr-promoter` |
+| 6 | `pr-promoter` | Draft PR with all analyzer PASS verdicts | Ready PR or merged PR | `workflow_dispatch` via `sfl-dispatcher` | Adds `human:ready-for-review` after promotion; merges approved ready PRs | Converts clean draft PRs to ready-for-review and squash-merges approved ready PRs |
 
-**Background:** `sfl-auditor` runs daily (~5:57 AM EDT) to detect and repair state
+**Background:** `sfl-dispatcher` is the manual orchestration entry point for
+the SFL workflow set, and `sfl-auditor` detects and repairs state
 discrepancies (orphaned labels, stale in-progress issues, missing PRs, etc.).
 
 ---

--- a/docs/SCHEDULE.md
+++ b/docs/SCHEDULE.md
@@ -26,9 +26,9 @@ These fire in response to GitHub events, manual dispatches, or other workflows.
 |---|---|---|
 | Manual dispatch | **SFL Dispatcher** (`sfl-dispatcher.yml`) | Checks for queued SFL work and dispatches gh-aw workflows when useful |
 | Dispatcher / manual | **Issue Processor** (`issue-processor.lock.yml`) | Claims one eligible issue and creates a draft PR |
-| `pull_request: opened` / dispatcher | **PR Analyzer A** (`pr-analyzer-a.lock.yml`) | First full-spectrum review pass |
-| Analyzer A dispatch / dispatcher | **PR Analyzer B** (`pr-analyzer-b.lock.yml`) | Second full-spectrum review pass |
-| Analyzer B dispatch / dispatcher | **PR Analyzer C** (`pr-analyzer-c.lock.yml`) | Final full-spectrum review pass |
+| Dispatcher / manual | **PR Analyzer A** (`pr-analyzer-a.lock.yml`) | First full-spectrum review pass |
+| Dispatcher / manual | **PR Analyzer B** (`pr-analyzer-b.lock.yml`) | Second full-spectrum review pass |
+| Dispatcher / manual | **PR Analyzer C** (`pr-analyzer-c.lock.yml`) | Final full-spectrum review pass |
 | Dispatcher / manual | **PR Fixer** (`pr-fixer.lock.yml`) | Applies analyzer feedback and advances the review cycle |
 | Dispatcher / manual | **PR Promoter** (`pr-promoter.lock.yml`) | Promotes clean draft PRs or merges approved ready PRs |
 | Manual dispatch | **SFL Auditor** (`sfl-auditor.yml`) | Detects and repairs issue/PR state discrepancies |
@@ -39,14 +39,14 @@ These fire in response to GitHub events, manual dispatches, or other workflows.
 
 ```text
 Manual audit/report workflow dispatch
-  ↓ creates issue with agent:fixable
+  ↓ creates issue with agent:fixable + action-item
 SFL Dispatcher
   ↓ dispatches work only when there is useful queued state
 Issue Processor
   ↓ claims issue → creates branch + draft PR
   ↓ labels: agent:in-progress, agent:pr
-PR Analyzer A → B → C (sequential review chain)
-  ↓ each model reviews the PR
+SFL Dispatcher
+  ↓ dispatches PR Analyzer A, B, and C when review passes are missing
 PR Fixer
   ↓ applies analyzer feedback when needed
 PR Promoter

--- a/docs/SCHEDULE.md
+++ b/docs/SCHEDULE.md
@@ -24,12 +24,14 @@ These fire in response to GitHub events, manual dispatches, or other workflows.
 
 | Trigger | Workflow | What It Does |
 |---|---|---|
-| `discussion: labeled` | **Discussion Processor** | Groups Discussion findings into `agent:fixable` issues |
-| `issues: opened/reopened` or Analyzer C dispatch | **SFL Issue Processor** | Claims issue, creates branch + draft PR |
-| `pull_request: opened` | **Analyzer A** | First full-spectrum review pass (Model A) |
-| Analyzer A dispatch | **Analyzer B** | Second full-spectrum review pass (Model B) |
-| Analyzer B dispatch | **Analyzer C** | Final review pass; dispatches label-actions |
-| Analyzer C dispatch / manual | **SFL PR Label Actions** | Checks labels, flips draft → ready-for-review or triggers fix cycle |
+| Manual dispatch | **SFL Dispatcher** (`sfl-dispatcher.yml`) | Checks for queued SFL work and dispatches gh-aw workflows when useful |
+| Dispatcher / manual | **Issue Processor** (`issue-processor.lock.yml`) | Claims one eligible issue and creates a draft PR |
+| `pull_request: opened` / dispatcher | **PR Analyzer A** (`pr-analyzer-a.lock.yml`) | First full-spectrum review pass |
+| Analyzer A dispatch / dispatcher | **PR Analyzer B** (`pr-analyzer-b.lock.yml`) | Second full-spectrum review pass |
+| Analyzer B dispatch / dispatcher | **PR Analyzer C** (`pr-analyzer-c.lock.yml`) | Final full-spectrum review pass |
+| Dispatcher / manual | **PR Fixer** (`pr-fixer.lock.yml`) | Applies analyzer feedback and advances the review cycle |
+| Dispatcher / manual | **PR Promoter** (`pr-promoter.lock.yml`) | Promotes clean draft PRs or merges approved ready PRs |
+| Manual dispatch | **SFL Auditor** (`sfl-auditor.yml`) | Detects and repairs issue/PR state discrepancies |
 
 ---
 
@@ -38,13 +40,15 @@ These fire in response to GitHub events, manual dispatches, or other workflows.
 ```text
 Manual audit/report workflow dispatch
   ↓ creates issue with agent:fixable
-Discussion Processor (if from Discussion)
-  ↓ groups findings into agent:fixable issue
-SFL Issue Processor
+SFL Dispatcher
+  ↓ dispatches work only when there is useful queued state
+Issue Processor
   ↓ claims issue → creates branch + draft PR
   ↓ labels: agent:in-progress, agent:pr
-Analyzer A → B → C (sequential review chain)
+PR Analyzer A → B → C (sequential review chain)
   ↓ each model reviews the PR
-SFL PR Label Actions
-  ↓ ready-for-review  OR  fix cycle back to Processor
+PR Fixer
+  ↓ applies analyzer feedback when needed
+PR Promoter
+  ↓ ready-for-review  OR  squash-merge after approval
 ```

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -171,25 +171,24 @@ The operating model, workflow library, and governance live at:
 
 | # | Workflow | What it does |
 |---|---------|-------------|
-| 0 | `discussion-processor` | Audit findings → categorized GitHub Issues |
-| 1 | `sfl-issue-processor` | Issue → draft PR with implementation |
-| 2 | `sfl-analyzer-a` | Claude Sonnet code review (marker + verdict) |
-| 3 | `sfl-analyzer-b` | Claude Opus code review (marker + verdict) |
-| 4 | `sfl-analyzer-c` | GPT code review (marker + verdict) |
-| 5 | `sfl-pr-label-actions` | Aggregate verdicts → ready-for-review or fix cycle |
+| 0 | `repo-audit` / `simplisticate` | Audit findings → categorized GitHub Issues |
+| 1 | `sfl-dispatcher` | Dispatches SFL workflows only when useful queued work exists |
+| 2 | `issue-processor` | Issue → draft PR with implementation |
+| 3 | `pr-analyzer-a` | First full-spectrum PR review pass (marker + verdict) |
+| 4 | `pr-analyzer-b` | Second full-spectrum PR review pass (marker + verdict) |
+| 5 | `pr-analyzer-c` | Final full-spectrum PR review pass (marker + verdict) |
+| 6 | `pr-fixer` | Applies analyzer feedback and advances the review cycle |
+| 7 | `pr-promoter` | Promotes clean draft PRs and merges approved ready PRs |
 
 ### Supporting Workflows
 
 | Workflow | Cadence | Purpose |
 |---------|---------|---------|
-| `sfl-auditor` | Daily (~5:57 AM EDT) | Detects/repairs state discrepancies |
-| `sfl-queue-monitor` | Scheduled | Monitors agent queue depth |
-| `sfl-improve-scorecard` | On demand | Scorecard keyword detection improvements |
-| `daily-repo-status` | Daily | Repository health report |
-| `repo-audit` | Scheduled | Comprehensive code/config audit |
-| `simplisticate-audit` | Scheduled | Complexity reduction audit |
-| `test-coverage-audit` | Scheduled | Coverage gap analysis |
-| `react-doctor-audit` | Scheduled | React code health audit |
+| `sfl-auditor` | Manual dispatch | Detects/repairs state discrepancies |
+| `sfl-dispatcher` | Manual dispatch | Finds queued work and dispatches the relevant SFL workflow |
+| `daily-repo-status` | Manual dispatch | Repository health report |
+| `repo-audit` | Manual dispatch | Comprehensive documentation/config audit |
+| `simplisticate` | Manual dispatch | Complexity reduction audit |
 
 ---
 

--- a/docs/WORKFLOW-README.md
+++ b/docs/WORKFLOW-README.md
@@ -34,9 +34,9 @@ workflows when there is work to process.
 | `sfl-dispatcher.yml` | Manual dispatch | Checks whether SFL work exists and dispatches issue, analyzer, fixer, and promoter workflows when useful | Local |
 | `sfl-auditor.yml` | Manual dispatch | Detects and repairs issue/PR label discrepancies and stale SFL state | Local |
 | `issue-processor.md` / `.lock.yml` | Manual dispatch through dispatcher | Claims the oldest eligible `agent:fixable` + `action-item` issue and opens one draft PR | Local |
-| `pr-analyzer-a.md` / `.lock.yml` | Pull request opened or dispatcher | Starts the sequential A -> B -> C review chain for SFL draft PRs | Local |
-| `pr-analyzer-b.md` / `.lock.yml` | Analyzer A dispatch or dispatcher | Continues the sequential full-spectrum review chain | Local |
-| `pr-analyzer-c.md` / `.lock.yml` | Analyzer B dispatch or dispatcher | Finishes the review chain and records the final analyzer verdict | Local |
+| `pr-analyzer-a.md` / `.lock.yml` | Manual dispatch through dispatcher | Runs the first full-spectrum review pass for SFL draft PRs | Local |
+| `pr-analyzer-b.md` / `.lock.yml` | Manual dispatch through dispatcher | Runs the second full-spectrum review pass for SFL draft PRs | Local |
+| `pr-analyzer-c.md` / `.lock.yml` | Manual dispatch through dispatcher | Runs the final review pass and records the final analyzer verdict | Local |
 | `pr-fixer.md` / `.lock.yml` | Manual dispatch through dispatcher | Applies analyzer feedback to one draft PR branch and advances the review cycle | Local |
 | `pr-promoter.md` / `.lock.yml` | Manual dispatch through dispatcher | Promotes clean draft PRs to ready-for-review and merges approved ready PRs | Local |
 | `repo-audit.md` / `.lock.yml` | Manual dispatch | Repository documentation/configuration audit | [CATALOG](https://github.com/relias-engineering/set-it-free-loop/blob/main/CATALOG.md) |

--- a/docs/WORKFLOW-README.md
+++ b/docs/WORKFLOW-README.md
@@ -25,20 +25,23 @@ That repo contains:
 
 ## Workflows active in this repo
 
-| Workflow                                                | Schedule                                        | Output                                                                                                                   | Source                                                                                 |
-| ------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `react-doctor-audit` (`React Doctor Audit`)             | Daily ~1:17 AM EDT                              | Rolling React Doctor issue stream; older issues stay open while an active agent PR still depends on them                 | Local                                                                                  |
-| `test-coverage-audit` (`Test Coverage Audit`)           | Daily 7:17 AM EDT                               | Single `agent:fixable` test-coverage issue                                                                               | Local                                                                                  |
-| `simplisticate-audit` (`Simplisticate Audit`)           | Daily ~2:27 AM EDT                              | Single `agent:fixable` simplification issue                                                                              | Local                                                                                  |
-| `daily-repo-status` (`SFL Repo Status`)                 | Daily ~3:37 AM EDT                              | `report` Discussion                                                                                                      | [CATALOG](https://github.com/relias-engineering/set-it-free-loop/blob/main/CATALOG.md) |
-| `repo-audit` (`Repo Audit`)                             | Daily ~4:47 AM EDT                              | Single consolidated `agent:fixable` issue                                                                                | [CATALOG](https://github.com/relias-engineering/set-it-free-loop/blob/main/CATALOG.md) |
-| `sfl-improve-scorecard` (`Scorecard Improvement Audit`) | Daily ~5:37 AM EDT                              | Single `agent:fixable` scorecard improvement issue                                                                       | Local                                                                                  |
-| `sfl-auditor`                                           | Daily ~5:57 AM EDT                              | Repairs issue/PR label discrepancies                                                                                     | Local                                                                                  |
-| `sfl-implement` (`SFL Implementer`)                     | `issues: opened/reopened` + Analyzer C dispatch | Single implementer: claims new issues or advances existing draft PRs from analyzer feedback                              | Local                                                                                  |
-| `sfl-analyzer-a`                                        | `pull_request: opened`                          | Starts the sequential A -> B -> C review chain for draft PRs (Model A)                                                   | Local                                                                                  |
-| `sfl-analyzer-b`                                        | Analyzer A dispatch                             | Continues the sequential full-spectrum review chain (Model B)                                                            | Local                                                                                  |
-| `sfl-analyzer-c`                                        | Analyzer B dispatch                             | Finishes the sequential full-spectrum review chain; dispatches label-actions for ready-for-review or fix-cycle decisions | Local                                                                                  |
-| `sfl-gate` (`SFL Gate`)                                 | `issues: labeled` / Analyzer C dispatch / manual dispatch | Deterministic orchestrator: validates entry, dispatches implementer, aggregates verdicts, flips draft → ready-for-review | Local                                                                                  |
+Schedules are currently paused in this repository. The workflow files keep
+manual dispatch entry points, and `sfl-dispatcher.yml` can dispatch gh-aw
+workflows when there is work to process.
+
+| Workflow file | Trigger | Output | Source |
+| --- | --- | --- | --- |
+| `sfl-dispatcher.yml` | Manual dispatch | Checks whether SFL work exists and dispatches issue, analyzer, fixer, and promoter workflows when useful | Local |
+| `sfl-auditor.yml` | Manual dispatch | Detects and repairs issue/PR label discrepancies and stale SFL state | Local |
+| `issue-processor.md` / `.lock.yml` | Manual dispatch through dispatcher | Claims the oldest eligible `agent:fixable` + `action-item` issue and opens one draft PR | Local |
+| `pr-analyzer-a.md` / `.lock.yml` | Pull request opened or dispatcher | Starts the sequential A -> B -> C review chain for SFL draft PRs | Local |
+| `pr-analyzer-b.md` / `.lock.yml` | Analyzer A dispatch or dispatcher | Continues the sequential full-spectrum review chain | Local |
+| `pr-analyzer-c.md` / `.lock.yml` | Analyzer B dispatch or dispatcher | Finishes the review chain and records the final analyzer verdict | Local |
+| `pr-fixer.md` / `.lock.yml` | Manual dispatch through dispatcher | Applies analyzer feedback to one draft PR branch and advances the review cycle | Local |
+| `pr-promoter.md` / `.lock.yml` | Manual dispatch through dispatcher | Promotes clean draft PRs to ready-for-review and merges approved ready PRs | Local |
+| `repo-audit.md` / `.lock.yml` | Manual dispatch | Repository documentation/configuration audit | [CATALOG](https://github.com/relias-engineering/set-it-free-loop/blob/main/CATALOG.md) |
+| `simplisticate.md` / `.lock.yml` | Manual dispatch | Code simplification audit and action-item creation | Local |
+| `daily-repo-status.md` / `.lock.yml` | Manual dispatch | Repository status report | [CATALOG](https://github.com/relias-engineering/set-it-free-loop/blob/main/CATALOG.md) |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.835",
+  "version": "0.1.836",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.834",
+  "version": "0.1.835",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #212

## Summary
- refresh SFL workflow catalog references in docs and prompts to match the current workflow files
- replace stale `sfl-gate`, `sfl-implement`, `sfl-pr-label-actions`, and old analyzer names with dispatcher, processor, analyzer, fixer, and promoter names
- keep generated workflow lockfiles untouched

## Verification
- `rg -n "sfl-gate|sfl-implement|sfl-pr-label-actions|sfl-analyzer-a|sfl-analyzer-b|sfl-analyzer-c|react-doctor-audit|test-coverage-audit|sfl-improve-scorecard|sfl-loop|SFL PR Label Actions|PR Router|PR Label Actions" docs .github/prompts .sfl --glob '!docs/archive/**'` -> exit 1, no matches
- `bunx markdownlint-cli2 "docs/WORKFLOW-README.md" "docs/GOAL-AND-GUIDING-PRINCIPLES.md" "docs/SCHEDULE.md" "docs/VISION.md" ".sfl/INTAKE.md" ".github/prompts/status.prompt.md" ".github/prompts/health.prompt.md"` -> 0 errors
- `git diff --check` -> exit 0
- pre-commit hook: lint-staged Markdown checks passed
- pre-commit hook: Markdown quality checks passed
- pre-commit hook: `vitest run --coverage` -> 287 files passed, 6427 tests passed
- pre-commit hook: TypeScript checks passed for browser, node, scripts, convex, and apphost configs
- pre-commit hook: coverage ratchet passed

## Notes
- The isolated worktree's post-commit Code Index hook emitted `Index directory ...\.codeindex does not exist. Run codeindex init first.` after the commit amend, but the commit command exited 0 and the branch is clean.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Refresh SFL workflow references across docs to reflect dispatcher-driven pipeline
> - Updates all documentation and prompt files to replace legacy workflows (`sfl-gate`, `sfl-implement`, `sfl-analyzers`) with the current set: `sfl-dispatcher`, `issue-processor`, `pr-analyzer-{a,b,c}`, `pr-fixer`, and `pr-promoter`.
> - Revises [INTAKE.md](.sfl/INTAKE.md), [GOAL-AND-GUIDING-PRINCIPLES.md](docs/GOAL-AND-GUIDING-PRINCIPLES.md), [VISION.md](docs/VISION.md), [SCHEDULE.md](docs/SCHEDULE.md), and [WORKFLOW-README.md](docs/WORKFLOW-README.md) to describe the dispatcher-driven flow where `sfl-dispatcher` manually orchestrates work and `sfl-auditor` handles state repair.
> - Updates intake requirements in prompt files and [INTAKE.md](.sfl/INTAKE.md) to require both `agent:fixable` and `action-item` labels for issue pickup.
> - Bumps version to `0.1.836` in [package.json](package.json).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ecf115.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->