### PR TITLE
Fix action-required Dependabot follow-up runs

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -66,7 +66,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -173,7 +173,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -200,7 +200,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -254,7 +254,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -305,7 +305,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 
@@ -336,7 +336,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 

--- a/.github/workflows/daily-repo-status.lock.yml
+++ b/.github/workflows/daily-repo-status.lock.yml
@@ -42,7 +42,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
 #
@@ -438,7 +438,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1385,7 +1385,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: read
   statuses: write
@@ -130,3 +131,13 @@ jobs:
             -f context="Dependabot Lockfile Fix / validated" \
             -f description="Required CI checks passed before this lockfile commit was pushed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Approve validated follow-up runs
+        if: steps.commit-lockfile.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ steps.commit-lockfile.outputs.sha }}
+          TARGET_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXCLUDED_WORKFLOW_PATH: .github/workflows/dependabot-lockfile.yml
+        run: bun scripts/approve-dependabot-followup-runs.ts

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 

--- a/.github/workflows/issue-processor.lock.yml
+++ b/.github/workflows/issue-processor.lock.yml
@@ -39,7 +39,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@8cfea5ae9bee18df8e50a96affdb6d666cd7b9a3 # v0.78.3
 #
@@ -430,7 +430,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1326,7 +1326,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/pr-analyzer-a.lock.yml
+++ b/.github/workflows/pr-analyzer-a.lock.yml
@@ -41,7 +41,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@8cfea5ae9bee18df8e50a96affdb6d666cd7b9a3 # v0.78.3
 #
@@ -402,7 +402,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1247,7 +1247,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/pr-analyzer-b.lock.yml
+++ b/.github/workflows/pr-analyzer-b.lock.yml
@@ -41,7 +41,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@8cfea5ae9bee18df8e50a96affdb6d666cd7b9a3 # v0.78.3
 #
@@ -402,7 +402,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1247,7 +1247,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/pr-analyzer-c.lock.yml
+++ b/.github/workflows/pr-analyzer-c.lock.yml
@@ -41,7 +41,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@8cfea5ae9bee18df8e50a96affdb6d666cd7b9a3 # v0.78.3
 #
@@ -402,7 +402,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1247,7 +1247,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/pr-fixer.lock.yml
+++ b/.github/workflows/pr-fixer.lock.yml
@@ -41,7 +41,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@8cfea5ae9bee18df8e50a96affdb6d666cd7b9a3 # v0.78.3
 #
@@ -405,7 +405,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1295,7 +1295,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/pr-promoter.lock.yml
+++ b/.github/workflows/pr-promoter.lock.yml
@@ -39,7 +39,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@8cfea5ae9bee18df8e50a96affdb6d666cd7b9a3 # v0.78.3
 #
@@ -400,7 +400,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1245,7 +1245,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
 

--- a/.github/workflows/repo-audit.lock.yml
+++ b/.github/workflows/repo-audit.lock.yml
@@ -38,7 +38,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
 #
@@ -430,7 +430,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1315,7 +1315,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: 24.12.0
       - name: Setup Bun

--- a/.github/workflows/simplisticate.lock.yml
+++ b/.github/workflows/simplisticate.lock.yml
@@ -40,7 +40,7 @@
 #   - actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
 #   - actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 (source v9)
-#   - actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+#   - actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
 #   - actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
 #   - github/gh-aw-actions/setup@c0338fef4749d08c21f8f975fb0e37efa17dda47 # v0.79.8
 #
@@ -432,7 +432,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false
@@ -1372,7 +1372,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
           package-manager-cache: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.879] - 2026-07-22
+
+### Changed
+
+- Sync Electron 43 update with main
+
 ## [0.1.878] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.878] - 2026-07-22
+
+### Fixed
+
+- Approve validated Dependabot follow-ups
+
 ## [0.1.877] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.879] - 2026-07-22
+
+### Changed
+
+- Simplify follow-up approval polling
+
 ## [0.1.878] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.880] - 2026-07-22
+
+### Fixed
+
+- Normalize workflow paths before approval
+
 ## [0.1.879] - 2026-07-22
 
 ### Changed

