### PR TITLE
Bound hung CI dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Lint (ESLint)
@@ -81,6 +82,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Type check (TypeScript + Convex)
@@ -108,6 +110,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run tests with coverage
@@ -188,6 +191,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run electron tests with coverage
@@ -215,6 +219,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run IPC contract tests
@@ -242,6 +247,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run Convex server function tests
@@ -269,6 +275,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Ensure Chrome is available for E2E
@@ -320,6 +327,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Build (vite + electron)
@@ -351,6 +359,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run Lighthouse CI


### PR DESCRIPTION
Closes #271

## Summary

- bound every `bun install --frozen-lockfile` step in CI to 10 minutes
- preserve separate cache and install steps so logs identify whether cache restore or dependency installation stalled
- convert an intermittent six-hour install stall into a bounded required-check failure without weakening `ci-complete`

## Evidence

- run 28810998852 attempt 1: `test-ipc-contracts` dependency installation ran from 2026-07-06T17:37:17Z to 2026-07-06T23:37:04Z and was cancelled
- the same failed job reran successfully on 2026-07-22, installing dependencies in 12 seconds, confirming an intermittent stall rather than a deterministic lockfile failure
- all 9 CI dependency-install steps now have `timeout-minutes: 10`

## Verification

- `actionlint .github/workflows/ci.yml`
- timeout coverage assertion: 9 install steps / 9 timeouts
- `bun install --frozen-lockfile`
- `bun run lint:md`
- `bun x prettier --check .github/workflows/ci.yml`
- `git diff --check`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run deps:check`
- `bun run e18e`
- `bun run test:coverage` (289 files, 6478 tests)
- `bun run test:electron:coverage` (44 files, 855 tests)
- `bun run test:convex:coverage` (19 files, 241 tests)
- `bun run test:ipc-contracts` (2 files, 34 tests)
- `bun run security:electron`

## Risk Acknowledgment

Risk: medium. This changes timeout behavior for every required CI dependency-install step. Ten minutes is substantially above the observed healthy install range (roughly 8-18 seconds in the affected run) while preventing a transient Bun/network stall from consuming GitHub's six-hour job limit. Reviewers should verify the limit remains appropriate for cache misses and unusually slow package downloads.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 10-minute timeout to CI dependency install steps
> Adds `timeout-minutes: 10` to the 'Install dependencies' step across all jobs in [ci.yml](.github/workflows/ci.yml). This prevents hung package installs from blocking CI runners indefinitely by failing fast after 10 minutes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5eb88a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->