### PR TITLE
fix: protect list keys from spread props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.874] - 2026-07-22
+
+### Fixed
+
+- Protect list keys from spread props
+
 ## [0.1.873] - 2026-07-06
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.873",
+  "version": "0.1.874",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/settings/AppearanceColorsSection.tsx
+++ b/src/components/settings/AppearanceColorsSection.tsx
@@ -1,4 +1,5 @@
 import { Palette, RotateCcw } from 'lucide-react'
+import { Fragment } from 'react'
 import { ColorPicker } from './AppearanceColorPicker'
 import type { ColorDef } from './appearanceUtils'
 
@@ -38,7 +39,9 @@ export function AppearanceColorsSection({
         <h4 className="color-group-label">Brand</h4>
         <div className="color-grid">
           {brandColors.map(c => (
-            <ColorPicker {...c} key={c.id} />
+            <Fragment key={c.id}>
+              <ColorPicker {...c} />
+            </Fragment>
           ))}
         </div>
       </div>
@@ -47,7 +50,9 @@ export function AppearanceColorsSection({
         <h4 className="color-group-label">Backgrounds</h4>
         <div className="color-grid">
           {backgroundColors.map(c => (
-            <ColorPicker {...c} key={c.id} />
+            <Fragment key={c.id}>
+              <ColorPicker {...c} />
+            </Fragment>
           ))}
         </div>
       </div>
@@ -56,7 +61,9 @@ export function AppearanceColorsSection({
         <h4 className="color-group-label">Status Bar</h4>
         <div className="color-grid">
           {statusBarColors.map(c => (
-            <ColorPicker {...c} key={c.id} />
+            <Fragment key={c.id}>
+              <ColorPicker {...c} />
+            </Fragment>
           ))}
         </div>
       </div>

--- a/src/components/settings/AppearanceColorsSection.tsx
+++ b/src/components/settings/AppearanceColorsSection.tsx
@@ -38,7 +38,7 @@ export function AppearanceColorsSection({
         <h4 className="color-group-label">Brand</h4>
         <div className="color-grid">
           {brandColors.map(c => (
-            <ColorPicker key={c.id} {...c} />
+            <ColorPicker {...c} key={c.id} />
           ))}
         </div>
       </div>
@@ -47,7 +47,7 @@ export function AppearanceColorsSection({
         <h4 className="color-group-label">Backgrounds</h4>
         <div className="color-grid">
           {backgroundColors.map(c => (
-            <ColorPicker key={c.id} {...c} />
+            <ColorPicker {...c} key={c.id} />
           ))}
         </div>
       </div>
@@ -56,7 +56,7 @@ export function AppearanceColorsSection({
         <h4 className="color-group-label">Status Bar</h4>
         <div className="color-grid">
           {statusBarColors.map(c => (
-            <ColorPicker key={c.id} {...c} />
+            <ColorPicker {...c} key={c.id} />
           ))}
         </div>
       </div>

--- a/src/components/sidebar/TerminalSidebar.tsx
+++ b/src/components/sidebar/TerminalSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { Fragment, useCallback, useRef, useState } from 'react'
 import {
   Plus,
   Trash2,
@@ -262,12 +262,13 @@ function TerminalChildrenList({
   return (
     <div className="terminal-sidebar-children">
       {terminalChildren.map(child => (
-        <TerminalNodeRow
-          child={child}
-          selected={activeNodeId === child.id && selectedItem === 'terminal-workspace'}
-          {...rowProps}
-          key={child.id}
-        />
+        <Fragment key={child.id}>
+          <TerminalNodeRow
+            child={child}
+            selected={activeNodeId === child.id && selectedItem === 'terminal-workspace'}
+            {...rowProps}
+          />
+        </Fragment>
       ))}
       {terminalChildren.length === 0 && (
         <div className="terminal-sidebar-no-terminals">
@@ -383,15 +384,16 @@ function TerminalFolderList({
   return (
     <div className="terminal-sidebar-list">
       {folders.map(folder => (
-        <TerminalFolder
-          folder={folder}
-          terminalChildren={getChildren(folder.id)}
-          expanded={isFolderExpanded(folder.id)}
-          activeNodeId={activeNodeId}
-          selectedItem={selectedItem}
-          {...folderProps}
-          key={folder.id}
-        />
+        <Fragment key={folder.id}>
+          <TerminalFolder
+            folder={folder}
+            terminalChildren={getChildren(folder.id)}
+            expanded={isFolderExpanded(folder.id)}
+            activeNodeId={activeNodeId}
+            selectedItem={selectedItem}
+            {...folderProps}
+          />
+        </Fragment>
       ))}
 
       {folders.length === 0 && (

--- a/src/components/sidebar/TerminalSidebar.tsx
+++ b/src/components/sidebar/TerminalSidebar.tsx
@@ -263,10 +263,10 @@ function TerminalChildrenList({
     <div className="terminal-sidebar-children">
       {terminalChildren.map(child => (
         <TerminalNodeRow
-          key={child.id}
           child={child}
           selected={activeNodeId === child.id && selectedItem === 'terminal-workspace'}
           {...rowProps}
+          key={child.id}
         />
       ))}
       {terminalChildren.length === 0 && (
@@ -384,13 +384,13 @@ function TerminalFolderList({
     <div className="terminal-sidebar-list">
       {folders.map(folder => (
         <TerminalFolder
-          key={folder.id}
           folder={folder}
           terminalChildren={getChildren(folder.id)}
           expanded={isFolderExpanded(folder.id)}
           activeNodeId={activeNodeId}
           selectedItem={selectedItem}
           {...folderProps}
+          key={folder.id}
         />
       ))}
 

--- a/src/components/sidebar/github-sidebar/OrgRepoTree.tsx
+++ b/src/components/sidebar/github-sidebar/OrgRepoTree.tsx
@@ -9,6 +9,7 @@ import {
   UserRound,
   UsersRound,
 } from 'lucide-react'
+import { Fragment } from 'react'
 import type {
   OrgRepo,
   OrgMember,
@@ -1041,7 +1042,11 @@ export function OrgRepoTree({ uniqueOrgs, ...props }: OrgRepoTreeProps) {
           <span className="sidebar-item-label">No accounts configured</span>
         </div>
       ) : (
-        uniqueOrgs.map(org => <OrgTreeNode org={org} {...props} key={org} />)
+        uniqueOrgs.map(org => (
+          <Fragment key={org}>
+            <OrgTreeNode org={org} {...props} />
+          </Fragment>
+        ))
       )}
     </div>
   )

--- a/src/components/sidebar/github-sidebar/OrgRepoTree.tsx
+++ b/src/components/sidebar/github-sidebar/OrgRepoTree.tsx
@@ -1041,7 +1041,7 @@ export function OrgRepoTree({ uniqueOrgs, ...props }: OrgRepoTreeProps) {
           <span className="sidebar-item-label">No accounts configured</span>
         </div>
       ) : (
-        uniqueOrgs.map(org => <OrgTreeNode key={org} org={org} {...props} />)
+        uniqueOrgs.map(org => <OrgTreeNode org={org} {...props} key={org} />)
       )}
     </div>
   )

--- a/src/components/sidebar/github-sidebar/PRTreeSection.tsx
+++ b/src/components/sidebar/github-sidebar/PRTreeSection.tsx
@@ -1,4 +1,5 @@
 import { ChevronDown, ChevronRight, FileText, GitPullRequest } from 'lucide-react'
+import { Fragment } from 'react'
 import type { PullRequest } from '../../../types/pullRequest'
 import { createPRDetailViewId } from '../../../utils/prDetailView'
 import { prSubNodes, sectionIcons } from './prConstants'
@@ -351,7 +352,9 @@ export function PRTreeSection(props: PRTreeSectionProps) {
   return (
     <>
       {props.prItems.map(item => (
-        <PRGroupNode item={item} {...props} key={item.id} />
+        <Fragment key={item.id}>
+          <PRGroupNode item={item} {...props} />
+        </Fragment>
       ))}
     </>
   )

--- a/src/components/sidebar/github-sidebar/PRTreeSection.tsx
+++ b/src/components/sidebar/github-sidebar/PRTreeSection.tsx
@@ -351,7 +351,7 @@ export function PRTreeSection(props: PRTreeSectionProps) {
   return (
     <>
       {props.prItems.map(item => (
-        <PRGroupNode key={item.id} item={item} {...props} />
+        <PRGroupNode item={item} {...props} key={item.id} />
       ))}
     </>
   )


### PR DESCRIPTION
Closes #260

## Summary
- move list reconciliation keys onto keyed fragments that cannot receive spread props
- preserve existing component prop forwarding and rendered DOM structure
- cover all seven React Doctor locations across settings, terminal, organization, and pull-request trees

## Verification
- `npx react-doctor@latest --verbose` (no target `jsx-key` findings)
- `bun run lint`
- `bun run typecheck`
- `bun run test:coverage` (288 files, 6,475 tests; 99.83% statements, 99.65% branches, 100% functions, 99.91% lines)
- `bun run build` completed TypeScript and all Vite production bundles; Electron packaging could not rebuild `node-pty` because Visual Studio Build Tools are not installed in this worktree environment

## Risk
Low. Key ownership moves to zero-DOM React fragments while component props and UI output remain unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix list keys leaking through spread props in sidebar and settings components
> In React, passing an object with a `key` field via spread props can silently override the intended list key. This fix wraps mapped elements in a `Fragment` keyed by the item's stable ID, isolating the list key from any `key` field that may exist in spread props.
>
> Affected components: [`AppearanceColorsSection`](https://github.com/HemSoft/hs-buddy/pull/276/files#diff-ed917305838ce66a792371773f96ac02e9884a688182a6f74baed6e9eace651e), [`TerminalSidebar`](https://github.com/HemSoft/hs-buddy/pull/276/files#diff-bad221cbdc1841efe59517b05c9e257b114baf4b42278578c1e6cb6e0dcfa935), [`OrgRepoTree`](https://github.com/HemSoft/hs-buddy/pull/276/files#diff-613e5c3b4a5baf3d6a54a3c0b42cca48e7feb56a6864ca3c1eb781ee305ae12a), and [`PRTreeSection`](https://github.com/HemSoft/hs-buddy/pull/276/files#diff-7615d1ba8177194aadba990ad09cdc155699bccc5aa60fe32af1a894395f12ba).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf02ce6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->