--- a/bun.lock
+++ b/bun.lock
@@ -57,7 +57,7 @@
         "@vitest/coverage-v8": "4.1.10",
         "convex-test": "0.0.53",
         "dependency-cruiser": "^17.4.3",
-        "electron": "^42.6.0",
+        "electron": "^43.0.0",
         "electron-builder": "^26.15.3",
         "esbuild": "^0.28.1",
         "eslint": "^10.6.0",
@@ -1261,7 +1261,7 @@
 
     "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
 
-    "electron": ["electron@42.6.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-axGNgd+yCTg+vi1VEGrQqAj9WVWkePKwbICSAvMiT2eTaxhij9a/xhBHD6rXV8wrlW9ZfJzE5+xg752ImxrmTw=="],
+    "electron": ["electron@43.0.0", "", { "dependencies": { "@electron-internal/extract-zip": "^1.0.1", "@electron/get": "^5.0.0", "@types/node": "^24.9.0" }, "bin": { "electron": "cli.js", "install-electron": "install.js" } }, "sha512-PV60GsWU6qufhuOhw3n+Yix3WPDcqDtBqE8orbEQGQGHEkgp9o/JCPgb7L4vIL0r1HnfPdqSRtboOTqbDkcFDQ=="],
 
     "electron-builder": ["electron-builder@26.15.3", "", { "dependencies": { "app-builder-lib": "26.15.3", "builder-util": "26.15.3", "builder-util-runtime": "9.7.0", "chalk": "^4.1.2", "ci-info": "^4.2.0", "dmg-builder": "26.15.3", "fs-extra": "^10.1.0", "lazy-val": "^1.0.5", "simple-update-notifier": "2.0.0", "yargs": "^17.6.2" }, "bin": { "electron-builder": "./cli.js", "install-app-deps": "./install-app-deps.js" } }, "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA=="],
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.878",
+  "version": "0.1.879",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",
@@ -119,7 +119,7 @@
     "@vitest/coverage-v8": "4.1.10",
     "convex-test": "0.0.53",
     "dependency-cruiser": "^17.4.3",
-    "electron": "^42.6.0",
+    "electron": "^43.0.0",
     "electron-builder": "^26.15.3",
     "esbuild": "^0.28.1",
     "eslint": "^10.6.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.878",
