### PR TITLE
Fix React render-time ref mutations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Lint (ESLint)
@@ -81,6 +82,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Type check (TypeScript + Convex)
@@ -108,6 +110,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run tests with coverage
@@ -188,6 +191,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run electron tests with coverage
@@ -215,6 +219,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run IPC contract tests
@@ -242,6 +247,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run Convex server function tests
@@ -269,6 +275,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Ensure Chrome is available for E2E
@@ -320,6 +327,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Build (vite + electron)
@@ -351,6 +359,7 @@ jobs:
           restore-keys: ${{ runner.os }}-bun-
 
       - name: Install dependencies
+        timeout-minutes: 10
         run: bun install --frozen-lockfile
 
       - name: Run Lighthouse CI

--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -9,6 +9,7 @@ on:
     branches: [main]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: read
   statuses: write
@@ -130,3 +131,13 @@ jobs:
             -f context="Dependabot Lockfile Fix / validated" \
             -f description="Required CI checks passed before this lockfile commit was pushed" \
             -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Approve validated follow-up runs
+        if: steps.commit-lockfile.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ steps.commit-lockfile.outputs.sha }}
+          TARGET_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EXCLUDED_WORKFLOW_PATH: .github/workflows/dependabot-lockfile.yml
+        run: bun scripts/approve-dependabot-followup-runs.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.884] - 2026-07-23
+
+### Fixed
+
+- Close stale hook callback races
+
 ## [0.1.882] - 2026-07-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.880] - 2026-07-22
