### PR TITLE
fix: stabilize shared prettier line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 src/**/* text=auto eol=lf
+shared/**/* text=auto eol=lf
 
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 .husky/* text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.868] - 2026-06-30
+
+### Fixed
+
+- Stabilize shared prettier line endings
+
 ## [0.1.867] - 2026-06-29
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.867",
+  "version": "0.1.868",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #255

## Summary
- Add a shared-tree Git attribute so Prettier-managed shared utility files check out with LF endings, matching the existing src policy.
- Let the repo hook update release metadata for version 0.1.868.

## Verification
- `bun install --frozen-lockfile`
- `bun run format:check`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bunx markdownlint-cli2 "*.md" "docs/**/*.md" ".github/**/*.md"`
- `bun run test:coverage` (288 files, 6475 tests passed)
- `git diff --check HEAD~1..HEAD`
- `git check-attr text eol -- shared/utils/bookmarkValidation.ts shared/utils/convexPatchUtils.ts shared/utils/featureIntakeUtils.ts shared/utils/scheduleUtils.ts shared/utils/statsMutationUtils.ts`

## Risk
Low. This is a repository attributes change plus automated release metadata. The intended behavior change is limited to line-ending stability for files under `shared/**/*`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Enforce LF line endings for files in the `shared/` directory
> Adds a [.gitattributes](https://github.com/HemSoft/hs-buddy/pull/256/files#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393e) rule to force LF line endings and automatic text normalization for all files under `shared/`, preventing inconsistent line endings across platforms from causing noisy prettier diffs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b54742a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->