+  "version": "0.1.879",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.877",
+  "version": "0.1.878",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.879",
+  "version": "0.1.880",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/approve-dependabot-followup-runs.test.ts
+++ b/scripts/approve-dependabot-followup-runs.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest'
+import {
+  approvalCandidates,
+  approvalScopeFromEnvironment,
+  isApprovalCandidate,
+  type ApprovalScope,
+  type WorkflowRun,
+} from './approve-dependabot-followup-runs'
+
+const scope: ApprovalScope = {
+  repository: 'HemSoft/hs-buddy',
+  headSha: '7301537c00000000000000000000000000000000',
+  pullNumber: 267,
+  excludedWorkflowPath: '.github/workflows/dependabot-lockfile.yml',
+}
+
+function candidate(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    id: 28_761_315_228,
+    name: 'CI',
+    path: '.github/workflows/ci.yml',
+    event: 'pull_request',
+    status: 'completed',
+    conclusion: 'action_required',
+    head_sha: scope.headSha,
+    actor: { login: 'github-actions[bot]' },
+    triggering_actor: { login: 'github-actions[bot]' },
+    repository: { full_name: scope.repository },
+    pull_requests: [{ number: scope.pullNumber }],
+    ...overrides,
+  }
+}
+
+describe('isApprovalCandidate', () => {
+  it('accepts the exact validated follow-up run shape', () => {
+    expect(isApprovalCandidate(candidate(), scope)).toBe(true)
+  })
+
+  it.each([
+    ['repository', { repository: { full_name: 'HemSoft/other' } }],
+    ['head SHA', { head_sha: 'a'.repeat(40) }],
+    ['event', { event: 'push' }],
+    ['status', { status: 'queued' }],
+    ['conclusion', { conclusion: 'success' }],
+    ['actor', { actor: { login: 'dependabot[bot]' } }],
+    ['triggering actor', { triggering_actor: { login: 'dependabot[bot]' } }],
+    ['pull request', { pull_requests: [{ number: 268 }] }],
+  ])('rejects a run with the wrong %s', (_field, overrides) => {
+    expect(isApprovalCandidate(candidate(overrides), scope)).toBe(false)
+  })
+
+  it('rejects the recursive Dependabot Lockfile Fix run', () => {
+    expect(
+      isApprovalCandidate(
+        candidate({
+          name: 'Dependabot Lockfile Fix',
+          path: '.github/workflows/dependabot-lockfile.yml',
+        }),
+        scope
+      )
+    ).toBe(false)
+  })
+})
+
+describe('approvalCandidates', () => {
+  it('returns only tightly scoped non-recursive runs', () => {
+    const runs = [
+      candidate(),
+      candidate({ id: 2, path: '.github/workflows/security.yml', name: 'Security Scanning' }),
+      candidate({ id: 3, head_sha: 'b'.repeat(40) }),
+      candidate({ id: 4, path: scope.excludedWorkflowPath }),
+    ]
+
+    expect(approvalCandidates(runs, scope).map(run => run.id)).toEqual([28_761_315_228, 2])
+  })
+})
+
+describe('approvalScopeFromEnvironment', () => {
+  it('parses and normalizes a complete scope', () => {
+    expect(
+      approvalScopeFromEnvironment({
+        TARGET_REPOSITORY: 'HemSoft/hs-buddy',
+        TARGET_SHA: 'A'.repeat(40),
+        TARGET_PR_NUMBER: '267',
+        EXCLUDED_WORKFLOW_PATH: '.github/workflows/dependabot-lockfile.yml',
+      })
+    ).toEqual({ ...scope, headSha: 'a'.repeat(40) })
+  })
+
+  it.each([
+    ['repository', { TARGET_REPOSITORY: 'hs-buddy' }],
+    ['SHA', { TARGET_SHA: 'short' }],
+    ['PR number', { TARGET_PR_NUMBER: '0' }],
+  ])('rejects an invalid %s', (_field, override) => {
+    expect(() =>
+      approvalScopeFromEnvironment({
+        TARGET_REPOSITORY: scope.repository,
+        TARGET_SHA: scope.headSha,
+        TARGET_PR_NUMBER: String(scope.pullNumber),
+        EXCLUDED_WORKFLOW_PATH: scope.excludedWorkflowPath,
+        ...override,
+      })
+    ).toThrow()
+  })
+})

--- a/scripts/approve-dependabot-followup-runs.test.ts
+++ b/scripts/approve-dependabot-followup-runs.test.ts
@@ -50,15 +50,20 @@ describe('isApprovalCandidate', () => {
   })
 
   it('rejects the recursive Dependabot Lockfile Fix run', () => {
-    expect(
-      isApprovalCandidate(
-        candidate({
-          name: 'Dependabot Lockfile Fix',
-          path: '.github/workflows/dependabot-lockfile.yml',
-        }),
-        scope
-      )
-    ).toBe(false)
+    for (const path of [
+      '.github/workflows/dependabot-lockfile.yml',
+      '.github/workflows/dependabot-lockfile.yml@refs/pull/267/merge',
+    ]) {
+      expect(
+        isApprovalCandidate(
+          candidate({
+            name: 'Dependabot Lockfile Fix',
+            path,
+          }),
+          scope
+        )
+      ).toBe(false)
+    }
   })
 })
 