+
+### Fixed
+
+- Move React ref updates out of render (#273)
+
 ## [0.1.879] - 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Sync Electron 43 update with main
 - Simplify follow-up approval polling
 
+### Fixed
+
+- Scope Copilot usage to current billing month
+- Address billing period review findings
+
 ## [0.1.878] - 2026-07-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.882] - 2026-07-23
+
+### Changed
+
+- Merge PR 279 with latest main
+
+## [0.1.880] - 2026-07-22
+
+### Fixed
+
+- Normalize workflow paths before approval
+
 ## [0.1.879] - 2026-07-22
 
 ### Changed
 
 - Sync Electron 43 update with main
+- Simplify follow-up approval polling
 
 ## [0.1.878] - 2026-07-22
 
 ### Fixed
 
+- Approve validated Dependabot follow-ups
 - Deduplicate normalized asset rows
 
 ## [0.1.877] - 2026-07-22

--- a/electron/ipc/githubHandlers.test.ts
+++ b/electron/ipc/githubHandlers.test.ts
@@ -25,11 +25,14 @@ vi.mock('../config', () => ({
 }))
 
 const mockExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
-const mockExecFileAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+const mockExecFileAsync = vi.fn((file: string, args: string[], options: unknown) =>
+  mockExecAsync(`${file} ${args.join(' ')}`, options)
+)
 
 vi.mock('../utils', () => ({
   execAsync: (...args: unknown[]) => mockExecAsync(...args),
-  execFileAsync: (...args: unknown[]) => mockExecFileAsync(...args),
+  execFileAsync: (file: string, args: string[], options: unknown) =>
+    mockExecFileAsync(file, args, options),
 }))
 
 vi.mock('../../src/utils/errorUtils', () => ({
@@ -249,6 +252,56 @@ describe('githubHandlers', () => {
       const result = await handler({}, 'test-org', 'testuser')
       expect(result.success).toBe(true)
       expect(result.data.org).toBe('test-org')
+    })
+
+    it('requests and parses only the current UTC billing period', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
+      try {
+        const { parseBillingUsage } = await import('../../src/utils/billingParsers')
+
+        vi.mocked(parseBillingUsage).mockReturnValueOnce({
+          premiumRequests: 7,
+          grossCost: 0.07,
+          discount: 0.02,
+          netCost: 0.05,
+          businessSeats: 2,
+          seatPlan: 'business',
+        })
+
+        const usageItems = [{ product: 'copilot', date: '2026-07-01' }]
+        mockExecAsync.mockResolvedValueOnce({
+          stdout: JSON.stringify({ usageItems }),
+          stderr: '',
+        })
+        mockExecAsync.mockResolvedValueOnce({
+          stdout: JSON.stringify({ seat_breakdown: { total: 3 } }),
+          stderr: '',
+        })
+
+        const handler = handlers.get('github:get-copilot-usage')!
+        const result = await handler({}, 'test-org')
+
+        expect(result.success).toBe(true)
+        expect(result.data).toEqual(
+          expect.objectContaining({
+            premiumRequests: 7,
+            grossCost: 0.07,
+            discount: 0.02,
+            netCost: 0.05,
+            businessSeats: 2,
+            seats: 3,
+            billingMonth: 7,
+            billingYear: 2026,
+          })
+        )
+        expect(mockExecAsync.mock.calls[0]?.[0]).toContain(
+          '/settings/billing/usage?year=2026&month=7'
+        )
+        expect(parseBillingUsage).toHaveBeenCalledWith(usageItems, { year: 2026, month: 7 })
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('returns error on failure', async () => {
@@ -764,25 +817,47 @@ describe('githubHandlers', () => {
         .mockResolvedValueOnce({ stdout: '[]', stderr: '' })
         .mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
 
-      const result = await fetchCopilotMetrics('test-org')
-      const assembleArgs = vi.mocked(assembleCopilotMetrics).mock.calls[0][0]
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          success: true,
-          data: expect.objectContaining({ org: 'test-org', billingYear: 2026, billingMonth: 1 }),
+      try {
+        const result = await fetchCopilotMetrics('test-org')
+        const assembleArgs = vi.mocked(assembleCopilotMetrics).mock.calls[0][0]
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({ org: 'test-org', billingYear: 2026, billingMonth: 1 }),
+          })
+        )
+        expect(parseBillingUsage).toHaveBeenCalledWith([{ product: 'copilot', grossQuantity: 7 }], {
+          year: 2026,
+          month: 7,
         })
-      )
-      expect(parseBillingUsage).toHaveBeenCalledWith([{ product: 'copilot', grossQuantity: 7 }])
-      expect(assembleArgs).toEqual(
-        expect.objectContaining({
-          org: 'test-org',
-          usageOk: true,
-          usage: expect.objectContaining({ premiumRequests: 7, businessSeats: 3 }),
-        })
-      )
-      expect(mockExecAsync.mock.calls[0]?.[0]).toContain('/orgs/test-org/settings/billing/usage')
-      expect(mockExecAsync.mock.calls[1]?.[0]).toContain('/users/test-org/settings/billing/usage')
+        expect(assembleArgs).toEqual(
+          expect.objectContaining({
+            org: 'test-org',
+            usageOk: true,
+            usage: expect.objectContaining({ premiumRequests: 7, businessSeats: 3 }),
+          })
+        )
+        expect(mockExecAsync.mock.calls[0]?.[0]).toContain('/orgs/test-org/settings/billing/usage')
+        expect(mockExecAsync.mock.calls[1]?.[0]).toContain('/users/test-org/settings/billing/usage')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('rejects invalid GitHub account slugs before invoking gh api', async () => {
+      const { fetchCopilotMetrics } = await import('./githubHandlers')
+
+      const result = await fetchCopilotMetrics('test-org; echo injected')
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'test-org; echo injected'",
+      })
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
     })
 
     it('fetchCopilotMetrics continues after double 404 billing misses', async () => {
@@ -945,6 +1020,33 @@ describe('githubHandlers', () => {
       expect(mockExecAsync.mock.calls[2]?.[0]).toContain(
         '/enterprises/Bertelsmann/settings/billing/budgets?page=1'
       )
+    })
+
+    it('github:get-copilot-budget scopes spend to the current billing month', async () => {
+      const { extractCopilotSpend } = await import('../../src/utils/billingParsers')
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+
+      try {
+        mockExecAsync
+          .mockResolvedValueOnce({ stdout: '[]', stderr: '' })
+          .mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
+
+        const handler = handlers.get('github:get-copilot-budget')!
+        await handler({}, 'test-org')
+
+        expect(extractCopilotSpend).toHaveBeenCalledWith(expect.anything(), {
+          year: 2026,
+          month: 7,
+        })
+        expect(mockExecFileAsync).toHaveBeenCalledWith(
+          'gh',
+          ['api', '/orgs/test-org/settings/billing/usage?year=2026&month=7'],
+          expect.objectContaining({ encoding: 'utf8', timeout: 15000 })
+        )
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('github:get-copilot-budget marks spend as unavailable when usage fetch fails', async () => {

--- a/electron/ipc/githubHandlers.ts
+++ b/electron/ipc/githubHandlers.ts
@@ -49,6 +49,27 @@ export const PERSONAL_BUDGETS: Record<string, number> = {}
 type ExecAsyncSettledResult = PromiseSettledResult<Awaited<ReturnType<typeof execAsync>>>
 type CliStdoutSettledResult = PromiseSettledResult<{ stdout: string }>
 
+const GITHUB_ACCOUNT_SLUG_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+
+function assertValidGitHubAccountSlug(org: string): void {
+  if (!GITHUB_ACCOUNT_SLUG_PATTERN.test(org)) {
+    throw new Error(`Invalid GitHub account slug: '${org}'`)
+  }
+}
+
+async function runGhApi(
+  endpoint: string,
+  execEnv: NodeJS.ProcessEnv,
+  timeout = API_TIMEOUT_MS,
+  headers: string[] = []
+): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('gh', ['api', endpoint, ...headers.flatMap(header => ['-H', header])], {
+    encoding: 'utf8',
+    timeout,
+    env: execEnv,
+  })
+}
+
 function asCliStdoutSettledResult(result: ExecAsyncSettledResult): CliStdoutSettledResult {
   return result as CliStdoutSettledResult
 }
@@ -87,52 +108,49 @@ async function getTokenEnv(username?: string): Promise<NodeJS.ProcessEnv> {
  *  Returns ParsedBillingUsage. Throws on non-404 errors. */
 async function fetchBillingUsage(
   org: string,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<ParsedBillingUsage> {
+  assertValidGitHubAccountSlug(org)
   let stdout: string
   try {
-    const result = await execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    })
+    const result = await runGhApi(
+      `/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`,
+      execEnv
+    )
     stdout = result.stdout
   } catch (orgError: unknown) {
     if (!isNotFoundError(orgError)) throw orgError
-    const result = await execAsync(`gh api /users/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    })
+    const result = await runGhApi(
+      `/users/${org}/settings/billing/usage?year=${year}&month=${month}`,
+      execEnv
+    )
     stdout = result.stdout
   }
 
   const data = JSON.parse(stdout.trim()) as { usageItems: BillingUsageItem[] }
-  return parseBillingUsage(data.usageItems)
+  return parseBillingUsage(data.usageItems, { year, month })
 }
 
 /** Fetch budget + Copilot usage spend (net, AI Credits billing) for a non-personal org. */
 async function fetchBudgetAndSpend(
   org: string,
-  _year: number,
-  _month: number,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<{ budgetAmount: number | null; spent: number }> {
+  assertValidGitHubAccountSlug(org)
   const [budgetResult, spendResult] = await Promise.allSettled([
-    execAsync(
-      `gh api /organizations/${org}/settings/billing/budgets -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
-    ),
-    execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    }),
+    runGhApi(`/organizations/${org}/settings/billing/budgets`, execEnv, API_TIMEOUT_MS, [
+      'X-GitHub-Api-Version: 2022-11-28',
+    ]),
+    runGhApi(`/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`, execEnv),
   ])
 
   return {
     budgetAmount: extractBudgetFromResult(budgetResult).budgetAmount,
-    spent: extractCopilotSpend(spendResult).net,
+    spent: extractCopilotSpend(spendResult, { year, month }).net,
   }
 }
 
@@ -161,7 +179,7 @@ export async function fetchCopilotMetrics(
   let usageOk = false
 
   try {
-    usage = await fetchBillingUsage(org, execEnv)
+    usage = await fetchBillingUsage(org, year, month, execEnv)
     usageOk = true
   } catch (error: unknown) {
     if (!isNotFoundError(error)) {
@@ -201,24 +219,25 @@ export async function fetchCopilotMetrics(
 /** Try org billing endpoint, fall back to user. Throws descriptive error on double-404. */
 async function fetchOrgOrUserBillingUsage(
   org: string,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<string> {
+  assertValidGitHubAccountSlug(org)
   try {
-    const result = await execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    })
+    const result = await runGhApi(
+      `/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`,
+      execEnv
+    )
     return result.stdout
   } catch (orgError: unknown) {
     if (!isNotFoundError(orgError)) throw orgError
 
     try {
-      const result = await execAsync(`gh api /users/${org}/settings/billing/usage`, {
-        encoding: 'utf8',
-        timeout: API_TIMEOUT_MS,
-        env: execEnv,
-      })
+      const result = await runGhApi(
+        `/users/${org}/settings/billing/usage?year=${year}&month=${month}`,
+        execEnv
+      )
       return result.stdout
     } catch (userError: unknown) {
       if (isNotFoundError(userError)) {
@@ -298,9 +317,11 @@ async function resolveEnterpriseBudgetFallback(
 
 function resolveSpendState(
   org: string,
-  usageResult: ExecAsyncSettledResult
+  usageResult: ExecAsyncSettledResult,
+  year: number,
+  month: number
 ): { spent: number; gross: number; spentError: string | null } {
-  const { net, gross } = extractCopilotSpend(asCliStdoutSettledResult(usageResult))
+  const { net, gross } = extractCopilotSpend(asCliStdoutSettledResult(usageResult), { year, month })
   return {
     spent: net,
     gross,
@@ -311,8 +332,8 @@ function resolveSpendState(
 /** Fetch budget + spend for an org via billing APIs, with enterprise budget fallback. */
 async function fetchOrgBudgetAndSpend(
   org: string,
-  _year: number,
-  _month: number,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<{
   budgetAmount: number | null
@@ -322,16 +343,12 @@ async function fetchOrgBudgetAndSpend(
   gross: number
   spentError: string | null
 }> {
+  assertValidGitHubAccountSlug(org)
   const [budgetResult, usageResult] = await Promise.allSettled([
-    execAsync(
-      `gh api /organizations/${org}/settings/billing/budgets -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
-    ),
-    execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    }),
+    runGhApi(`/organizations/${org}/settings/billing/budgets`, execEnv, API_TIMEOUT_MS, [
+      'X-GitHub-Api-Version: 2022-11-28',
+    ]),
+    runGhApi(`/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`, execEnv),
   ])
 
   const extractedBudget = extractBudgetFromResult(asCliStdoutSettledResult(budgetResult))
@@ -341,7 +358,7 @@ async function fetchOrgBudgetAndSpend(
     extractedBudget.preventFurtherUsage,
     execEnv
   )
-  const spentState = resolveSpendState(org, usageResult)
+  const spentState = resolveSpendState(org, usageResult, year, month)
 
   return {
     ...budgetState,
@@ -665,12 +682,17 @@ function registerCopilotUsageHandlers(): void {
     async (_event, org: string, username?: string) => {
       try {
         const execEnv = await getTokenEnv(username)
-        const stdout = await fetchOrgOrUserBillingUsage(org, execEnv)
+        const now = new Date()
+        const billingYear = now.getUTCFullYear()
+        const billingMonth = now.getUTCMonth() + 1
+        const stdout = await fetchOrgOrUserBillingUsage(org, billingYear, billingMonth, execEnv)
 
         const data = JSON.parse(stdout.trim()) as { usageItems: BillingUsageItem[] }
-        const parsed = parseBillingUsage(data.usageItems)
+        const parsed = parseBillingUsage(data.usageItems, {
+          year: billingYear,
+          month: billingMonth,
+        })
         const seatCount = await fetchSeatCount(org, execEnv)
-        const now = new Date()
 
         let userCredits: number | null = null
         if (username) {
@@ -690,8 +712,8 @@ function registerCopilotUsageHandlers(): void {
             org,
             ...parsed,
             seats: seatCount ?? parsed.businessSeats,
-            billingMonth: now.getUTCMonth() + 1,
-            billingYear: now.getUTCFullYear(),
+            billingMonth,
+            billingYear,
             userCredits,
             allItems: data.usageItems.filter(item => item.product === 'copilot'),
             fetchedAt: Date.now(),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.883",
+  "version": "0.1.884",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.879",
+  "version": "0.1.880",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.879",
+  "version": "0.1.882",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/approve-dependabot-followup-runs.test.ts
+++ b/scripts/approve-dependabot-followup-runs.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  approvalCandidates,
+  approvalScopeFromEnvironment,
+  isApprovalCandidate,
+  type ApprovalScope,
+  type WorkflowRun,
+} from './approve-dependabot-followup-runs'
+
+const scope: ApprovalScope = {
+  repository: 'HemSoft/hs-buddy',
+  headSha: '7301537c00000000000000000000000000000000',
+  pullNumber: 267,
+  excludedWorkflowPath: '.github/workflows/dependabot-lockfile.yml',
+}
+
+function candidate(overrides: Partial<WorkflowRun> = {}): WorkflowRun {
+  return {
+    id: 28_761_315_228,
+    name: 'CI',
+    path: '.github/workflows/ci.yml',
+    event: 'pull_request',
+    status: 'completed',
+    conclusion: 'action_required',
+    head_sha: scope.headSha,
+    actor: { login: 'github-actions[bot]' },
+    triggering_actor: { login: 'github-actions[bot]' },
+    repository: { full_name: scope.repository },
+    pull_requests: [{ number: scope.pullNumber }],
+    ...overrides,
+  }
+}
+
+describe('isApprovalCandidate', () => {
+  it('accepts the exact validated follow-up run shape', () => {
+    expect(isApprovalCandidate(candidate(), scope)).toBe(true)
+  })
+
+  it.each([
+    ['repository', { repository: { full_name: 'HemSoft/other' } }],
+    ['head SHA', { head_sha: 'a'.repeat(40) }],
+    ['event', { event: 'push' }],
+    ['status', { status: 'queued' }],
+    ['conclusion', { conclusion: 'success' }],
+    ['actor', { actor: { login: 'dependabot[bot]' } }],
+    ['triggering actor', { triggering_actor: { login: 'dependabot[bot]' } }],
+    ['pull request', { pull_requests: [{ number: 268 }] }],
+  ])('rejects a run with the wrong %s', (_field, overrides) => {
+    expect(isApprovalCandidate(candidate(overrides), scope)).toBe(false)
+  })
+
+  it('rejects the recursive Dependabot Lockfile Fix run', () => {
+    for (const path of [
+      '.github/workflows/dependabot-lockfile.yml',
+      '.github/workflows/dependabot-lockfile.yml@refs/pull/267/merge',
+    ]) {
+      expect(
+        isApprovalCandidate(
+          candidate({
+            name: 'Dependabot Lockfile Fix',
+            path,
+          }),
+          scope
+        )
+      ).toBe(false)
+    }
+  })
+})
+
+describe('approvalCandidates', () => {
+  it('returns only tightly scoped non-recursive runs', () => {
+    const runs = [
+      candidate(),
+      candidate({ id: 2, path: '.github/workflows/security.yml', name: 'Security Scanning' }),
+      candidate({ id: 3, head_sha: 'b'.repeat(40) }),
+      candidate({ id: 4, path: scope.excludedWorkflowPath }),
+    ]
+
+    expect(approvalCandidates(runs, scope).map(run => run.id)).toEqual([28_761_315_228, 2])
+  })
+})
+
+describe('approvalScopeFromEnvironment', () => {
+  it('parses and normalizes a complete scope', () => {
+    expect(
+      approvalScopeFromEnvironment({
+        TARGET_REPOSITORY: 'HemSoft/hs-buddy',
+        TARGET_SHA: 'A'.repeat(40),
+        TARGET_PR_NUMBER: '267',
+        EXCLUDED_WORKFLOW_PATH: '.github/workflows/dependabot-lockfile.yml',
+      })
+    ).toEqual({ ...scope, headSha: 'a'.repeat(40) })
+  })
+
+  it.each([
+    ['repository', { TARGET_REPOSITORY: 'hs-buddy' }],
+    ['SHA', { TARGET_SHA: 'short' }],
+    ['PR number', { TARGET_PR_NUMBER: '0' }],
+  ])('rejects an invalid %s', (_field, override) => {
+    expect(() =>
+      approvalScopeFromEnvironment({
+        TARGET_REPOSITORY: scope.repository,
+        TARGET_SHA: scope.headSha,
+        TARGET_PR_NUMBER: String(scope.pullNumber),
+        EXCLUDED_WORKFLOW_PATH: scope.excludedWorkflowPath,
+        ...override,
+      })
+    ).toThrow()
+  })
+})

--- a/scripts/approve-dependabot-followup-runs.ts
+++ b/scripts/approve-dependabot-followup-runs.ts
@@ -1,0 +1,268 @@
+const EXPECTED_ACTOR = 'github-actions[bot]'
+const MAX_POLL_ATTEMPTS = 12
+const POLL_INTERVAL_MS = 5_000
+const EMPTY_POLLS_AFTER_APPROVAL = 2
+
+interface WorkflowActor {
+  login?: string
+}
+
+interface WorkflowRepository {
+  full_name?: string
+}
+
+interface WorkflowPullRequest {
+  number?: number
+}
+
+export interface WorkflowRun {
+  id?: number
+  name?: string
+  path?: string
+  event?: string
+  status?: string
+  conclusion?: string | null
+  head_sha?: string
+  actor?: WorkflowActor | null
+  triggering_actor?: WorkflowActor | null
+  repository?: WorkflowRepository
+  pull_requests?: WorkflowPullRequest[]
+}
+
+export interface ApprovalScope {
+  repository: string
+  headSha: string
+  pullNumber: number
+  excludedWorkflowPath: string
+}
+
+interface WorkflowRunsResponse {
+  workflow_runs: WorkflowRun[]
+}
+
+interface Environment {
+  GH_TOKEN?: string
+  GITHUB_API_URL?: string
+  TARGET_REPOSITORY?: string
+  TARGET_SHA?: string
+  TARGET_PR_NUMBER?: string
+  EXCLUDED_WORKFLOW_PATH?: string
+}
+
+function required(environment: Environment, name: keyof Environment): string {
+  const value = environment[name]?.trim()
+  if (!value) throw new Error(`${name} is required`)
+  return value
+}
+
+export function approvalScopeFromEnvironment(environment: Environment): ApprovalScope {
+  const repository = required(environment, 'TARGET_REPOSITORY')
+  if (!/^[^/\s]+\/[^/\s]+$/.test(repository)) {
+    throw new Error('TARGET_REPOSITORY must be in owner/repository form')
+  }
+
+  const headSha = required(environment, 'TARGET_SHA').toLowerCase()
+  if (!/^[0-9a-f]{40}$/.test(headSha)) {
+    throw new Error('TARGET_SHA must be a full 40-character commit SHA')
+  }
+
+  const pullNumber = Number(required(environment, 'TARGET_PR_NUMBER'))
+  if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error('TARGET_PR_NUMBER must be a positive integer')
+  }
+
+  return {
+    repository,
+    headSha,
+    pullNumber,
+    excludedWorkflowPath: required(environment, 'EXCLUDED_WORKFLOW_PATH'),
+  }
+}
+
+function targetsExactPullRequest(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return (
+    run.repository?.full_name === scope.repository &&
+    run.head_sha?.toLowerCase() === scope.headSha &&
+    run.pull_requests?.some(pullRequest => pullRequest.number === scope.pullNumber) === true
+  )
+}
+
+function isPendingApproval(run: WorkflowRun): boolean {
+  return (
+    run.event === 'pull_request' &&
+    run.status === 'completed' &&
+    run.conclusion === 'action_required'
+  )
+}
+
+function wasCreatedByActions(run: WorkflowRun): boolean {
+  return run.actor?.login === EXPECTED_ACTOR && run.triggering_actor?.login === EXPECTED_ACTOR
+}
+
+function workflowFilePath(path: string | undefined): string | undefined {
+  return path?.split('@', 1)[0]
+}
+
+function isExcludedWorkflow(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return workflowFilePath(run.path) === scope.excludedWorkflowPath
+}
+
+export function isApprovalCandidate(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return (
+    Number.isSafeInteger(run.id) &&
+    targetsExactPullRequest(run, scope) &&
+    isPendingApproval(run) &&
+    wasCreatedByActions(run) &&
+    !isExcludedWorkflow(run, scope) &&
+    typeof run.path === 'string'
+  )
+}
+
+export function approvalCandidates(runs: WorkflowRun[], scope: ApprovalScope): WorkflowRun[] {
+  return runs.filter(run => isApprovalCandidate(run, scope))
+}
+
+function repositoryPath(repository: string): string {
+  return repository.split('/').map(encodeURIComponent).join('/')
+}
+
+async function responseError(response: Response): Promise<Error> {
+  const body = (await response.text()).slice(0, 1_000)
+  return new Error(`GitHub API request failed (${response.status} ${response.statusText}): ${body}`)
+}
+
+async function listActionRequiredRuns(
+  apiUrl: string,
+  token: string,
+  scope: ApprovalScope
+): Promise<WorkflowRun[]> {
+  const url = new URL(`${apiUrl}/repos/${repositoryPath(scope.repository)}/actions/runs`)
+  url.searchParams.set('event', 'pull_request')
+  url.searchParams.set('status', 'action_required')
+  url.searchParams.set('head_sha', scope.headSha)
+  url.searchParams.set('per_page', '100')
+
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!response.ok) throw await responseError(response)
+
+  const payload = (await response.json()) as Partial<WorkflowRunsResponse>
+  if (!Array.isArray(payload.workflow_runs)) {
+    throw new Error('GitHub API response did not contain workflow_runs')
+  }
+  return payload.workflow_runs
+}
+
+async function approveRun(apiUrl: string, token: string, repository: string, runId: number) {
+  const url = `${apiUrl}/repos/${repositoryPath(repository)}/actions/runs/${runId}/approve`
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+  })
+  if (!response.ok) throw await responseError(response)
+}
+
+function sleep(milliseconds: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+function describeRun(run: WorkflowRun): string {
+  return `${run.name ?? 'unnamed'} (${run.path ?? 'unknown path'}, run ${run.id ?? 'unknown'})`
+}
+
+interface PollState {
+  approvedRunIds: Set<number>
+  emptyPollsAfterApproval: number
+}
+
+async function approveCandidatesForPoll(
+  runs: WorkflowRun[],
+  scope: ApprovalScope,
+  apiUrl: string,
+  token: string,
+  state: PollState
+): Promise<boolean> {
+  const candidates = approvalCandidates(runs, scope).filter(
+    run => !state.approvedRunIds.has(run.id as number)
+  )
+  if (candidates.length === 0) return false
+
+  for (const run of candidates) {
+    const runId = run.id as number
+    console.log(`Approving ${describeRun(run)} for ${scope.headSha}`)
+    await approveRun(apiUrl, token, scope.repository, runId)
+    state.approvedRunIds.add(runId)
+  }
+  return true
+}
+
+async function pollOnce(
+  apiUrl: string,
+  token: string,
+  scope: ApprovalScope,
+  state: PollState
+): Promise<boolean> {
+  const runs = await listActionRequiredRuns(apiUrl, token, scope)
+  if (await approveCandidatesForPoll(runs, scope, apiUrl, token, state)) {
+    state.emptyPollsAfterApproval = 0
+    return false
+  }
+
+  if (state.approvedRunIds.size === 0) return false
+  state.emptyPollsAfterApproval += 1
+  return state.emptyPollsAfterApproval >= EMPTY_POLLS_AFTER_APPROVAL
+}
+
+function isRemainingRelevant(run: WorkflowRun, scope: ApprovalScope): boolean {
+  return (
+    !isExcludedWorkflow(run, scope) && targetsExactPullRequest(run, scope) && isPendingApproval(run)
+  )
+}
+
+async function assertNoRelevantRunsRemain(
+  apiUrl: string,
+  token: string,
+  scope: ApprovalScope
+): Promise<void> {
+  const remainingRuns = await listActionRequiredRuns(apiUrl, token, scope)
+  const remainingRelevant = remainingRuns.filter(run => isRemainingRelevant(run, scope))
+  if (remainingRelevant.length === 0) return
+
+  throw new Error(
+    `Refusing to leave non-excluded action_required runs: ${remainingRelevant.map(describeRun).join(', ')}`
+  )
+}
+
+async function main(): Promise<void> {
+  const environment = process.env as Environment
+  const token = required(environment, 'GH_TOKEN')
+  const apiUrl = (environment.GITHUB_API_URL ?? 'https://api.github.com').replace(/\/$/, '')
+  const scope = approvalScopeFromEnvironment(environment)
+  const state: PollState = { approvedRunIds: new Set(), emptyPollsAfterApproval: 0 }
+
+  for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt++) {
+    if (await pollOnce(apiUrl, token, scope, state)) break
+    if (attempt < MAX_POLL_ATTEMPTS) await sleep(POLL_INTERVAL_MS)
+  }
+
+  await assertNoRelevantRunsRemain(apiUrl, token, scope)
+
+  console.log(
+    state.approvedRunIds.size === 0
+      ? `No non-excluded action_required follow-up runs appeared for ${scope.headSha}`
+      : `Approved ${state.approvedRunIds.size} validated follow-up run(s) for ${scope.headSha}`
+  )
+}
+
+if (import.meta.main) {
+  await main()
+}

--- a/src/components/RateLimitGauge.tsx
+++ b/src/components/RateLimitGauge.tsx
@@ -41,26 +41,15 @@ function formatResetTime(resetTimestamp: number): string {
 
 function useCountdownAnimation(remaining: number, refreshInterval: number): number {
   const [countdown, setCountdown] = useState(1)
-  const [previousRemaining, setPreviousRemaining] = useState(remaining)
   const animFrameRef = useRef<number>(0)
-  const startTimeRef = useRef<number | null>(null)
-
-  if (startTimeRef.current === null) {
-    startTimeRef.current = Date.now()
-  }
-
-  if (remaining !== previousRemaining) {
-    setPreviousRemaining(remaining)
-    startTimeRef.current = Date.now()
-    setCountdown(1)
-  }
+  const startTimeRef = useRef(Date.now())
 
   useEffect(() => {
+    startTimeRef.current = Date.now()
+    setCountdown(1)
     const intervalMs = refreshInterval * 1000
     const tick = () => {
-      /* v8 ignore next -- startTimeRef is always primed during render above */
-      const startedAt = startTimeRef.current ?? Date.now()
-      const elapsed = Date.now() - startedAt
+      const elapsed = Date.now() - startTimeRef.current
       const next = Math.max(0, 1 - elapsed / intervalMs)
       setCountdown(next)
       if (next > 0) animFrameRef.current = requestAnimationFrame(tick)

--- a/src/hooks/useAIReviewMonitor.test.ts
+++ b/src/hooks/useAIReviewMonitor.test.ts
@@ -119,6 +119,32 @@ describe('useAIReviewMonitor', () => {
     expect(result.current.reviewBanner).not.toBeNull()
   })
 
+  it('resets completed review state after the monitored pull request changes', async () => {
+    const provider = makeProvider({
+      poll: vi.fn().mockResolvedValue({ status: 'completed' }),
+    })
+    const { result, rerender } = renderHook(
+      (options: typeof defaultOptions) => useAIReviewMonitor({ provider, ...options }),
+      { initialProps: defaultOptions }
+    )
+
+    await act(async () => {
+      await result.current.handleRequestReview()
+      vi.advanceTimersByTime(POLL_MS)
+    })
+    expect(result.current.reviewState).toBe('done')
+    expect(result.current.reviewBanner).not.toBeNull()
+
+    rerender({
+      ...defaultOptions,
+      prId: 43,
+      prUrl: 'https://github.com/org/repo/pull/43',
+    })
+
+    expect(result.current.reviewState).toBe('idle')
+    expect(result.current.reviewBanner).toBeNull()
+  })
+
   it('does not request if state is not idle', async () => {
     const triggerFn = vi.fn().mockResolvedValue(undefined)
     const provider = makeProvider({

--- a/src/hooks/useAIReviewMonitor.ts
+++ b/src/hooks/useAIReviewMonitor.ts
@@ -139,14 +139,11 @@ function useResetAIReviewMonitorState(
   setReviewState: (state: AIReviewState) => void,
   setReviewBanner: (banner: { completedAt: number } | null) => void
 ) {
-  const [previousMonitorResetKey, setPreviousMonitorResetKey] = useState(monitorResetKey)
-
   /* v8 ignore start */
-  if (previousMonitorResetKey !== monitorResetKey) {
-    setPreviousMonitorResetKey(monitorResetKey)
+  useEffect(() => {
     setReviewState('idle')
     setReviewBanner(null)
-  }
+  }, [monitorResetKey, setReviewState, setReviewBanner])
   /* v8 ignore stop */
 }
 

--- a/src/hooks/useAppTabs.ts
+++ b/src/hooks/useAppTabs.ts
@@ -126,9 +126,13 @@ export function useAppTabs({ onViewOpen, onViewClose }: UseAppTabsOptions) {
   const { tabs, activeTabId } = tabState
   const nextTabIdRef = useRef(0)
   const onViewCloseRef = useRef(onViewClose)
-  onViewCloseRef.current = onViewClose
   const onViewOpenRef = useRef(onViewOpen)
-  onViewOpenRef.current = onViewOpen
+  useEffect(() => {
+    onViewCloseRef.current = onViewClose
+  }, [onViewClose])
+  useEffect(() => {
+    onViewOpenRef.current = onViewOpen
+  }, [onViewOpen])
   useEffect(() => {
     onViewOpenRef.current(DASHBOARD_VIEW_ID)
   }, [])

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -211,9 +211,12 @@ export function useAutoRefresh(
   }, [cardId, settings])
 
   const refreshRef = useRef(refreshFn)
-  refreshRef.current = refreshFn
   const pausedRef = useRef(paused)
-  pausedRef.current = paused
+  // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- latest callback avoids restarting the refresh interval when callers pass a fresh function
+  refreshRef.current = refreshFn
+  useEffect(() => {
+    pausedRef.current = paused
+  }, [paused])
   const mountedRef = useRef(true)
   useEffect(
     () => () => {

--- a/src/hooks/useAutoRefresh.ts
+++ b/src/hooks/useAutoRefresh.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from 'react'
 import { formatDistanceToNow, formatSecondsCountdown } from '../utils/dateUtils'
 import { safeGetItem, safeSetItem, safeGetJson, safeSetJson } from '../utils/storage'
 
@@ -214,7 +214,7 @@ export function useAutoRefresh(
   const pausedRef = useRef(paused)
   // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- latest callback avoids restarting the refresh interval when callers pass a fresh function
   refreshRef.current = refreshFn
-  useEffect(() => {
+  useLayoutEffect(() => {
     pausedRef.current = paused
   }, [paused])
   const mountedRef = useRef(true)

--- a/src/hooks/useCopilotReviewMonitor.ts
+++ b/src/hooks/useCopilotReviewMonitor.ts
@@ -137,14 +137,11 @@ function useResetCopilotReviewMonitorState(
   setCopilotReviewState: (state: CopilotReviewState) => void,
   setCopilotReviewBanner: (banner: { completedAt: number } | null) => void
 ) {
-  const [previousMonitorResetKey, setPreviousMonitorResetKey] = useState(monitorResetKey)
-
   /* v8 ignore start */
-  if (previousMonitorResetKey !== monitorResetKey) {
-    setPreviousMonitorResetKey(monitorResetKey)
+  useEffect(() => {
     setCopilotReviewState('idle')
     setCopilotReviewBanner(null)
-  }
+  }, [monitorResetKey, setCopilotReviewState, setCopilotReviewBanner])
   /* v8 ignore stop */
 }
 

--- a/src/hooks/useDashboardCards.ts
+++ b/src/hooks/useDashboardCards.ts
@@ -121,7 +121,9 @@ export function useDashboardCards() {
   const toggleVersionRef = useRef(0)
   const mountedRef = useIsMounted()
 
-  visibilityRef.current = visibility
+  useEffect(() => {
+    visibilityRef.current = visibility
+  }, [visibility])
 
   useEffect(() => {
     const raw = safeGetItem(CACHE_KEY)

--- a/src/hooks/useFinance.ts
+++ b/src/hooks/useFinance.ts
@@ -220,10 +220,13 @@ export function useFinance() {
 
   const abortRef = useRef(false)
   const watchlistRef = useRef(watchlist)
-  watchlistRef.current = watchlist
   // Tracks whether the user has mutated the watchlist locally. If so, we must
   // NOT overwrite their changes when the async IPC load resolves.
   const mutatedRef = useRef(false)
+
+  useEffect(() => {
+    watchlistRef.current = watchlist
+  }, [watchlist])
 
   const refresh = useCallback((symbols?: string[]) => {
     const list = symbols ?? watchlistRef.current

--- a/src/hooks/useLatest.ts
+++ b/src/hooks/useLatest.ts
@@ -9,11 +9,13 @@ import { useRef } from 'react'
  * useEffect(() => { fnRef.current = fn }, [fn])
  * ```
  *
- * Assigning in the render body (not an effect) avoids the one-frame
- * stale window that the useEffect version introduces.
+ * Assigning during render intentionally keeps the ref current for effects and
+ * event handlers without making consumers depend on the value. This is the
+ * established latest-ref escape hatch, not an externally visible side effect.
  */
 export function useLatest<T>(value: T) {
   const ref = useRef(value)
+  // react-doctor-disable-next-line react-doctor/no-ref-current-in-render -- latest-ref helper; the write is isolated and not externally observable during render
   ref.current = value
   return ref
 }

--- a/src/hooks/useOrgCachedFetch.ts
+++ b/src/hooks/useOrgCachedFetch.ts
@@ -134,7 +134,10 @@ export function useOrgCachedFetch<T>({
   const [error, setError] = useState<string | null>(null)
   const hasDataRef = useRef(seedData != null)
   const seedDataRef = useRef(seedData)
-  seedDataRef.current = seedData
+
+  useLayoutEffect(() => {
+    seedDataRef.current = seedData
+  }, [seedData])
 
   // Reset state when cacheKey changes (e.g., navigating between orgs).
   // useLayoutEffect prevents a flash of stale data before paint.

--- a/src/hooks/usePRThreadsPanel.test.ts
+++ b/src/hooks/usePRThreadsPanel.test.ts
@@ -298,6 +298,38 @@ describe('usePRThreadsPanel', () => {
     expect(result.current.loading).toBe(false)
   })
 
+  it('ignores an in-flight branch result when the PR becomes invalid', async () => {
+    let resolveFetchBranches!: (value: { headSha: string }) => void
+    const pendingBranches = new Promise<{ headSha: string }>(resolve => {
+      resolveFetchBranches = resolve
+    })
+
+    mockUseLatestPRReviewRun.mockReturnValue({
+      reviewedHeadSha: 'reviewed-sha',
+      reviewedThreadStats: { unresolved: 2, outdated: 1 },
+      resultId: 'r1',
+    })
+    mockEnqueue
+      .mockReset()
+      .mockReturnValueOnce(pendingBranches)
+      .mockResolvedValueOnce(makeThreadsResult())
+      .mockResolvedValueOnce(makeThreadsResult())
+
+    const { result, rerender } = renderHook(
+      (props: { pr: typeof basePR }) => usePRThreadsPanel(props.pr),
+      { initialProps: { pr: basePR } }
+    )
+
+    rerender({ pr: { ...basePR, id: 0 } })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      resolveFetchBranches({ headSha: 'stale-sha' })
+    })
+
+    expect(result.current.needsRefresh).toBe(false)
+  })
+
   it('computes activeThreads from unresolved threads', async () => {
     const { result } = renderHook(() => usePRThreadsPanel(basePR))
 

--- a/src/hooks/usePRThreadsPanel.ts
+++ b/src/hooks/usePRThreadsPanel.ts
@@ -132,9 +132,11 @@ function useResetHeadShaWhenUnavailable(
   setCurrentHeadSha: (headSha: string | null) => void
 ) {
   /* v8 ignore start */
-  if (!canFetchHeadSha && currentHeadSha !== null) {
-    setCurrentHeadSha(null)
-  }
+  useEffect(() => {
+    if (!canFetchHeadSha && currentHeadSha !== null) {
+      setCurrentHeadSha(null)
+    }
+  }, [canFetchHeadSha, currentHeadSha, setCurrentHeadSha])
   /* v8 ignore stop */
 }
 

--- a/src/hooks/usePRThreadsPanel.ts
+++ b/src/hooks/usePRThreadsPanel.ts
@@ -201,11 +201,11 @@ export function usePRThreadsPanel(pr: PRDetailInfo) {
   useResetHeadShaWhenUnavailable(canFetchHeadSha, currentHeadSha, setCurrentHeadSha)
 
   useEffect(() => {
+    const requestId = ++headShaRequestRef.current
+
     if (!canFetchHeadSha || !owner) {
       return
     }
-
-    const requestId = ++headShaRequestRef.current
 
     enqueueRef
       .current(

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { getRepoContextFromViewId, type RepoContext } from '../utils/repoContext'
 import { killTerminalSession, getSessionId } from '../components/terminal/terminalSessions'
 import { isModKey } from '../utils/platform'
@@ -127,13 +127,13 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
   const terminalOpenRef = useRef(terminalOpen)
   const activeViewIdRef = useRef(activeViewId)
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     terminalTabsRef.current = terminalTabs
   }, [terminalTabs])
-  useEffect(() => {
+  useLayoutEffect(() => {
     terminalOpenRef.current = terminalOpen
   }, [terminalOpen])
-  useEffect(() => {
+  useLayoutEffect(() => {
     activeViewIdRef.current = activeViewId
   }, [activeViewId])
 

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -124,11 +124,18 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
   const heightSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const tabsSaveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const terminalTabsRef = useRef(terminalTabs)
-  terminalTabsRef.current = terminalTabs
   const terminalOpenRef = useRef(terminalOpen)
-  terminalOpenRef.current = terminalOpen
   const activeViewIdRef = useRef(activeViewId)
-  activeViewIdRef.current = activeViewId
+
+  useEffect(() => {
+    terminalTabsRef.current = terminalTabs
+  }, [terminalTabs])
+  useEffect(() => {
+    terminalOpenRef.current = terminalOpen
+  }, [terminalOpen])
+  useEffect(() => {
+    activeViewIdRef.current = activeViewId
+  }, [activeViewId])
 
   // Convex persistence
   const settings = useSettings()

--- a/src/hooks/useTerminalWorkspace.tsx
+++ b/src/hooks/useTerminalWorkspace.tsx
@@ -172,10 +172,15 @@ function useTerminalWorkspaceInternal(): UseTerminalWorkspaceReturn {
   const [loaded, setLoaded] = useState(false)
 
   const nodesRef = useRef(nodes)
-  nodesRef.current = nodes
   const activeNodeIdRef = useRef(activeNodeId)
-  activeNodeIdRef.current = activeNodeId
   const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    nodesRef.current = nodes
+  }, [nodes])
+  useEffect(() => {
+    activeNodeIdRef.current = activeNodeId
+  }, [activeNodeId])
 
   // Convex
   const workspace = useQuery(api.terminalWorkspaces.getWorkspace)

--- a/src/hooks/useToggleSet.ts
+++ b/src/hooks/useToggleSet.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef } from 'react'
+import { useState, useCallback, useLayoutEffect, useMemo, useRef } from 'react'
 
 /**
  * Manages a Set<string> of toggled keys (e.g. expanded sections, selected items).
@@ -18,7 +18,9 @@ import { useState, useCallback, useMemo, useRef } from 'react'
 export function useToggleSet(initial: Iterable<string> = []) {
   const [set, setSet] = useState(() => new Set(initial))
   const currentRef = useRef(set)
-  currentRef.current = set
+  useLayoutEffect(() => {
+    currentRef.current = set
+  }, [set])
 
   const toggle = useCallback((key: string): boolean => {
     const wasPresent = currentRef.current.has(key)

--- a/src/utils/billingParsers.period.test.ts
+++ b/src/utils/billingParsers.period.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { parseBillingUsage, type BillingUsageItem } from './billingParsers'
+
+const usageItem = (overrides: Partial<BillingUsageItem>): BillingUsageItem => ({
+  date: '2026-07-01',
+  product: 'copilot',
+  sku: 'Copilot AI Credits',
+  quantity: 1,
+  unitType: 'request',
+  pricePerUnit: 0.01,
+  grossAmount: 0.01,
+  discountAmount: 0,
+  netAmount: 0.01,
+  organizationName: 'test',
+  repositoryName: '',
+  ...overrides,
+})
+
+describe('parseBillingUsage billing-period filtering', () => {
+  it('limits usage and seat totals to the requested billing month', () => {
+    const items = [
+      usageItem({
+        date: '2026-06-30',
+        quantity: 11,
+        grossAmount: 0.11,
+        discountAmount: 0.01,
+        netAmount: 0.1,
+      }),
+      usageItem({
+        quantity: 7,
+        grossAmount: 0.07,
+        discountAmount: 0.02,
+        netAmount: 0.05,
+      }),
+      usageItem({ date: '2026-06-01', sku: 'Copilot Business', unitType: 'seat', quantity: 2 }),
+      usageItem({ sku: 'Copilot Business', unitType: 'seat', quantity: 3 }),
+    ]
+
+    expect(parseBillingUsage(items, { year: 2026, month: 7 })).toEqual({
+      premiumRequests: 7,
+      grossCost: 0.07,
+      discount: 0.02,
+      netCost: 0.05,
+      businessSeats: 3,
+      seatPlan: 'business',
+    })
+  })
+
+  it('does not mix the same month across billing years', () => {
+    const items = [
+      usageItem({ date: '2025-01-31', quantity: 13 }),
+      usageItem({ date: '2026-01-01', quantity: 5 }),
+    ]
+
+    expect(parseBillingUsage(items, { year: 2026, month: 1 }).premiumRequests).toBe(5)
+  })
+})

--- a/src/utils/billingParsers.ts
+++ b/src/utils/billingParsers.ts
@@ -27,6 +27,11 @@ export interface ParsedBillingUsage {
   seatPlan: string
 }
 
+export interface BillingPeriod {
+  year: number
+  month: number
+}
+
 /** Shape returned by enterprise/org premium request usage APIs. */
 export interface PremiumUsageItem {
   grossQuantity: number
@@ -107,11 +112,25 @@ function inferSeatPlan(items: BillingUsageItem[]): string {
   return ''
 }
 
-export function parseBillingUsage(items: BillingUsageItem[]): ParsedBillingUsage {
-  const premiumItems = items.filter(
+function filterBillingPeriod(
+  items: BillingUsageItem[],
+  period?: BillingPeriod
+): BillingUsageItem[] {
+  if (!period) return items
+  const month = String(period.month).padStart(2, '0')
+  const prefix = `${period.year}-${month}-`
+  return items.filter(item => item.date.startsWith(prefix))
+}
+
+export function parseBillingUsage(
+  items: BillingUsageItem[],
+  period?: BillingPeriod
+): ParsedBillingUsage {
+  const periodItems = filterBillingPeriod(items, period)
+  const premiumItems = periodItems.filter(
     item => item.product === 'copilot' && COPILOT_USAGE_SKUS.has(item.sku)
   )
-  const seatItems = items.filter(
+  const seatItems = periodItems.filter(
     item => item.product === 'copilot' && COPILOT_SEAT_SKUS.has(item.sku)
   )
 
@@ -121,7 +140,7 @@ export function parseBillingUsage(items: BillingUsageItem[]): ParsedBillingUsage
     discount: roundCents(sumBy(premiumItems, item => item.discountAmount)),
     netCost: roundCents(sumBy(premiumItems, item => item.netAmount)),
     businessSeats: roundCents(sumBy(seatItems, item => item.quantity)),
-    seatPlan: inferSeatPlan(items),
+    seatPlan: inferSeatPlan(periodItems),
   }
 }
 
@@ -130,12 +149,15 @@ export function parseBillingUsage(items: BillingUsageItem[]): ParsedBillingUsage
  * `/orgs/{org}/settings/billing/usage` result. Filters to Copilot *usage* SKUs
  * so per-seat subscription cost is excluded from "spend".
  */
-export function extractCopilotSpend(result: PromiseSettledResult<{ stdout: string }>): {
+export function extractCopilotSpend(
+  result: PromiseSettledResult<{ stdout: string }>,
+  period?: BillingPeriod
+): {
   net: number
   gross: number
 } {
   const data = parseFulfilledStdout<{ usageItems?: BillingUsageItem[] }>(result)
-  const parsed = parseBillingUsage(data?.usageItems ?? [])
+  const parsed = parseBillingUsage(data?.usageItems ?? [], period)
   return { net: parsed.netCost, gross: parsed.grossCost }
 }
 


### PR DESCRIPTION
Closes #273

## Summary

- move ordinary state-to-ref synchronization into commit-phase effects across tabs, refresh, dashboard, finance, org cache, and terminal hooks
- move AI review monitor and PR head-SHA resets out of render and add a regression test for PR changes
- make the rate-limit countdown reset in its animation effect instead of mutating refs/state during render
- retain narrowly documented synchronous latest-ref/latest-callback escape hatches where an effect would reintroduce stale callbacks or restart consumers
- reduce React Doctor 0.8.3 from 84 to 64 source findings, with zero `no-ref-current-in-render` or `no-prop-callback-in-render` findings

## Queue hygiene

The original mixed issue scope was split before implementation:

- #281 owns state-updater side effects
- #282 owns effect dependencies, cleanup, and cancellation
- #283 owns accessibility semantics and keyboard behavior
- #284 owns sequential GitHub API awaits

## Verification

- `bun install --frozen-lockfile`
- `bunx react-doctor --verbose` (84 → 64 source findings; both target rules cleared)
- focused Vitest: 13 files, 368 tests
- `bunx markdownlint-cli2`
- `bun run format:check`
- `git diff --check`
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bun run test:coverage` (289 files, 6479 tests)
- `bun run test:electron:coverage` (44 files, 855 tests)
- `bun run test:convex:coverage` (19 files, 241 tests)
- `bun run deps:check`
- `bun run e18e` (no undocumented direct dependency findings)
- `bun run security:electron`
- `bun x vite build`
- `bun run bundle-size`

## Risk Acknowledgment

Risk: medium. Ref synchronization and reset timing now follows React commit semantics in terminal, refresh, monitoring, and cached-fetch hooks. The shared latest-ref and auto-refresh callback paths remain synchronous by design and carry targeted React Doctor explanations so they do not force stale callbacks or interval restarts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix render-time ref mutations across React hooks by moving assignments into effects
> - Moves ref assignments (and some state resets) out of render into `useEffect` or `useLayoutEffect` across a dozen hooks, including [`useAppTabs`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-683c16f7477d1574c495098f39b6c80a34e266f6761e2f6290ebd6c584ab5477), [`useAutoRefresh`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-d80920b66025c60fcd29f0bcbdbe23f70e0f27bce74f799fb2c74e69f990c2b2), [`useTerminalPanel`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-73bd824b91e56036b13a14fcd5186d0b68dede2f725f90e2fca25b5d7aa841bb), and [`useToggleSet`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-e0c0e5ea7b5175716f32a368acf4aa1aa77b71c3118f0958149443aeb25ed940).
> - Fixes render-time state updates in [`useAIReviewMonitor`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-de0320895cb9557488847fc02f836ff5335d83efb08adba2bb697ef59716adce), [`useCopilotReviewMonitor`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-702fc43a848e07735fa7dd03b59a63a06cccb5c29fd8975f24a0ba98cb1623d2), and [`usePRThreadsPanel`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-9e00f99b741bf477035c135df7c7b792e544e880ec71bf8c28ac968d89e3c706) by moving conditional resets into `useEffect`.
> - The [`RateLimitGauge.useCountdownAnimation`](https://github.com/HemSoft/hs-buddy/pull/285/files#diff-c62d6cde3f7763131ae511e231e0d03fbb9624065d860013904ef9641cde3eb5) hook removes `previousRemaining` state and initializes `startTimeRef` at hook creation, resetting via effect instead of during render.
> - `useLayoutEffect` is used where pre-paint timing matters (e.g. `pausedRef` in `useAutoRefresh`, `seedDataRef` in `useOrgCachedFetch`, `currentRef` in `useToggleSet`).
> - Behavioral Change: refs and reset state now update asynchronously after render rather than synchronously during it, which is correct React behavior but may affect any code that reads these refs in the same render cycle.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 22fa25a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->