### PR TITLE
test: cover performance audit gaps

### DIFF
--- a/.agents/skills/performance/SKILL.md
+++ b/.agents/skills/performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance
-description: "V1.0 - Commands: Run, Compare, Gaps. Runs vitest benchmarks, compares against baseline, flags regressions, and identifies uncovered code paths. Use when checking performance, adding benchmarks, or validating no degradation after changes."
+description: 'V1.0 - Commands: Run, Compare, Gaps. Runs vitest benchmarks, compares against baseline, flags regressions, and identifies uncovered code paths. Use when checking performance, adding benchmarks, or validating no degradation after changes.'
 ---
 
 # Performance
@@ -47,18 +47,22 @@ Report a table of uncovered functions with file path, function name, and priorit
 
 ## Benchmark Files
 
-| File | Covers |
-|------|--------|
-| `src/utils/dateUtils.bench.ts` | formatDistanceToNow, format, formatDateKey, formatDuration, formatUptime, formatDateFull, formatDateCompact, formatHour12 |
-| `src/services/jsonSerialization.bench.ts` | JSON.stringify/parse at 10/100/1000 entries, cache entry lookup |
+| File                                               | Covers                                                                                                                                             |
+| -------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/utils/dateUtils.bench.ts`                     | formatDistanceToNow, format, formatDateKey, formatDuration, formatUptime, formatDateFull, formatDateCompact, formatHour12                          |
+| `src/services/jsonSerialization.bench.ts`          | JSON.stringify/parse at 10/100/1000 entries, cache entry lookup                                                                                    |
 | `electron/services/copilotSessionParsing.bench.ts` | getSessionDetail streaming parse (10/100/500 requests), regex extraction hot path (scanInfo, JSON.parse, regex fallback, kind detection, key path) |
-| `src/components/copilot-usage/quotaUtils.bench.ts` | computeProjection (4 scenarios: mid-cycle, early, near-reset, zero remaining) |
-| `src/services/taskQueue.bench.ts` | enqueue+drain (serial, concurrent, mixed priority), cancel, priority insertion |
-| `src/utils/reactions.bench.ts` | applyReactionToResult (small/medium/large PR, miss, new reaction type) |
-| `convex/lib/cronUtils.bench.ts` | calculateNextRunAt (6 cron patterns including timezone) |
-| `src/utils/budgetUtils.bench.ts` | findCopilotBudget (5/50/200 budgets, with/without filter), findBudgetAcrossPages (1/3/5 pages) |
-| `src/components/tempo/tempoUtils.bench.ts` | nextStartTime (3/10/50 worklogs) |
-| `electron/services/copilotSessionService.bench.ts` | resolveWorkspaceName (single-folder, multi-root, encoded URI, empty JSON fallback, missing file catch path) |
+| `src/components/copilot-usage/quotaUtils.bench.ts` | computeProjection (4 scenarios: mid-cycle, early, near-reset, zero remaining)                                                                      |
+| `src/services/taskQueue.bench.ts`                  | enqueue+drain (serial, concurrent, mixed priority), cancel, priority insertion                                                                     |
+| `src/utils/reactions.bench.ts`                     | applyReactionToResult (small/medium/large PR, miss, new reaction type)                                                                             |
+| `convex/lib/cronUtils.bench.ts`                    | calculateNextRunAt (6 cron patterns including timezone)                                                                                            |
+| `src/utils/budgetUtils.bench.ts`                   | findCopilotBudget (5/50/200 budgets, with/without filter), findBudgetAcrossPages (1/3/5 pages)                                                     |
+| `src/components/tempo/tempoUtils.bench.ts`         | nextStartTime (3/10/50 worklogs)                                                                                                                   |
+| `electron/services/copilotSessionService.bench.ts` | resolveWorkspaceName (single-folder, multi-root, encoded URI, empty JSON fallback, missing file catch path)                                        |
+| `perf/ipc-throughput.bench.ts`                     | ipcHandler dispatch overhead with small/medium/large payloads and error path, JSON serialization and round-trip payload simulation                 |
+| `src/utils/billingParsers.bench.ts`                | parseBillingUsage (25/250/1000 items), settled-result billing JSON parsing, overage and assembled metrics helpers                                  |
+| `src/utils/sessionDigest.bench.ts`                 | aggregateResults (10/100/500 requests), countSearchChurn, computeDominantTools, computeSessionDigest                                               |
+| `src/utils/copilotEnterpriseUsers.bench.ts`        | parseCopilotEnterpriseUsersContent with BOM, normalizeCopilotEnterpriseUsersSnapshot for nested and direct aggregate user payloads                 |
 
 ## Baseline (2026-06-26, refresh #3)
 
@@ -67,130 +71,184 @@ Vitest packages are pinned to 4.1.5 in `package.json` and `bun.lock`; refresh th
 
 ### dateUtils
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| formatDistanceToNow — recent timestamp | 8,300,100 | 0.0001 |
-| formatDistanceToNow — old timestamp | 8,530,604 | 0.0001 |
-| formatDistanceToNow — string date | 3,815,798 | 0.0003 |
-| formatDistanceToNow — Date object | 6,864,482 | 0.0001 |
-| format — yyyy-MM-dd | 2,343,776 | 0.0004 |
-| format — MMMM dd, yyyy HH:mm:ss | 1,804,986 | 0.0006 |
-| format — MMM d, yyyy h:mm a | 1,831,093 | 0.0005 |
-| format — timestamp input | 1,730,055 | 0.0006 |
-| formatDateKey | 7,142,922 | 0.0001 |
-| formatDuration — milliseconds | 25,176,673 | 0.0001 |
-| formatDuration — seconds | 11,311,410 | 0.0001 |
-| formatDuration — minutes | 24,463,938 | 0.0001 |
-| formatUptime — seconds | 24,672,901 | 0.0001 |
-| formatUptime — hours and minutes | 24,343,726 | 0.0001 |
-| formatUptime — days and hours | 24,888,753 | 0.0001 |
-| formatDateFull — timestamp | 38,046 | 0.0263 |
-| formatDateFull — string | 37,285 | 0.0268 |
-| formatDateFull — null | 25,303,864 | 0.0001 |
-| formatDateCompact — timestamp | 38,440 | 0.0260 |
-| formatHour12 — all 24 hours | 5,388,644 | 0.0002 |
+| Benchmark                              | ops/sec (hz) | mean (ms) |
+| -------------------------------------- | ------------ | --------- |
+| formatDistanceToNow — recent timestamp | 8,300,100    | 0.0001    |
+| formatDistanceToNow — old timestamp    | 8,530,604    | 0.0001    |
+| formatDistanceToNow — string date      | 3,815,798    | 0.0003    |
+| formatDistanceToNow — Date object      | 6,864,482    | 0.0001    |
+| format — yyyy-MM-dd                    | 2,343,776    | 0.0004    |
+| format — MMMM dd, yyyy HH:mm:ss        | 1,804,986    | 0.0006    |
+| format — MMM d, yyyy h:mm a            | 1,831,093    | 0.0005    |
+| format — timestamp input               | 1,730,055    | 0.0006    |
+| formatDateKey                          | 7,142,922    | 0.0001    |
+| formatDuration — milliseconds          | 25,176,673   | 0.0001    |
+| formatDuration — seconds               | 11,311,410   | 0.0001    |
+| formatDuration — minutes               | 24,463,938   | 0.0001    |
+| formatUptime — seconds                 | 24,672,901   | 0.0001    |
+| formatUptime — hours and minutes       | 24,343,726   | 0.0001    |
+| formatUptime — days and hours          | 24,888,753   | 0.0001    |
+| formatDateFull — timestamp             | 38,046       | 0.0263    |
+| formatDateFull — string                | 37,285       | 0.0268    |
+| formatDateFull — null                  | 25,303,864   | 0.0001    |
+| formatDateCompact — timestamp          | 38,440       | 0.0260    |
+| formatHour12 — all 24 hours            | 5,388,644    | 0.0002    |
 
 ### jsonSerialization
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| JSON.stringify — 10 entries | 219,253 | 0.0046 |
-| JSON.stringify — 100 entries | 21,086 | 0.0474 |
-| JSON.stringify — 1000 entries | 1,649 | 0.6063 |
-| JSON.parse — 10 entries | 133,187 | 0.0075 |
-| JSON.parse — 100 entries | 13,278 | 0.0753 |
-| JSON.parse — 1000 entries | 1,254 | 0.7977 |
-| cache entry lookup (1000 entries) | 1,234 | 0.8104 |
+| Benchmark                         | ops/sec (hz) | mean (ms) |
+| --------------------------------- | ------------ | --------- |
+| JSON.stringify — 10 entries       | 219,253      | 0.0046    |
+| JSON.stringify — 100 entries      | 21,086       | 0.0474    |
+| JSON.stringify — 1000 entries     | 1,649        | 0.6063    |
+| JSON.parse — 10 entries           | 133,187      | 0.0075    |
+| JSON.parse — 100 entries          | 13,278       | 0.0753    |
+| JSON.parse — 1000 entries         | 1,254        | 0.7977    |
+| cache entry lookup (1000 entries) | 1,234        | 0.8104    |
 
 ### copilotSessionParsing
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| getSessionDetail — 10 requests | 12,237 | 0.0817 |
-| getSessionDetail — 100 requests | 3,389 | 0.2951 |
-| getSessionDetail — 500 requests | 634 | 1.5779 |
-| extractScanInfo regexes | 2,741,559 | 0.0004 |
-| extractResultData JSON.parse | 1,099,546 | 0.0009 |
-| extractResultData regex fallback | 11,517,732 | 0.0001 |
-| kind detection regex | 13,026,773 | 0.0001 |
-| key path extraction regex | 10,871,368 | 0.0001 |
+| Benchmark                        | ops/sec (hz) | mean (ms) |
+| -------------------------------- | ------------ | --------- |
+| getSessionDetail — 10 requests   | 12,237       | 0.0817    |
+| getSessionDetail — 100 requests  | 3,389        | 0.2951    |
+| getSessionDetail — 500 requests  | 634          | 1.5779    |
+| extractScanInfo regexes          | 2,741,559    | 0.0004    |
+| extractResultData JSON.parse     | 1,099,546    | 0.0009    |
+| extractResultData regex fallback | 11,517,732   | 0.0001    |
+| kind detection regex             | 13,026,773   | 0.0001    |
+| key path extraction regex        | 10,871,368   | 0.0001    |
 
 ### quotaUtils
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| computeProjection — mid-cycle with overage | 2,837,512 | 0.0004 |
-| computeProjection — early cycle low usage | 2,874,755 | 0.0003 |
-| computeProjection — near-reset heavy usage | 2,644,847 | 0.0004 |
-| computeProjection — zero remaining | 2,784,350 | 0.0004 |
+| Benchmark                                  | ops/sec (hz) | mean (ms) |
+| ------------------------------------------ | ------------ | --------- |
+| computeProjection — mid-cycle with overage | 2,837,512    | 0.0004    |
+| computeProjection — early cycle low usage  | 2,874,755    | 0.0003    |
+| computeProjection — near-reset heavy usage | 2,644,847    | 0.0004    |
+| computeProjection — zero remaining         | 2,784,350    | 0.0004    |
 
 ### taskQueue
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| enqueue 10 tasks (serial) | 242,353 | 0.0041 |
-| enqueue 10 tasks (concurrent=5) | 216,733 | 0.0046 |
-| enqueue 50 tasks (mixed priority) | 46,895 | 0.0213 |
-| cancel 10 of 20 pending | 6,476 | 0.1544 |
-| insert 100 prioritized tasks | 37,910 | 0.0264 |
+| Benchmark                         | ops/sec (hz) | mean (ms) |
+| --------------------------------- | ------------ | --------- |
+| enqueue 10 tasks (serial)         | 242,353      | 0.0041    |
+| enqueue 10 tasks (concurrent=5)   | 216,733      | 0.0046    |
+| enqueue 50 tasks (mixed priority) | 46,895       | 0.0213    |
+| cancel 10 of 20 pending           | 6,476        | 0.1544    |
+| insert 100 prioritized tasks      | 37,910       | 0.0264    |
 
 ### reactions
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| applyReaction — small PR (9 comments) | 7,035,854 | 0.0001 |
-| applyReaction — medium PR (53 comments) | 2,509,577 | 0.0004 |
-| applyReaction — large PR (303 comments) | 625,380 | 0.0016 |
-| applyReaction — miss (not found) | 3,189,610 | 0.0003 |
-| applyReaction — add new type | 2,520,882 | 0.0004 |
+| Benchmark                               | ops/sec (hz) | mean (ms) |
+| --------------------------------------- | ------------ | --------- |
+| applyReaction — small PR (9 comments)   | 7,035,854    | 0.0001    |
+| applyReaction — medium PR (53 comments) | 2,509,577    | 0.0004    |
+| applyReaction — large PR (303 comments) | 625,380      | 0.0016    |
+| applyReaction — miss (not found)        | 3,189,610    | 0.0003    |
+| applyReaction — add new type            | 2,520,882    | 0.0004    |
 
 ### cronUtils
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| calculateNextRunAt — every minute | 18,631 | 0.0537 |
-| calculateNextRunAt — every 5 minutes | 17,322 | 0.0577 |
-| calculateNextRunAt — daily at midnight | 34,507 | 0.0290 |
-| calculateNextRunAt — weekdays at 9am | 15,309 | 0.0653 |
-| calculateNextRunAt — complex | 39,383 | 0.0254 |
-| calculateNextRunAt — no timezone (UTC) | 62,718 | 0.0159 |
+| Benchmark                              | ops/sec (hz) | mean (ms) |
+| -------------------------------------- | ------------ | --------- |
+| calculateNextRunAt — every minute      | 18,631       | 0.0537    |
+| calculateNextRunAt — every 5 minutes   | 17,322       | 0.0577    |
+| calculateNextRunAt — daily at midnight | 34,507       | 0.0290    |
+| calculateNextRunAt — weekdays at 9am   | 15,309       | 0.0653    |
+| calculateNextRunAt — complex           | 39,383       | 0.0254    |
+| calculateNextRunAt — no timezone (UTC) | 62,718       | 0.0159    |
 
 ### budgetUtils
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| findCopilotBudget — 5 budgets | 11,310,276 | 0.0001 |
-| findCopilotBudget — 50 budgets | 2,855,225 | 0.0004 |
-| findCopilotBudget — 200 budgets | 529,934 | 0.0019 |
-| findCopilotBudget — 50 w/ filter (match) | 944,346 | 0.0011 |
-| findCopilotBudget — 50 w/ filter (no match) | 1,289,115 | 0.0008 |
-| findBudgetAcrossPages — found page 1 | 916,082 | 0.0011 |
-| findBudgetAcrossPages — found page 3 of 5 | 286,275 | 0.0035 |
-| findBudgetAcrossPages — not found (5 pages) | 191,442 | 0.0052 |
+| Benchmark                                   | ops/sec (hz) | mean (ms) |
+| ------------------------------------------- | ------------ | --------- |
+| findCopilotBudget — 5 budgets               | 11,310,276   | 0.0001    |
+| findCopilotBudget — 50 budgets              | 2,855,225    | 0.0004    |
+| findCopilotBudget — 200 budgets             | 529,934      | 0.0019    |
+| findCopilotBudget — 50 w/ filter (match)    | 944,346      | 0.0011    |
+| findCopilotBudget — 50 w/ filter (no match) | 1,289,115    | 0.0008    |
+| findBudgetAcrossPages — found page 1        | 916,082      | 0.0011    |
+| findBudgetAcrossPages — found page 3 of 5   | 286,275      | 0.0035    |
+| findBudgetAcrossPages — not found (5 pages) | 191,442      | 0.0052    |
 
 ### tempoUtils
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| nextStartTime — 3 worklogs | 15,372,925 | 0.0001 |
-| nextStartTime — 10 worklogs | 14,841,679 | 0.0001 |
-| nextStartTime — 50 worklogs | 11,595,382 | 0.0001 |
+| Benchmark                   | ops/sec (hz) | mean (ms) |
+| --------------------------- | ------------ | --------- |
+| nextStartTime — 3 worklogs  | 15,372,925   | 0.0001    |
+| nextStartTime — 10 worklogs | 14,841,679   | 0.0001    |
+| nextStartTime — 50 worklogs | 11,595,382   | 0.0001    |
 
 ### copilotSessionService
 
-| Benchmark | ops/sec (hz) | mean (ms) |
-|-----------|-------------|-----------|
-| resolveWorkspaceName — single-folder workspace | 21,247 | 0.0471 |
-| resolveWorkspaceName — multi-root workspace | 21,951 | 0.0456 |
-| resolveWorkspaceName — encoded URI with spaces | 21,729 | 0.0460 |
-| resolveWorkspaceName — empty JSON (fallback to dirname) | 23,739 | 0.0421 |
-| resolveWorkspaceName — missing file (catch path) | 72,182 | 0.0139 |
+| Benchmark                                               | ops/sec (hz) | mean (ms) |
+| ------------------------------------------------------- | ------------ | --------- |
+| resolveWorkspaceName — single-folder workspace          | 21,247       | 0.0471    |
+| resolveWorkspaceName — multi-root workspace             | 21,951       | 0.0456    |
+| resolveWorkspaceName — encoded URI with spaces          | 21,729       | 0.0460    |
+| resolveWorkspaceName — empty JSON (fallback to dirname) | 23,739       | 0.0421    |
+| resolveWorkspaceName — missing file (catch path)        | 72,182       | 0.0139    |
+
+### ipcThroughput
+
+| Benchmark                          | ops/sec (hz) | mean (ms) |
+| ---------------------------------- | ------------ | --------- |
+| ipcHandler — small payload (~50B)  | 7,601,154    | 0.0001    |
+| ipcHandler — medium payload (~5KB) | 7,842,368    | 0.0001    |
+| ipcHandler — large payload (~50KB) | 7,775,872    | 0.0001    |
+| ipcHandler — error path            | 188,571      | 0.0053    |
+| JSON serialize — small payload     | 8,882,396    | 0.0001    |
+| JSON serialize — medium payload    | 121,951      | 0.0082    |
+| JSON serialize — large payload     | 7,997        | 0.1250    |
+| JSON round-trip — small payload    | 3,115,423    | 0.0003    |
+| JSON round-trip — medium payload   | 42,089       | 0.0238    |
+| JSON round-trip — large payload    | 2,744        | 0.3644    |
+
+### billingParsers
+
+| Benchmark                                   | ops/sec (hz) | mean (ms) |
+| ------------------------------------------- | ------------ | --------- |
+| parseBillingUsage — 25 billing items        | 1,445,283    | 0.0007    |
+| parseBillingUsage — 250 billing items       | 155,331      | 0.0064    |
+| parseBillingUsage — 1000 billing items      | 38,284       | 0.0261    |
+| extractCopilotSpend — 250 items JSON stdout | 8,630        | 0.1159    |
+| extractBudgetFromResult — two budgets       | 1,873,795    | 0.0005    |
+| computeOverageSpend — premium snapshot      | 16,269,729   | 0.0001    |
+| assembleCopilotMetrics — success payload    | 25,245,072   | 0.0000    |
+
+### sessionDigest
+
+| Benchmark                                 | ops/sec (hz) | mean (ms) |
+| ----------------------------------------- | ------------ | --------- |
+| aggregateResults — 10 requests            | 4,233,826    | 0.0002    |
+| aggregateResults — 100 requests           | 739,057      | 0.0014    |
+| aggregateResults — 500 requests           | 153,694      | 0.0065    |
+| countSearchChurn — 500 requests           | 145,032      | 0.0069    |
+| computeDominantTools — 500 requests       | 92,630       | 0.0108    |
+| computeSessionDigest — 100-request digest | 206,229      | 0.0048    |
+
+### copilotEnterpriseUsers
+
+| Benchmark                                                            | ops/sec (hz) | mean (ms) |
+| -------------------------------------------------------------------- | ------------ | --------- |
+| parseCopilotEnterpriseUsersContent — 100 nested users JSON with BOM  | 3,281        | 0.3048    |
+| normalizeCopilotEnterpriseUsersSnapshot — 10 nested users            | 22,503       | 0.0444    |
+| normalizeCopilotEnterpriseUsersSnapshot — 100 nested users           | 2,253        | 0.4438    |
+| normalizeCopilotEnterpriseUsersSnapshot — 500 nested users           | 436          | 2.2919    |
+| normalizeCopilotEnterpriseUsersSnapshot — 500 direct aggregate users | 3,651        | 0.2739    |
 
 ## Known Coverage Gaps
 
 Functions that should have benchmarks but don't yet. Address these when touching the related code.
 
-No known gaps. Run the **Gaps** check to scan for new uncovered functions.
+| File                              | Priority | Notes                                                                                             |
+| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------- |
+| `src/utils/financeCalc.ts`        | Medium   | Finance aggregation and projection helpers should get focused benchmarks before broad changes.    |
+| `src/utils/networkSecurity.ts`    | Medium   | URL validation and security classification paths are worth benchmarking before further hardening. |
+| `src/utils/terminalPathUtils.ts`  | Low      | Path parsing helpers are pure and currently lower throughput risk.                                |
+| `src/utils/featureIntakeUtils.ts` | Low      | Intake formatting helpers are pure and lower frequency.                                           |
+| `src/utils/scheduleUtils.ts`      | Low      | Schedule display helpers are pure and lower frequency.                                            |
 
 ## Updating the Baseline
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.846] - 2026-06-27
+
+### Added
+
+- Add benchmark coverage for performance audit gaps
+
+### Changed
+
+- Cover performance audit gaps
+
 ## [0.1.845] - 2026-06-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.845",
+  "version": "0.1.846",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/perf/ipc-throughput.bench.ts
+++ b/perf/ipc-throughput.bench.ts
@@ -11,17 +11,7 @@
  * @vitest-environment node
  */
 import { bench, describe } from 'vitest'
-
-// Simulate the ipcHandler wrapper pattern from electron/ipc/ipcHandler.ts
-function ipcHandlerSim<A extends unknown[], T>(fn: (...args: A) => Promise<T>) {
-  return async (...args: A): Promise<T | { success: false; error: string }> => {
-    try {
-      return await fn(...args)
-    } catch (error: unknown) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) }
-    }
-  }
-}
+import { ipcHandler } from '../electron/ipc/ipcHandler'
 
 // Simulate typical handler payloads with fixed data for deterministic benchmarks
 const FIXED_TIMESTAMP = 1_700_000_000_000
@@ -45,27 +35,28 @@ const largePayload = {
 }
 
 describe('IPC handler dispatch overhead', () => {
-  const fastHandler = ipcHandlerSim(async () => smallPayload)
-  const mediumHandler = ipcHandlerSim(async () => mediumPayload)
-  const largeHandler = ipcHandlerSim(async () => largePayload)
-  const errorHandler = ipcHandlerSim(async () => {
+  const event = {} as Parameters<ReturnType<typeof ipcHandler>>[0]
+  const fastHandler = ipcHandler(async () => smallPayload)
+  const mediumHandler = ipcHandler(async () => mediumPayload)
+  const largeHandler = ipcHandler(async () => largePayload)
+  const errorHandler = ipcHandler(async () => {
     throw new Error('simulated failure')
   })
 
   bench('small payload (~50B)', async () => {
-    await fastHandler()
+    await fastHandler(event)
   })
 
   bench('medium payload (~5KB)', async () => {
-    await mediumHandler()
+    await mediumHandler(event)
   })
 
   bench('large payload (~50KB)', async () => {
-    await largeHandler()
+    await largeHandler(event)
   })
 
   bench('error path', async () => {
-    await errorHandler()
+    await errorHandler(event)
   })
 })
 

--- a/src/utils/billingParsers.bench.ts
+++ b/src/utils/billingParsers.bench.ts
@@ -1,0 +1,114 @@
+import { bench, describe } from 'vitest'
+import {
+  assembleCopilotMetrics,
+  computeOverageSpend,
+  extractBudgetFromResult,
+  extractCopilotSpend,
+  parseBillingUsage,
+  type BillingUsageItem,
+} from './billingParsers'
+
+function makeBillingItem(
+  index: number,
+  overrides: Partial<BillingUsageItem> = {}
+): BillingUsageItem {
+  return {
+    date: '2026-06-01',
+    product: 'copilot',
+    sku: 'Copilot AI Credits',
+    quantity: 10 + (index % 7),
+    unitType: 'credit',
+    pricePerUnit: 0.01,
+    grossAmount: 0.1 + index * 0.001,
+    discountAmount: index % 3 === 0 ? 0.01 : 0,
+    netAmount: 0.09 + index * 0.001,
+    organizationName: `org-${index % 5}`,
+    repositoryName: `repo-${index}`,
+    ...overrides,
+  }
+}
+
+function makeBillingItems(count: number): BillingUsageItem[] {
+  return Array.from({ length: count }, (_, index) => {
+    if (index % 20 === 0) {
+      return makeBillingItem(index, {
+        sku: index % 40 === 0 ? 'Copilot Enterprise' : 'Copilot Business',
+        quantity: 5,
+        unitType: 'seat',
+      })
+    }
+    if (index % 11 === 0) return makeBillingItem(index, { product: 'actions' })
+    return makeBillingItem(index)
+  })
+}
+
+function stdoutResult(json: unknown): PromiseSettledResult<{ stdout: string }> {
+  return { status: 'fulfilled', value: { stdout: JSON.stringify(json) } }
+}
+
+const smallUsage = makeBillingItems(25)
+const mediumUsage = makeBillingItems(250)
+const largeUsage = makeBillingItems(1000)
+const mediumUsageResult = stdoutResult({ usageItems: mediumUsage })
+const budgetResult = stdoutResult({
+  budgets: [
+    { budget_product_sku: 'actions_minutes', budget_amount: 100, prevent_further_usage: false },
+    {
+      budget_product_sku: 'copilot_premium_requests',
+      budget_amount: 500,
+      prevent_further_usage: true,
+    },
+  ],
+})
+const quotaOverage = {
+  quota_snapshots: {
+    premium_interactions: {
+      overage_count: 125,
+      remaining: -200,
+    },
+  },
+}
+const usage = parseBillingUsage(mediumUsage)
+
+describe('parseBillingUsage', () => {
+  bench('25 billing items', () => {
+    parseBillingUsage(smallUsage)
+  })
+
+  bench('250 billing items', () => {
+    parseBillingUsage(mediumUsage)
+  })
+
+  bench('1000 billing items', () => {
+    parseBillingUsage(largeUsage)
+  })
+})
+
+describe('billing API settled-result parsing', () => {
+  bench('extractCopilotSpend — 250 items JSON stdout', () => {
+    extractCopilotSpend(mediumUsageResult)
+  })
+
+  bench('extractBudgetFromResult — two budgets', () => {
+    extractBudgetFromResult(budgetResult)
+  })
+})
+
+describe('billing derived metrics', () => {
+  bench('computeOverageSpend — premium snapshot', () => {
+    computeOverageSpend(quotaOverage)
+  })
+
+  bench('assembleCopilotMetrics — success payload', () => {
+    assembleCopilotMetrics({
+      org: 'HemSoft',
+      usageOk: true,
+      usage,
+      budgetAmount: 500,
+      spent: 42.25,
+      month: 6,
+      year: 2026,
+      fetchedAt: 1_782_432_000_000,
+    })
+  })
+})

--- a/src/utils/copilotEnterpriseUsers.bench.ts
+++ b/src/utils/copilotEnterpriseUsers.bench.ts
@@ -1,0 +1,87 @@
+import { bench, describe } from 'vitest'
+import {
+  normalizeCopilotEnterpriseUsersSnapshot,
+  parseCopilotEnterpriseUsersContent,
+} from './copilotEnterpriseUsers'
+
+function makeNestedUser(index: number) {
+  return {
+    User: `user-${String(index).padStart(4, '0')}`,
+    Success: index % 17 !== 0,
+    Responses: Array.from({ length: 3 }, (_, day) => ({
+      Day: day + 1,
+      Response: {
+        usageItems: Array.from({ length: 4 }, (_, item) => ({
+          model: item % 2 === 0 ? 'Claude Opus 4.8' : 'GPT-5.4 Codex',
+          grossQuantity: index + day + item,
+          grossAmount: (index + day + item) * 0.01,
+          netAmount: (index + day + item) * 0.005,
+        })),
+      },
+    })),
+  }
+}
+
+function makeDirectUser(index: number) {
+  return {
+    login: `direct-user-${String(index).padStart(4, '0')}`,
+    grossQuantity: index * 3,
+    grossAmount: index * 0.03,
+    netAmount: index * 0.01,
+    topModel: index % 2 === 0 ? 'Claude Sonnet 4.5' : 'GPT-5.4 Codex',
+  }
+}
+
+function makeNestedSnapshot(userCount: number) {
+  return {
+    GeneratedAtUtc: '2026-06-26T12:00:00.000Z',
+    Enterprise: 'bertelsmann',
+    Organization: 'Relias-Engineering',
+    Year: 2026,
+    Month: 6,
+    Days: [1, 2, 3],
+    Users: Array.from({ length: userCount }, (_, index) => makeNestedUser(index)),
+  }
+}
+
+function makeDirectSnapshot(userCount: number) {
+  return {
+    generatedAtUtc: '2026-06-26T12:00:00.000Z',
+    org: 'HemSoft',
+    users: Array.from({ length: userCount }, (_, index) => makeDirectUser(index)),
+  }
+}
+
+const metadata = {
+  sourceFile: 'D:\\github\\HemSoft\\codexbar\\data\\copilot-metrics.json',
+  fileLastWriteTime: '2026-06-26T12:00:00.000Z',
+}
+const nested10 = makeNestedSnapshot(10)
+const nested100 = makeNestedSnapshot(100)
+const nested500 = makeNestedSnapshot(500)
+const direct500 = makeDirectSnapshot(500)
+const nested100Json = `\uFEFF${JSON.stringify(nested100)}`
+
+describe('parseCopilotEnterpriseUsersContent', () => {
+  bench('100 nested users JSON with BOM', () => {
+    parseCopilotEnterpriseUsersContent(nested100Json)
+  })
+})
+
+describe('normalizeCopilotEnterpriseUsersSnapshot', () => {
+  bench('10 nested users', () => {
+    normalizeCopilotEnterpriseUsersSnapshot(nested10, metadata)
+  })
+
+  bench('100 nested users', () => {
+    normalizeCopilotEnterpriseUsersSnapshot(nested100, metadata)
+  })
+
+  bench('500 nested users', () => {
+    normalizeCopilotEnterpriseUsersSnapshot(nested500, metadata)
+  })
+
+  bench('500 direct aggregate users', () => {
+    normalizeCopilotEnterpriseUsersSnapshot(direct500, metadata)
+  })
+})

--- a/src/utils/sessionDigest.bench.ts
+++ b/src/utils/sessionDigest.bench.ts
@@ -1,0 +1,86 @@
+import { bench, describe } from 'vitest'
+import {
+  aggregateResults,
+  computeDominantTools,
+  computeSessionDigest,
+  countSearchChurn,
+} from './sessionDigest'
+import type { SessionModelInfo, SessionRequestResult } from '../types/copilotSession'
+
+const toolPool = [
+  'edit',
+  'grep_search',
+  'semantic_search',
+  'file_search',
+  'terminal',
+  'apply_patch',
+]
+
+function makeResults(count: number): SessionRequestResult[] {
+  return Array.from({ length: count }, (_, index) => ({
+    prompt: `Investigate request ${index} and make the smallest safe change.`,
+    promptTokens: 100 + (index % 13),
+    outputTokens: 180 + (index % 17),
+    firstProgressMs: 50 + index,
+    totalElapsedMs: 500 + index * 3,
+    toolCallCount: 1 + (index % 5),
+    toolNames: toolPool.slice(index % 3, (index % 3) + 3),
+  }))
+}
+
+const model: SessionModelInfo = {
+  id: 'gpt-5.4-codex',
+  name: 'GPT-5.4 Codex',
+  family: 'gpt',
+  vendor: 'openai',
+  multiplier: '2x',
+  multiplierNumeric: 2,
+  maxInputTokens: 200_000,
+  maxOutputTokens: 32_000,
+}
+const smallResults = makeResults(10)
+const mediumResults = makeResults(100)
+const largeResults = makeResults(500)
+const mediumAggregate = aggregateResults(mediumResults)
+const digestInput = {
+  sessionId: 'session-1',
+  title: 'Benchmark session',
+  startTime: 1_782_432_000_000,
+  model,
+  requestCount: mediumResults.length,
+  results: mediumResults,
+  totalPromptTokens: mediumAggregate.totalPromptTokens,
+  totalOutputTokens: mediumAggregate.totalOutputTokens,
+  totalToolCalls: mediumAggregate.totalToolCalls,
+  totalDurationMs: mediumAggregate.totalDurationMs,
+}
+
+describe('session result aggregation', () => {
+  bench('aggregateResults — 10 requests', () => {
+    aggregateResults(smallResults)
+  })
+
+  bench('aggregateResults — 100 requests', () => {
+    aggregateResults(mediumResults)
+  })
+
+  bench('aggregateResults — 500 requests', () => {
+    aggregateResults(largeResults)
+  })
+})
+
+describe('session tool analysis', () => {
+  bench('countSearchChurn — 500 requests', () => {
+    countSearchChurn(largeResults)
+  })
+
+  bench('computeDominantTools — 500 requests', () => {
+    computeDominantTools(largeResults)
+  })
+})
+
+describe('computeSessionDigest', () => {
+  bench('100-request digest', () => {
+    computeSessionDigest(digestInput, 'hs-buddy', 'agent', 1_782_432_123_000)
+  })
+})


### PR DESCRIPTION
Closes #229

## Summary
- add focused benchmarks for billing parsers, session digests, and Copilot enterprise user normalization
- switch the IPC throughput benchmark from a simulated wrapper to the real `ipcHandler`
- register the new benchmark files and five-run median baselines in the performance skill, with remaining known gaps listed explicitly

## Verification
- `bun install --frozen-lockfile`
- `bun run bench --outputJson .tmp-bench-issue229-runN.json perf/ipc-throughput.bench.ts src/utils/billingParsers.bench.ts src/utils/sessionDigest.bench.ts src/utils/copilotEnterpriseUsers.bench.ts` (5 runs for baseline medians)
- `bun run bench --outputJson .tmp-bench-issue229-final.json perf/ipc-throughput.bench.ts src/utils/billingParsers.bench.ts src/utils/sessionDigest.bench.ts src/utils/copilotEnterpriseUsers.bench.ts`
- `bun run test src/utils/billingParsers.test.ts src/utils/sessionDigest.test.ts src/utils/copilotEnterpriseUsers.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bunx markdownlint-cli2 .agents/skills/performance/SKILL.md CHANGELOG.md`
- `bun run knip`
- `bun run test`
- pre-commit hook: `vitest run --coverage`, `tsc --noEmit ...`, `bun scripts/coverage-ratchet.ts`, markdown checks, revision bump

## Stack
- Base PR: #230
- This PR should merge after #230.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add performance benchmark coverage for billing, session, IPC, and enterprise user utilities
> - Adds new Vitest benchmark suites for `billingParsers`, `sessionDigest`, `ipc-throughput`, and `copilotEnterpriseUsers` to close documented coverage gaps in [SKILL.md](https://github.com/HemSoft/hs-buddy/pull/231/files#diff-991d609320b383e88433c8b28ba83ce17e34d55a38fa02ada07aa6e854548d02).
> - Introduces [scripts/bench-median.ts](https://github.com/HemSoft/hs-buddy/pull/231/files#diff-549118d5fcb662d197925cadc482c7c27683ecd1f5ed861f23ed8adb912de5f1) to compute median outputs from multiple benchmark runs; the benchmarks workflow now runs five iterations and compares medians instead of single runs.
> - Adds a [.github/actions/setup-bun/action.yml](https://github.com/HemSoft/hs-buddy/pull/231/files#diff-1552bbeaa57455bd845d0afa00e8713168f24ada61a1a08921576dbc72750f87) composite action pinning Bun to 1.3.7, used across CI, security, release, and dependabot workflows.
> - Pins Node to 24.12.0 and Vitest to 4.1.5 across all workflows for reproducibility.
> - Behavioral Change: benchmark comparison failures are now advisory (non-blocking) when harness or toolchain files change; E2E tests now target Chrome instead of Chromium in CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 62de894. 13 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->