--- a/scripts/approve-dependabot-followup-runs.ts
+++ b/scripts/approve-dependabot-followup-runs.ts
@@ -1,0 +1,230 @@
+const EXPECTED_ACTOR = 'github-actions[bot]'
+const MAX_POLL_ATTEMPTS = 12
+const POLL_INTERVAL_MS = 5_000
+const EMPTY_POLLS_AFTER_APPROVAL = 2
+
+interface WorkflowActor {
+  login?: string
+}
+
+interface WorkflowRepository {
+  full_name?: string
+}
+
+interface WorkflowPullRequest {
+  number?: number
+}
+
+export interface WorkflowRun {
+  id?: number
+  name?: string
+  path?: string
+  event?: string
+  status?: string
+  conclusion?: string | null
+  head_sha?: string
+  actor?: WorkflowActor | null
+  triggering_actor?: WorkflowActor | null
+  repository?: WorkflowRepository
+  pull_requests?: WorkflowPullRequest[]
+}
+
+export interface ApprovalScope {
+  repository: string
+  headSha: string
+  pullNumber: number
+  excludedWorkflowPath: string
+}
+
+interface WorkflowRunsResponse {
+  workflow_runs: WorkflowRun[]
+}
+
+interface Environment {
+  GH_TOKEN?: string
+  GITHUB_API_URL?: string
+  TARGET_REPOSITORY?: string
+  TARGET_SHA?: string
+  TARGET_PR_NUMBER?: string
+  EXCLUDED_WORKFLOW_PATH?: string
+}
+
+function required(environment: Environment, name: keyof Environment): string {
+  const value = environment[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+export function approvalScopeFromEnvironment(environment: Environment): ApprovalScope {
+  const repository = required(environment, 'TARGET_REPOSITORY')
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) {
+    throw new Error('TARGET_REPOSITORY must be in owner/repository form')
+  }
+
+  const headSha = required(environment, 'TARGET_SHA').toLowerCase()
+  if (!/^[0-9a-f]{40}$/.test(headSha)) {
+    throw new Error('TARGET_SHA must be a full 40-character commit SHA')
+  }
+
+  const pullNumber = Number(required(environment, 'TARGET_PR_NUMBER'))
+  if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error('TARGET_PR_NUMBER must be a positive integer')
+  }
+
+  return {
+    repository,
+    headSha,
+    pullNumber,
+    excludedWorkflowPath: required(environment, 'EXCLUDED_WORKFLOW_PATH'),
+  }
+}
+
+function targetsExactPullRequest(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return (
+    run.repository?.full_name === scope.repository &&
+    run.head_sha?.toLowerCase() === scope.headSha &&
+    run.pull_requests?.some(pullRequest => pullRequest.number === scope.pullNumber) === true
+  )
+}
+
+function isPendingApproval(run: WorkflowRun): boolean {
+  return (
+    run.event === 'pull_request' &&
+    run.status === 'completed' &&
+    run.conclusion === 'action_required'
+  )
+}
+
+function wasCreatedByActions(run: WorkflowRun): boolean {
+  return run.actor?.login === EXPECTED_ACTOR && run.triggering_actor?.login === EXPECTED_ACTOR
+}
+
+export function isApprovalCandidate(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return (
+    Number.isSafeInteger(run.id) &&
+    targetsExactPullRequest(run, scope) &&
+    isPendingApproval(run) &&
+    wasCreatedByActions(run) &&
+    run.path !== scope.excludedWorkflowPath &&
+    typeof run.path === 'string'
+  )
+}
+
+export function approvalCandidates(runs: WorkflowRun[], scope: ApprovalScope): WorkflowRun[] {
+  return runs.filter(run => isApprovalCandidate(run, scope))
+}
+
+function repositoryPath(repository: string): string {
+  return repository.split('/').map(encodeURIComponent).join('/')
+}
+
+async function responseError(response: Response): Promise<Error> {
+  const body = (await response.text()).slice(0, 1_000)
+  return new Error(`GitHub API request failed (${response.status} ${response.statusText}): ${body}`)
+}
+
+async function listActionRequiredRuns(
+  apiUrl: string,
+  token: string,
+  scope: ApprovalScope
+): Promise<WorkflowRun[]> {
+  const url = new URL(`${apiUrl}/repos/${repositoryPath(scope.repository)}/actions/runs`)
+  url.searchParams.set('event', 'pull_request')
+  url.searchParams.set('status', 'action_required')
+  url.searchParams.set('head_sha', scope.headSha)
+  url.searchParams.set('per_page', '100')
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!response.ok) throw await responseError(response)
+
+  const payload = (await response.json()) as Partial<WorkflowRunsResponse>
+  if (!Array.isArray(payload.workflow_runs)) {
+    throw new Error('GitHub API response did not contain workflow_runs')
+  }
+  return payload.workflow_runs
+}
+
+async function approveRun(apiUrl: string, token: string, repository: string, runId: number) {
+  const url = `${apiUrl}/repos/${repositoryPath(repository)}/actions/runs/${runId}/approve`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!response.ok) throw await responseError(response)
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+function describeRun(run: WorkflowRun): string {
+  return `${run.name ?? 'unnamed'} (${run.path ?? 'unknown path'}, run ${run.id ?? 'unknown'})`
+}
+
+async function main(): Promise<void> {
+  const environment = process.env as Environment
+  const token = required(environment, 'GH_TOKEN')
+  const apiUrl = (environment.GITHUB_API_URL ?? 'https://api.github.com').replace(/\/$/, '')
+  const scope = approvalScopeFromEnvironment(environment)
+  const approvedRunIds = new Set<number>()
+  let emptyPollsAfterApproval = 0
+
+  for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt++) {
+    const runs = await listActionRequiredRuns(apiUrl, token, scope)
+    const candidates = approvalCandidates(runs, scope).filter(
+      run => !approvedRunIds.has(run.id as number)
+    )
+
+    if (candidates.length === 0) {
+      if (approvedRunIds.size > 0) {
+        emptyPollsAfterApproval += 1
+        if (emptyPollsAfterApproval >= EMPTY_POLLS_AFTER_APPROVAL) break
+      }
+    } else {
+      emptyPollsAfterApproval = 0
+      for (const run of candidates) {
+        const runId = run.id as number
+        console.log(`Approving ${describeRun(run)} for ${scope.headSha}`)
+        await approveRun(apiUrl, token, scope.repository, runId)
+        approvedRunIds.add(runId)
+      }
+    }
+
+    if (attempt < MAX_POLL_ATTEMPTS) await sleep(POLL_INTERVAL_MS)
+  }
+
+  const remainingRuns = await listActionRequiredRuns(apiUrl, token, scope)
+  const remainingRelevant = remainingRuns.filter(
+    run =>
+      run.path !== scope.excludedWorkflowPath &&
+      run.repository?.full_name === scope.repository &&
+      run.head_sha?.toLowerCase() === scope.headSha &&
+      run.event === 'pull_request' &&
+      run.pull_requests?.some(pullRequest => pullRequest.number === scope.pullNumber) === true
+  )
+  if (remainingRelevant.length > 0) {
+    throw new Error(
+      `Refusing to leave non-excluded action_required runs: ${remainingRelevant.map(describeRun).join(', ')}`
+    )
+  }
+
+  console.log(
+    approvedRunIds.size === 0
+      ? `No non-excluded action_required follow-up runs appeared for ${scope.headSha}`
+      : `Approved ${approvedRunIds.size} validated follow-up run(s) for ${scope.headSha}`
+  )
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/scripts/approve-dependabot-followup-runs.ts
+++ b/scripts/approve-dependabot-followup-runs.ts
@@ -99,13 +99,21 @@ function wasCreatedByActions(run: WorkflowRun): boolean {
   return run.actor?.login === EXPECTED_ACTOR && run.triggering_actor?.login === EXPECTED_ACTOR
 }
 
