### PR TITLE
fix(bundle): deduplicate normalized asset rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.876] - 2026-07-22
+
+### Fixed
+
+- Deduplicate normalized asset rows
+
 ## [0.1.875] - 2026-07-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.875",
+  "version": "0.1.876",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/bundle-size-utils.test.ts
+++ b/scripts/bundle-size-utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { deduplicateBundles, normalizeBundleFile, type BundleEntry } from './bundle-size-utils'
+
+function bundle(file: string, sizeBytes: number): BundleEntry {
+  return { file, sizeBytes, sizeHuman: `${sizeBytes} B` }
+}
+
+describe('normalizeBundleFile', () => {
+  it('strips Vite content hashes', () => {
+    expect(normalizeBundleFile('dist/assets/wasm-BnjxR4X6.js')).toBe('dist/assets/wasm.js')
+  })
+})
+
+describe('deduplicateBundles', () => {
+  it('keeps the largest asset for each normalized filename', () => {
+    const bundles = deduplicateBundles([
+      bundle('dist/assets/wasm-ByWQv1Qj.js', 12_000),
+      bundle('dist/assets/index-AbCdEf12.js', 80_000),
+      bundle('dist/assets/wasm-BnjxR4X6.js', 622_325),
+    ])
+
+    expect(bundles).toEqual([
+      bundle('dist/assets/wasm.js', 622_325),
+      bundle('dist/assets/index.js', 80_000),
+    ])
+  })
+
+  it('produces the same result regardless of colliding asset order', () => {
+    const smaller = bundle('dist/assets/wasm-ByWQv1Qj.js', 12_000)
+    const larger = bundle('dist/assets/wasm-BnjxR4X6.js', 622_325)
+
+    expect(deduplicateBundles([smaller, larger])).toEqual(deduplicateBundles([larger, smaller]))
+  })
+})

--- a/scripts/bundle-size-utils.ts
+++ b/scripts/bundle-size-utils.ts
@@ -1,0 +1,27 @@
+export interface BundleEntry {
+  file: string
+  sizeBytes: number
+  sizeHuman: string
+}
+
+// Normalize filenames by stripping Vite content hashes: index-DBd6EIt0.js → index.js
+export function normalizeBundleFile(file: string): string {
+  return file.replace(/-[A-Za-z0-9_-]{8}\./, '.')
+}
+
+/** Keep one deterministic entry per normalized filename, preferring the largest asset. */
+export function deduplicateBundles(bundles: readonly BundleEntry[]): BundleEntry[] {
+  const deduped = new Map<string, BundleEntry>()
+
+  for (const bundle of bundles) {
+    const normalizedFile = normalizeBundleFile(bundle.file)
+    const existing = deduped.get(normalizedFile)
+    if (!existing || bundle.sizeBytes > existing.sizeBytes) {
+      deduped.set(normalizedFile, { ...bundle, file: normalizedFile })
+    }
+  }
+
+  return [...deduped.values()].sort(
+    (a, b) => b.sizeBytes - a.sizeBytes || a.file.localeCompare(b.file)
+  )
+}

