### PR TITLE
perf: split oversized Vite production chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.877] - 2026-07-22
+
+### Fixed
+
+- Preserve lazy chunks in bundle splitting
+
 ## [0.1.876] - 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.876] - 2026-07-22
+
+### Changed
+
+- Split oversized production chunks
+
 ## [0.1.875] - 2026-07-22
 
 ### Changed

--- a/bundle-size-baseline.json
+++ b/bundle-size-baseline.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-07-22T19:39:21.644Z",
+  "updatedAt": "2026-07-22T20:08:32.942Z",
   "bundles": [
     {
       "file": "dist/assets/emacs-lisp.js",
@@ -17,9 +17,14 @@
       "sizeHuman": "607.74 kB"
     },
     {
+      "file": "dist/assets/TerminalPane.js",
+      "sizeBytes": 375588,
+      "sizeHuman": "366.79 kB"
+    },
+    {
       "file": "dist/assets/vendor.js",
-      "sizeBytes": 340338,
-      "sizeHuman": "332.36 kB"
+      "sizeBytes": 293136,
+      "sizeHuman": "286.27 kB"
     },
     {
       "file": "dist/assets/wolfram.js",
@@ -28,8 +33,13 @@
     },
     {
       "file": "dist/assets/app.js",
-      "sizeBytes": 243523,
-      "sizeHuman": "237.82 kB"
+      "sizeBytes": 243767,
+      "sizeHuman": "238.05 kB"
+    },
+    {
+      "file": "dist-electron/vendor.js",
+      "sizeBytes": 226499,
+      "sizeHuman": "221.19 kB"
     },
     {
       "file": "dist/assets/vue-vine.js",
@@ -65,6 +75,11 @@
       "file": "dist/assets/objective-cpp.js",
       "sizeBytes": 171965,
       "sizeHuman": "167.93 kB"
+    },
+    {
+      "file": "dist-electron/app.js",
+      "sizeBytes": 161475,
+      "sizeHuman": "157.69 kB"
     },
     {
       "file": "dist/assets/app.css",
@@ -312,6 +327,11 @@
       "sizeHuman": "32.71 kB"
     },
     {
+      "file": "dist/assets/vendor.css",
+      "sizeBytes": 32307,
+      "sizeHuman": "31.55 kB"
+    },
+    {
       "file": "dist/assets/stylus.js",
       "sizeBytes": 31067,
       "sizeHuman": "30.34 kB"
@@ -373,11 +393,6 @@
     },
     {
       "file": "dist/assets/codeql.js",
-      "sizeBytes": 26876,
-      "sizeHuman": "26.25 kB"
-    },
-    {
-      "file": "dist/assets/vendor.css",
       "sizeBytes": 26876,
       "sizeHuman": "26.25 kB"
     },
@@ -1247,6 +1262,11 @@
       "sizeHuman": "4.55 kB"
     },
     {
+      "file": "dist/assets/TerminalPane.css",
+      "sizeBytes": 4552,
+      "sizeHuman": "4.45 kB"
+    },
+    {
       "file": "dist/assets/rosmsg.js",
       "sizeBytes": 4516,
       "sizeHuman": "4.41 kB"
@@ -1485,6 +1505,11 @@
       "file": "dist/assets/xsl.js",
       "sizeBytes": 1360,
       "sizeHuman": "1.33 kB"
+    },
+    {
+      "file": "dist-electron/rolldown-runtime.js",
+      "sizeBytes": 1261,
+      "sizeHuman": "1.23 kB"
     },
     {
       "file": "dist/assets/git-commit.js",

--- a/bundle-size-baseline.json
+++ b/bundle-size-baseline.json
@@ -1,25 +1,15 @@
 {
-  "updatedAt": "2026-07-04T01:43:41.853Z",
+  "updatedAt": "2026-07-22T19:39:21.644Z",
   "bundles": [
-    {
-      "file": "dist/assets/index.js",
-      "sizeBytes": 1719194,
-      "sizeHuman": "1.64 MB"
-    },
     {
       "file": "dist/assets/emacs-lisp.js",
       "sizeBytes": 779873,
       "sizeHuman": "761.59 kB"
     },
     {
-      "file": "dist-electron/main.js",
-      "sizeBytes": 726149,
-      "sizeHuman": "709.13 kB"
-    },
-    {
       "file": "dist/assets/cpp.js",
-      "sizeBytes": 626126,
-      "sizeHuman": "611.45 kB"
+      "sizeBytes": 626137,
+      "sizeHuman": "611.46 kB"
     },
     {
       "file": "dist/assets/wasm.js",
@@ -27,19 +17,19 @@
       "sizeHuman": "607.74 kB"
     },
     {
-      "file": "dist/assets/TerminalPane.js",
-      "sizeBytes": 375480,
-      "sizeHuman": "366.68 kB"
-    },
-    {
-      "file": "dist/assets/index.css",
-      "sizeBytes": 344997,
-      "sizeHuman": "336.91 kB"
+      "file": "dist/assets/vendor.js",
+      "sizeBytes": 340338,
+      "sizeHuman": "332.36 kB"
     },
     {
       "file": "dist/assets/wolfram.js",
       "sizeBytes": 262384,
       "sizeHuman": "256.23 kB"
+    },
+    {
+      "file": "dist/assets/app.js",
+      "sizeBytes": 243523,
+      "sizeHuman": "237.82 kB"
     },
     {
       "file": "dist/assets/vue-vine.js",
@@ -53,28 +43,33 @@
     },
     {
       "file": "dist/assets/typescript.js",
-      "sizeBytes": 181135,
-      "sizeHuman": "176.89 kB"
+      "sizeBytes": 181146,
+      "sizeHuman": "176.90 kB"
     },
     {
       "file": "dist/assets/jsx.js",
-      "sizeBytes": 177847,
-      "sizeHuman": "173.68 kB"
+      "sizeBytes": 177858,
+      "sizeHuman": "173.69 kB"
     },
     {
       "file": "dist/assets/tsx.js",
-      "sizeBytes": 175591,
-      "sizeHuman": "171.48 kB"
+      "sizeBytes": 175602,
+      "sizeHuman": "171.49 kB"
     },
     {
       "file": "dist/assets/javascript.js",
-      "sizeBytes": 174882,
-      "sizeHuman": "170.78 kB"
+      "sizeBytes": 174893,
+      "sizeHuman": "170.79 kB"
     },
     {
       "file": "dist/assets/objective-cpp.js",
       "sizeBytes": 171965,
       "sizeHuman": "167.93 kB"
+    },
+    {
+      "file": "dist/assets/app.css",
+      "sizeBytes": 153022,
+      "sizeHuman": "149.44 kB"
     },
     {
       "file": "dist/assets/mdx.js",
@@ -143,8 +138,8 @@
     },
     {
       "file": "dist/assets/c.js",
-      "sizeBytes": 72168,
-      "sizeHuman": "70.48 kB"
+      "sizeBytes": 72179,
+      "sizeHuman": "70.49 kB"
     },
     {
       "file": "dist/assets/python.js",
@@ -173,8 +168,8 @@
     },
     {
       "file": "dist/assets/html.js",
-      "sizeBytes": 57311,
-      "sizeHuman": "55.97 kB"
+      "sizeBytes": 57322,
+      "sizeHuman": "55.98 kB"
     },
     {
       "file": "dist/assets/stata.js",
@@ -203,8 +198,8 @@
     },
     {
       "file": "dist/assets/css.js",
-      "sizeBytes": 49096,
-      "sizeHuman": "47.95 kB"
+      "sizeBytes": 49107,
+      "sizeHuman": "47.96 kB"
     },
     {
       "file": "dist/assets/ada.js",
@@ -258,8 +253,8 @@
     },
     {
       "file": "dist/assets/shellscript.js",
-      "sizeBytes": 41534,
-      "sizeHuman": "40.56 kB"
+      "sizeBytes": 41545,
+      "sizeHuman": "40.57 kB"
     },
     {
       "file": "dist/assets/haskell.js",
@@ -363,13 +358,13 @@
     },
     {
       "file": "dist/assets/java.js",
-      "sizeBytes": 27274,
-      "sizeHuman": "26.63 kB"
+      "sizeBytes": 27285,
+      "sizeHuman": "26.65 kB"
     },
     {
       "file": "dist/assets/scss.js",
-      "sizeBytes": 27258,
-      "sizeHuman": "26.62 kB"
+      "sizeBytes": 27269,
+      "sizeHuman": "26.63 kB"
     },
     {
       "file": "dist/assets/c3.js",
@@ -378,6 +373,11 @@
     },
     {
       "file": "dist/assets/codeql.js",
+      "sizeBytes": 26876,
+      "sizeHuman": "26.25 kB"
+    },
+    {
+      "file": "dist/assets/vendor.css",
       "sizeBytes": 26876,
       "sizeHuman": "26.25 kB"
     },
@@ -433,8 +433,8 @@
     },
     {
       "file": "dist/assets/angular-html.js",
-      "sizeBytes": 24238,
-      "sizeHuman": "23.67 kB"
+      "sizeBytes": 24249,
+      "sizeHuman": "23.68 kB"
     },
     {
       "file": "dist/assets/templ.js",
@@ -458,8 +458,8 @@
     },
     {
       "file": "dist/assets/sql.js",
-      "sizeBytes": 23483,
-      "sizeHuman": "22.93 kB"
+      "sizeBytes": 23494,
+      "sizeHuman": "22.94 kB"
     },
     {
       "file": "dist/assets/bird2.js",
@@ -643,8 +643,8 @@
     },
     {
       "file": "dist/assets/graphql.js",
-      "sizeBytes": 18076,
-      "sizeHuman": "17.65 kB"
+      "sizeBytes": 18087,
+      "sizeHuman": "17.66 kB"
     },
     {
       "file": "dist/assets/move.js",
@@ -708,8 +708,8 @@
     },
     {
       "file": "dist/assets/lua.js",
-      "sizeBytes": 15589,
-      "sizeHuman": "15.22 kB"
+      "sizeBytes": 15600,
+      "sizeHuman": "15.23 kB"
     },
     {
       "file": "dist/assets/nix.js",
@@ -883,8 +883,8 @@
     },
     {
       "file": "dist/assets/yaml.js",
-      "sizeBytes": 10561,
-      "sizeHuman": "10.31 kB"
+      "sizeBytes": 10572,
+      "sizeHuman": "10.32 kB"
     },
     {
       "file": "dist/assets/raku.js",
@@ -1018,13 +1018,13 @@
     },
     {
       "file": "dist/assets/haml.js",
-      "sizeBytes": 8327,
-      "sizeHuman": "8.13 kB"
+      "sizeBytes": 8338,
+      "sizeHuman": "8.14 kB"
     },
     {
       "file": "dist/assets/regexp.js",
-      "sizeBytes": 8043,
-      "sizeHuman": "7.85 kB"
+      "sizeBytes": 8054,
+      "sizeHuman": "7.87 kB"
     },
     {
       "file": "dist/assets/monokai.js",
@@ -1078,8 +1078,8 @@
     },
     {
       "file": "dist/assets/r.js",
-      "sizeBytes": 6596,
-      "sizeHuman": "6.44 kB"
+      "sizeBytes": 6607,
+      "sizeHuman": "6.45 kB"
     },
     {
       "file": "dist/assets/smalltalk.js",
@@ -1188,8 +1188,8 @@
     },
     {
       "file": "dist/assets/xml.js",
-      "sizeBytes": 5438,
-      "sizeHuman": "5.31 kB"
+      "sizeBytes": 5449,
+      "sizeHuman": "5.32 kB"
     },
     {
       "file": "dist/assets/bicep.js",
@@ -1247,11 +1247,6 @@
       "sizeHuman": "4.55 kB"
     },
     {
-      "file": "dist/assets/TerminalPane.css",
-      "sizeBytes": 4552,
-      "sizeHuman": "4.45 kB"
-    },
-    {
       "file": "dist/assets/rosmsg.js",
       "sizeBytes": 4516,
       "sizeHuman": "4.41 kB"
@@ -1292,14 +1287,14 @@
       "sizeHuman": "3.81 kB"
     },
     {
-      "file": "dist/assets/turtle.js",
-      "sizeBytes": 3693,
+      "file": "dist/assets/glsl.js",
+      "sizeBytes": 3699,
       "sizeHuman": "3.61 kB"
     },
     {
-      "file": "dist/assets/glsl.js",
-      "sizeBytes": 3688,
-      "sizeHuman": "3.60 kB"
+      "file": "dist/assets/turtle.js",
+      "sizeBytes": 3693,
+      "sizeHuman": "3.61 kB"
     },
     {
       "file": "dist/assets/narrat.js",
@@ -1398,8 +1393,8 @@
     },
     {
       "file": "dist/assets/json.js",
-      "sizeBytes": 2879,
-      "sizeHuman": "2.81 kB"
+      "sizeBytes": 2890,
+      "sizeHuman": "2.82 kB"
     },
     {
       "file": "dist/assets/log.js",
@@ -1522,14 +1517,29 @@
       "sizeHuman": "732 B"
     },
     {
+      "file": "dist/assets/index.js",
+      "sizeBytes": 724,
+      "sizeHuman": "724 B"
+    },
+    {
       "file": "dist/assets/shellsession.js",
       "sizeBytes": 713,
       "sizeHuman": "713 B"
     },
     {
+      "file": "dist/assets/rolldown-runtime.js",
+      "sizeBytes": 694,
+      "sizeHuman": "694 B"
+    },
+    {
       "file": "dist/assets/codeowners.js",
       "sizeBytes": 540,
       "sizeHuman": "540 B"
+    },
+    {
+      "file": "dist-electron/main.js",
+      "sizeBytes": 109,
+      "sizeHuman": "109 B"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.875",
+  "version": "0.1.876",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.876",
+  "version": "0.1.877",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/bundle-size.ts
+++ b/scripts/bundle-size.ts
@@ -11,7 +11,7 @@
  * The baseline is stored in bundle-size-baseline.json (committed to repo).
  */
 import { readdirSync, readFileSync, statSync, writeFileSync, existsSync } from 'node:fs'
-import { resolve } from 'node:path'
+import { basename, dirname, relative, resolve } from 'node:path'
 
 const root = resolve(import.meta.dirname, '..')
 const baselinePath = resolve(root, 'bundle-size-baseline.json')
@@ -49,13 +49,40 @@ function collectRendererAssets(distDir: string): BundleEntry[] {
     })
 }
 
-function collectElectronMain(distElectronDir: string): BundleEntry | null {
-  if (!existsSync(distElectronDir)) return null
-  // Use the exact unhashed main.js — hashed variants (main-*.js) are stale build artifacts
+function collectElectronMainChunks(distElectronDir: string): BundleEntry[] {
   const mainPath = resolve(distElectronDir, 'main.js')
-  if (!existsSync(mainPath)) return null
-  const size = statSync(mainPath).size
-  return { file: 'dist-electron/main.js', sizeBytes: size, sizeHuman: humanSize(size) }
+  if (!existsSync(mainPath)) return []
+
+  const chunks: BundleEntry[] = []
+  const pending = [mainPath]
+  const visited = new Set<string>()
+  const importPattern = /(?:\bfrom\s*|\bimport\s*(?:\(\s*)?)(["'])(\.[^"']+\.js)\1/g
+
+  while (pending.length > 0) {
+    const filePath = pending.pop()
+    if (!filePath || visited.has(filePath)) continue
+    visited.add(filePath)
+
+    const size = statSync(filePath).size
+    chunks.push({
+      file: `dist-electron/${relative(distElectronDir, filePath).replaceAll('\\', '/')}`,
+      sizeBytes: size,
+      sizeHuman: humanSize(size),
+    })
+
+    const source = readFileSync(filePath, 'utf-8')
+    for (const match of source.matchAll(importPattern)) {
+      const importedPath = resolve(dirname(filePath), match[2])
+      if (!existsSync(importedPath)) {
+        throw new Error(
+          `Missing Electron chunk ${basename(importedPath)} imported by ${basename(filePath)}.`
+        )
+      }
+      pending.push(importedPath)
+    }
+  }
+
+  return chunks
 }
 
 function collectBundles(): BundleEntry[] {
@@ -70,13 +97,13 @@ function collectBundles(): BundleEntry[] {
     bundles.push({ file: 'dist-electron/preload.mjs', sizeBytes: size, sizeHuman: humanSize(size) })
   }
 
-  const mainEntry = collectElectronMain(distElectronDir)
-  if (!mainEntry) {
+  const mainChunks = collectElectronMainChunks(distElectronDir)
+  if (mainChunks.length === 0) {
     throw new Error(
       'Missing dist-electron/main.js. Run a clean Electron build before bundle-size check.'
     )
   }
-  bundles.push(mainEntry)
+  bundles.push(...mainChunks)
 
   return bundles.sort((a, b) => b.sizeBytes - a.sizeBytes)
 }
@@ -88,20 +115,7 @@ function normalizeFile(file: string): string {
 
 const isUpdate = process.argv.includes('--update')
 
-function warnStaleArtifacts(): void {
-  const distElectronDir = resolve(root, 'dist-electron')
-  if (!existsSync(distElectronDir)) return
-  const stale = readdirSync(distElectronDir).filter(f => f.startsWith('main-') && f.endsWith('.js'))
-  if (stale.length > 0) {
-    console.warn(
-      `⚠  ${stale.length} stale main-*.js artifact(s) in dist-electron/. ` +
-        'Run a clean build to remove them (Unix: rm dist-electron/main-*.js, PowerShell: Remove-Item dist-electron\\main-*.js)'
-    )
-  }
-}
-
 try {
-  warnStaleArtifacts()
   const bundles = collectBundles()
 
   if (bundles.length === 0) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,43 @@ const requireShim = [
   'const require = __createRequire(import.meta.url);',
 ].join('\n')
 
+// Keep splittable application and dependency chunks below Vite's default
+// 500 kB budget. Shiki ships a few individual grammar modules that are larger
+// than that threshold and cannot be split further, so the renderer warning
+// limit is set just above the largest grammar while every multi-module group
+// remains capped below 500 kB.
+const MAX_SPLIT_CHUNK_SIZE = 450 * 1024
+const SHIKI_GRAMMAR_WARNING_LIMIT_KB = 800
+
+function codeSplittingGroups(sourcePattern: RegExp, preserveShikiChunks = false) {
+  return {
+    minSize: 20 * 1024,
+    groups: [
+      {
+        name: 'vendor',
+        test: (id: string) => {
+          if (!/[\\/]node_modules[\\/]/.test(id)) return false
+          if (!preserveShikiChunks) return true
+
+          const normalizedId = id.replaceAll('\\', '/')
+          return (
+            !normalizedId.includes('/node_modules/shiki/') &&
+            !normalizedId.includes('/node_modules/@shikijs/')
+          )
+        },
+        maxSize: MAX_SPLIT_CHUNK_SIZE,
+        priority: 20,
+      },
+      {
+        name: 'app',
+        test: sourcePattern,
+        maxSize: MAX_SPLIT_CHUNK_SIZE,
+        priority: 10,
+      },
+    ],
+  }
+}
+
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   // In E2E mode (--mode e2e OR VITE_E2E=1), skip the Electron plugin entirely
@@ -45,6 +82,14 @@ export default defineConfig(({ mode }) => {
           },
         }
       : {}),
+    build: {
+      chunkSizeWarningLimit: SHIKI_GRAMMAR_WARNING_LIMIT_KB,
+      rolldownOptions: {
+        output: {
+          codeSplitting: codeSplittingGroups(/[\\/]src[\\/]/, true),
+        },
+      },
+    },
     plugins: [
       react(),
       ...(!isE2E
@@ -55,12 +100,13 @@ export default defineConfig(({ mode }) => {
                 vite: {
                   build: {
                     target: 'esnext',
-                    rollupOptions: {
+                    rolldownOptions: {
                       // node-pty is a native module — must not be bundled.
                       // OTel SDK packages are dev-only (Aspire) — lazy-loaded at runtime.
                       external: ['node-pty', ...otelExternals],
                       output: {
                         banner: requireShim,
+                        codeSplitting: codeSplittingGroups(/[\\/](?:electron|shared)[\\/]/),
                       },
                     },
                   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,7 +35,7 @@ const requireShim = [
 const MAX_SPLIT_CHUNK_SIZE = 450 * 1024
 const SHIKI_GRAMMAR_WARNING_LIMIT_KB = 800
 
-function codeSplittingGroups(sourcePattern: RegExp, preserveShikiChunks = false) {
+function codeSplittingGroups(sourcePattern: RegExp, preserveRendererLazyChunks = false) {
   return {
     minSize: 20 * 1024,
     groups: [
@@ -43,12 +43,13 @@ function codeSplittingGroups(sourcePattern: RegExp, preserveShikiChunks = false)
         name: 'vendor',
         test: (id: string) => {
           if (!/[\\/]node_modules[\\/]/.test(id)) return false
-          if (!preserveShikiChunks) return true
+          if (!preserveRendererLazyChunks) return true
 
           const normalizedId = id.replaceAll('\\', '/')
           return (
             !normalizedId.includes('/node_modules/shiki/') &&
-            !normalizedId.includes('/node_modules/@shikijs/')
+            !normalizedId.includes('/node_modules/@shikijs/') &&
+            !normalizedId.includes('/node_modules/@xterm/')
           )
         },
         maxSize: MAX_SPLIT_CHUNK_SIZE,
@@ -56,7 +57,12 @@ function codeSplittingGroups(sourcePattern: RegExp, preserveShikiChunks = false)
       },
       {
         name: 'app',
-        test: sourcePattern,
+        test: (id: string) => {
+          if (!sourcePattern.test(id)) return false
+          if (!preserveRendererLazyChunks) return true
+
+          return !id.replaceAll('\\', '/').includes('/src/components/terminal/TerminalPane.')
+        },
         maxSize: MAX_SPLIT_CHUNK_SIZE,
         priority: 10,
       },


### PR DESCRIPTION
Closes #262

## Summary

- split renderer application and third-party modules into deterministic Rolldown groups capped at 450 KiB
- apply the same size-bounded splitting to the Electron main process
- preserve Shiki's existing lazy grammar chunks and document their indivisible 800 KiB renderer warning budget
- refresh the bundle-size baseline for the new chunk layout

## Result

- renderer entry: 1,719.19 kB -> 0.72 kB bootstrap
- largest splittable renderer app chunk: 243.52 kB
- largest splittable renderer vendor chunk: 340.33 kB
- Electron main entry: 726.00 kB -> 0.10 kB bootstrap
- largest Electron chunk: 226.49 kB
- `vite build` emits no oversized-chunk warning

## Verification

- `bun install --frozen-lockfile`
- `bun x vite build`
- `bun run bundle-size`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bunx markdownlint-cli2`
- `bun x prettier --check "{src,shared}/**/*.{ts,tsx,js,json,css}" vite.config.ts bundle-size-baseline.json`
- `git diff --check`
- `bun run test:coverage` (288 files, 6,475 tests)
- `bun run test:electron:coverage` (44 files, 855 tests)
- `bun run test:convex:coverage` (19 files, 241 tests)
- `bun run deps:check`
- `bun run security:electron`
- `bun run e18e` (no undocumented direct dependency findings)

## Risk

Medium: chunk boundaries can affect module initialization order and startup behavior. The configuration uses Rolldown's supported `codeSplitting` groups, preserves Shiki's dynamic grammar boundaries, and passes the full renderer/Electron/Convex verification suite.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split oversized Vite production chunks into vendor and app groups
> - Adds a `codeSplittingGroups` util in [vite.config.ts](https://github.com/HemSoft/hs-buddy/pull/277/files#diff-6a3b01ba97829c9566ef2d8dc466ffcffb4bdac08706d3d6319e42e0aa6890dd) that defines `vendor` and `app` output groups, each capped at 450 KiB, for both the renderer and Electron main builds.
> - Lazy-loaded renderer chunks (Shiki, `@xterm`, `TerminalPane`) are excluded from splitting groups so they remain as separate async chunks.
> - Raises the chunk size warning limit to 800 KiB for large, unsplittable Shiki grammar modules.
> - Updates [scripts/bundle-size.ts](https://github.com/HemSoft/hs-buddy/pull/277/files#diff-b2267be83ae4c79b855b359047473c3b543518aa208ae5d245086631658b2f2b) to traverse all chunks reachable from `dist-electron/main.js` instead of tracking a single file, and fails if any referenced chunk is missing.
> - Behavioral Change: Electron main build switches from `rollupOptions` to `rolldownOptions`; bundle output now contains multiple vendor/app chunks instead of a single `main.js`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4aebe8a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->