+function workflowFilePath(path: string | undefined): string | undefined {
+  return path?.split('@', 1)[0]
+}
+
+function isExcludedWorkflow(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return workflowFilePath(run.path) === scope.excludedWorkflowPath
+}
+
 export function isApprovalCandidate(run: WorkflowRun, scope: ApprovalScope): boolean {
   return (
     Number.isSafeInteger(run.id) &&
     targetsExactPullRequest(run, scope) &&
     isPendingApproval(run) &&
     wasCreatedByActions(run) &&
-    run.path !== scope.excludedWorkflowPath &&
+    !isExcludedWorkflow(run, scope) &&
     typeof run.path === 'string'
   )
 }
@@ -216,9 +224,7 @@ async function pollOnce(
 
 function isRemainingRelevant(run: WorkflowRun, scope: ApprovalScope): boolean {
   return (
-    run.path !== scope.excludedWorkflowPath &&
-    targetsExactPullRequest(run, scope) &&
-    isPendingApproval(run)
+    !isExcludedWorkflow(run, scope) && targetsExactPullRequest(run, scope) && isPendingApproval(run)
   )
 }
 

--- a/scripts/approve-dependabot-followup-runs.ts
+++ b/scripts/approve-dependabot-followup-runs.ts
@@ -171,57 +171,89 @@ function describeRun(run: WorkflowRun): string {
   return `${run.name ?? 'unnamed'} (${run.path ?? 'unknown path'}, run ${run.id ?? 'unknown'})`
 }
 
+interface PollState {
+  approvedRunIds: Set<number>
+  emptyPollsAfterApproval: number
+}
+
+async function approveCandidatesForPoll(
+  runs: WorkflowRun[],
+  scope: ApprovalScope,
+  apiUrl: string,
+  token: string,
+  state: PollState
+): Promise<boolean> {
+  const candidates = approvalCandidates(runs, scope).filter(
+    run => !state.approvedRunIds.has(run.id as number)
+  )
+  if (candidates.length === 0) return false
+
+  for (const run of candidates) {
+    const runId = run.id as number
+    console.log(`Approving ${describeRun(run)} for ${scope.headSha}`)
+    await approveRun(apiUrl, token, scope.repository, runId)
+    state.approvedRunIds.add(runId)
+  }
+  return true
+}
+
+async function pollOnce(
+  apiUrl: string,
+  token: string,
+  scope: ApprovalScope,
+  state: PollState
+): Promise<boolean> {
+  const runs = await listActionRequiredRuns(apiUrl, token, scope)
+  if (await approveCandidatesForPoll(runs, scope, apiUrl, token, state)) {
+    state.emptyPollsAfterApproval = 0
+    return false
+  }
+
+  if (state.approvedRunIds.size === 0) return false
+  state.emptyPollsAfterApproval += 1
+  return state.emptyPollsAfterApproval >= EMPTY_POLLS_AFTER_APPROVAL
+}
+
+function isRemainingRelevant(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return (
+    run.path !== scope.excludedWorkflowPath &&
+    targetsExactPullRequest(run, scope) &&
+    isPendingApproval(run)
+  )
+}
+
+async function assertNoRelevantRunsRemain(
+  apiUrl: string,
+  token: string,
+  scope: ApprovalScope
+): Promise<void> {
+  const remainingRuns = await listActionRequiredRuns(apiUrl, token, scope)
+  const remainingRelevant = remainingRuns.filter(run => isRemainingRelevant(run, scope))
+  if (remainingRelevant.length === 0) return
+
+  throw new Error(
+    `Refusing to leave non-excluded action_required runs: ${remainingRelevant.map(describeRun).join(', ')}`
+  )
+}
+
 async function main(): Promise<void> {
   const environment = process.env as Environment
   const token = required(environment, 'GH_TOKEN')
   const apiUrl = (environment.GITHUB_API_URL ?? 'https://api.github.com').replace(/\/$/, '')
   const scope = approvalScopeFromEnvironment(environment)
-  const approvedRunIds = new Set<number>()
-  let emptyPollsAfterApproval = 0
+  const state: PollState = { approvedRunIds: new Set(), emptyPollsAfterApproval: 0 }
 
   for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt++) {
-    const runs = await listActionRequiredRuns(apiUrl, token, scope)
-    const candidates = approvalCandidates(runs, scope).filter(
-      run => !approvedRunIds.has(run.id as number)
-    )
-
-    if (candidates.length === 0) {
-      if (approvedRunIds.size > 0) {
-        emptyPollsAfterApproval += 1
-        if (emptyPollsAfterApproval >= EMPTY_POLLS_AFTER_APPROVAL) break
-      }
-    } else {
-      emptyPollsAfterApproval = 0
-      for (const run of candidates) {
-        const runId = run.id as number
-        console.log(`Approving ${describeRun(run)} for ${scope.headSha}`)
-        await approveRun(apiUrl, token, scope.repository, runId)
-        approvedRunIds.add(runId)
-      }
-    }
-
+    if (await pollOnce(apiUrl, token, scope, state)) break
     if (attempt < MAX_POLL_ATTEMPTS) await sleep(POLL_INTERVAL_MS)
   }
 
-  const remainingRuns = await listActionRequiredRuns(apiUrl, token, scope)
-  const remainingRelevant = remainingRuns.filter(
-    run =>
-      run.path !== scope.excludedWorkflowPath &&
-      run.repository?.full_name === scope.repository &&
-      run.head_sha?.toLowerCase() === scope.headSha &&
-      run.event === 'pull_request' &&
-      run.pull_requests?.some(pullRequest => pullRequest.number === scope.pullNumber) === true
-  )
-  if (remainingRelevant.length > 0) {
-    throw new Error(
-      `Refusing to leave non-excluded action_required runs: ${remainingRelevant.map(describeRun).join(', ')}`
-    )
-  }
+  await assertNoRelevantRunsRemain(apiUrl, token, scope)
 
   console.log(
-    approvedRunIds.size === 0
+    state.approvedRunIds.size === 0
       ? `No non-excluded action_required follow-up runs appeared for ${scope.headSha}`
-      : `Approved ${approvedRunIds.size} validated follow-up run(s) for ${scope.headSha}`
+      : `Approved ${state.approvedRunIds.size} validated follow-up run(s) for ${scope.headSha}`
   )
 }
 