--- a/scripts/bundle-size.ts
+++ b/scripts/bundle-size.ts
@@ -12,6 +12,7 @@
  */
 import { readdirSync, readFileSync, statSync, writeFileSync, existsSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { deduplicateBundles, normalizeBundleFile, type BundleEntry } from './bundle-size-utils'
 
 const root = resolve(import.meta.dirname, '..')
 const baselinePath = resolve(root, 'bundle-size-baseline.json')
@@ -19,12 +20,6 @@ const baselinePath = resolve(root, 'bundle-size-baseline.json')
 // 5% growth allowed before warning, 10% before failure
 const WARN_THRESHOLD = 0.05
 const FAIL_THRESHOLD = 0.1
-
-interface BundleEntry {
-  file: string
-  sizeBytes: number
-  sizeHuman: string
-}
 
 interface Baseline {
   updatedAt: string
@@ -81,11 +76,6 @@ function collectBundles(): BundleEntry[] {
   return bundles.sort((a, b) => b.sizeBytes - a.sizeBytes)
 }
 
-// Normalize filenames by stripping Vite content hashes: index-DBd6EIt0.js → index.js
-function normalizeFile(file: string): string {
-  return file.replace(/-[A-Za-z0-9_-]{8}\./, '.')
-}
-
 const isUpdate = process.argv.includes('--update')
 
 function warnStaleArtifacts(): void {
@@ -102,7 +92,7 @@ function warnStaleArtifacts(): void {
 
 try {
   warnStaleArtifacts()
-  const bundles = collectBundles()
+  const bundles = deduplicateBundles(collectBundles())
 
   if (bundles.length === 0) {
     console.error('No bundles found. Run `npx vite build` first.')
@@ -110,19 +100,9 @@ try {
   }
 
   if (isUpdate) {
-    // Deduplicate by normalized name, keeping the largest file for each
-    const deduped = new Map<string, BundleEntry>()
-    for (const b of bundles) {
-      const norm = normalizeFile(b.file)
-      const existing = deduped.get(norm)
-      if (!existing || b.sizeBytes > existing.sizeBytes) {
-        deduped.set(norm, { file: norm, sizeBytes: b.sizeBytes, sizeHuman: b.sizeHuman })
-      }
-    }
-
     const baseline: Baseline = {
       updatedAt: new Date().toISOString(),
-      bundles: [...deduped.values()].sort((a, b) => b.sizeBytes - a.sizeBytes),
+      bundles,
     }
     writeFileSync(baselinePath, JSON.stringify(baseline, null, 2) + '\n')
     console.log('Bundle size baseline updated:')
@@ -136,7 +116,7 @@ try {
   if (!existsSync(baselinePath)) {
     console.log('No baseline found. Current bundle sizes:')
     for (const b of bundles) {
-      console.log(`  ${normalizeFile(b.file).padEnd(35)} ${b.sizeHuman}`)
+      console.log(`  ${normalizeBundleFile(b.file).padEnd(35)} ${b.sizeHuman}`)
     }
     console.log('\nRun with --update to create the baseline.')
     process.exit(0)
@@ -155,7 +135,7 @@ try {
   console.log(`  ${'─'.repeat(35)} ${'─'.repeat(12)} ${'─'.repeat(12)} ${'─'.repeat(10)}`)
 
   for (const bundle of bundles) {
-    const norm = normalizeFile(bundle.file)
+    const norm = normalizeBundleFile(bundle.file)
     const base = baselineMap.get(norm)
 
     if (!base) {


### PR DESCRIPTION
Closes #263

## Summary

- apply one shared normalized-name deduplication pass to bundle-size check and update modes
- keep the largest asset when multiple Vite hashes normalize to the same baseline key
- add regression coverage for the colliding `wasm-*` assets from the issue

## Verification

- `bun install --frozen-lockfile`
- `bun x vitest run scripts/bundle-size-utils.test.ts`
- `bun x vite build`
- `bun run bundle-size` (exactly one `dist/assets/wasm.js` row; exit 0)
- `bunx markdownlint-cli2`
- `bun x prettier --check scripts/bundle-size.ts scripts/bundle-size-utils.ts scripts/bundle-size-utils.test.ts`
- `git diff --check`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run test:coverage` (289 files, 6,478 tests)
- `bun run test:electron:coverage` (44 files, 855 tests)
- `bun run test:convex:coverage` (19 files, 241 tests)
- `bun run deps:check`
- `bun run e18e` (no undocumented direct dependency findings)
- `bun run security:electron` (0 findings)

## Risk

Low. The change preserves the existing normalization and largest-asset policy, but applies it consistently before either reporting path. PR #277 also edits `scripts/bundle-size.ts` for distinct chunk-traversal work, so whichever PR merges second may need a narrow rebase.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deduplicate normalized asset rows in bundle size reporting
> - Adds `normalizeBundleFile` to [bundle-size-utils.ts](https://github.com/HemSoft/hs-buddy/pull/278/files#diff-b6daa25d52e91bf40006d90417ece233e3b2e5d0d2c62f0bbbb89331d32a646b) to strip 8-character Vite content hashes from filenames (e.g. `index-DBd6EIt0.js` → `index.js`).
> - Adds `deduplicateBundles` which keeps the largest size variant per normalized name and returns results sorted by size descending then filename.
> - [bundle-size.ts](https://github.com/HemSoft/hs-buddy/pull/278/files#diff-b2267be83ae4c79b855b359047473c3b543518aa208ae5d245086631658b2f2b) now deduplicates immediately after collecting entries, removing inline deduplication logic and using normalized filenames consistently in output and comparisons.
> - Behavioral Change: baseline and reported output now contain one entry per logical asset rather than one per hashed filename variant.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2b607b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->