### PR DESCRIPTION
Closes #270

## Summary

- grant the Dependabot lockfile workflow `actions: write` so it can approve downstream runs created by its validated `GITHUB_TOKEN` push
- poll only for `action_required` `pull_request` runs matching the exact repository, pushed SHA, PR number, and `github-actions[bot]` actor/triggering actor
- explicitly exclude the recursive `Dependabot Lockfile Fix` workflow and fail if any other scoped `action_required` run remains
- cover the approval predicate and environment validation with focused unit tests

## Verification

- `actionlint .github/workflows/dependabot-lockfile.yml` (actionlint 1.7.12)
- `bunx vitest run scripts/approve-dependabot-followup-runs.test.ts` (15/15 tests)
- `bun run test` (289/289 files, 6490/6490 tests)
- `bun run knip`
- `bun run lint`
- `bun run typecheck`
- `bun run format:check`
- targeted Prettier check for the workflow and new scripts
- `git diff --check`
- commit hooks: full coverage suite, TypeScript configs, coverage ratchet, lint-staged ESLint/Prettier

## Risk Acknowledgment

Risk: medium. This changes GitHub Actions approval behavior for Dependabot follow-up validation. Approval is deliberately limited to the exact validated lockfile SHA and PR, requires both actor identities to be `github-actions[bot]`, excludes the lockfile workflow itself, and runs only after the existing full validation suite has passed and the lockfile commit has been pushed and marked validated.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add auto-approval script for action-required Dependabot follow-up workflow runs
> - Adds [approve-dependabot-followup-runs.ts](https://github.com/HemSoft/hs-buddy/pull/279/files#diff-271de9d7df67184c7527a3eae09429657daadb5a19d6d1b311a2227ab3893217), a CLI script that polls the GitHub API and approves `action_required` workflow runs for a targeted Dependabot PR and commit SHA, skipping already-approved runs and an excluded workflow path.
> - The [dependabot-lockfile.yml](https://github.com/HemSoft/hs-buddy/pull/279/files#diff-35ee362c70f83aa8efbb73b529eb60804ead8dadccae748cc4bab16d27e68962) workflow invokes the script after pushing a validated lockfile fix, and gains `actions: write` permission to support approvals.
> - Updates `actions/setup-node` from v6.4.0 to v7.0.0 (pinned commit) across all workflow files.
> - Risk: the script throws an error if any relevant `action_required` runs remain after polling completes, which will fail the workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4cd50f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->