### PR TITLE
Fix Copilot usage billing-period totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Scope Copilot usage to current billing month
+- Address billing period review findings
 
 ## [0.1.878] - 2026-07-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Sync Electron 43 update with main
 
+### Fixed
+
+- Scope Copilot usage to current billing month
+
 ## [0.1.878] - 2026-07-22
 
 ### Fixed

--- a/electron/ipc/githubHandlers.test.ts
+++ b/electron/ipc/githubHandlers.test.ts
@@ -251,6 +251,56 @@ describe('githubHandlers', () => {
       expect(result.data.org).toBe('test-org')
     })
 
+    it('requests and parses only the current UTC billing period', async () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-01T12:00:00Z'))
+      try {
+        const { parseBillingUsage } = await import('../../src/utils/billingParsers')
+
+        vi.mocked(parseBillingUsage).mockReturnValueOnce({
+          premiumRequests: 7,
+          grossCost: 0.07,
+          discount: 0.02,
+          netCost: 0.05,
+          businessSeats: 2,
+          seatPlan: 'business',
+        })
+
+        const usageItems = [{ product: 'copilot', date: '2026-07-01' }]
+        mockExecAsync.mockResolvedValueOnce({
+          stdout: JSON.stringify({ usageItems }),
+          stderr: '',
+        })
+        mockExecAsync.mockResolvedValueOnce({
+          stdout: JSON.stringify({ seat_breakdown: { total: 3 } }),
+          stderr: '',
+        })
+
+        const handler = handlers.get('github:get-copilot-usage')!
+        const result = await handler({}, 'test-org')
+
+        expect(result.success).toBe(true)
+        expect(result.data).toEqual(
+          expect.objectContaining({
+            premiumRequests: 7,
+            grossCost: 0.07,
+            discount: 0.02,
+            netCost: 0.05,
+            businessSeats: 2,
+            seats: 3,
+            billingMonth: 7,
+            billingYear: 2026,
+          })
+        )
+        expect(mockExecAsync.mock.calls[0]?.[0]).toContain(
+          '/settings/billing/usage?year=2026&month=7'
+        )
+        expect(parseBillingUsage).toHaveBeenCalledWith(usageItems, { year: 2026, month: 7 })
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it('returns error on failure', async () => {
       // tryGetCliToken succeeds
       mockExecAsync.mockResolvedValueOnce({ stdout: 'ghp_token123\n', stderr: '' })
@@ -773,7 +823,10 @@ describe('githubHandlers', () => {
           data: expect.objectContaining({ org: 'test-org', billingYear: 2026, billingMonth: 1 }),
         })
       )
-      expect(parseBillingUsage).toHaveBeenCalledWith([{ product: 'copilot', grossQuantity: 7 }])
+      expect(parseBillingUsage).toHaveBeenCalledWith([{ product: 'copilot', grossQuantity: 7 }], {
+        year: 2026,
+        month: 7,
+      })
       expect(assembleArgs).toEqual(
         expect.objectContaining({
           org: 'test-org',

--- a/electron/ipc/githubHandlers.test.ts
+++ b/electron/ipc/githubHandlers.test.ts
@@ -25,11 +25,14 @@ vi.mock('../config', () => ({
 }))
 
 const mockExecAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
-const mockExecFileAsync = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+const mockExecFileAsync = vi.fn((file: string, args: string[], options: unknown) =>
+  mockExecAsync(`${file} ${args.join(' ')}`, options)
+)
 
 vi.mock('../utils', () => ({
   execAsync: (...args: unknown[]) => mockExecAsync(...args),
-  execFileAsync: (...args: unknown[]) => mockExecFileAsync(...args),
+  execFileAsync: (file: string, args: string[], options: unknown) =>
+    mockExecFileAsync(file, args, options),
 }))
 
 vi.mock('../../src/utils/errorUtils', () => ({
@@ -814,28 +817,47 @@ describe('githubHandlers', () => {
         .mockResolvedValueOnce({ stdout: '[]', stderr: '' })
         .mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
 
-      const result = await fetchCopilotMetrics('test-org')
-      const assembleArgs = vi.mocked(assembleCopilotMetrics).mock.calls[0][0]
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
 
-      expect(result).toEqual(
-        expect.objectContaining({
-          success: true,
-          data: expect.objectContaining({ org: 'test-org', billingYear: 2026, billingMonth: 1 }),
+      try {
+        const result = await fetchCopilotMetrics('test-org')
+        const assembleArgs = vi.mocked(assembleCopilotMetrics).mock.calls[0][0]
+
+        expect(result).toEqual(
+          expect.objectContaining({
+            success: true,
+            data: expect.objectContaining({ org: 'test-org', billingYear: 2026, billingMonth: 1 }),
+          })
+        )
+        expect(parseBillingUsage).toHaveBeenCalledWith([{ product: 'copilot', grossQuantity: 7 }], {
+          year: 2026,
+          month: 7,
         })
-      )
-      expect(parseBillingUsage).toHaveBeenCalledWith([{ product: 'copilot', grossQuantity: 7 }], {
-        year: 2026,
-        month: 7,
+        expect(assembleArgs).toEqual(
+          expect.objectContaining({
+            org: 'test-org',
+            usageOk: true,
+            usage: expect.objectContaining({ premiumRequests: 7, businessSeats: 3 }),
+          })
+        )
+        expect(mockExecAsync.mock.calls[0]?.[0]).toContain('/orgs/test-org/settings/billing/usage')
+        expect(mockExecAsync.mock.calls[1]?.[0]).toContain('/users/test-org/settings/billing/usage')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('rejects invalid GitHub account slugs before invoking gh api', async () => {
+      const { fetchCopilotMetrics } = await import('./githubHandlers')
+
+      const result = await fetchCopilotMetrics('test-org; echo injected')
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'test-org; echo injected'",
       })
-      expect(assembleArgs).toEqual(
-        expect.objectContaining({
-          org: 'test-org',
-          usageOk: true,
-          usage: expect.objectContaining({ premiumRequests: 7, businessSeats: 3 }),
-        })
-      )
-      expect(mockExecAsync.mock.calls[0]?.[0]).toContain('/orgs/test-org/settings/billing/usage')
-      expect(mockExecAsync.mock.calls[1]?.[0]).toContain('/users/test-org/settings/billing/usage')
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
     })
 
     it('fetchCopilotMetrics continues after double 404 billing misses', async () => {
@@ -998,6 +1020,33 @@ describe('githubHandlers', () => {
       expect(mockExecAsync.mock.calls[2]?.[0]).toContain(
         '/enterprises/Bertelsmann/settings/billing/budgets?page=1'
       )
+    })
+
+    it('github:get-copilot-budget scopes spend to the current billing month', async () => {
+      const { extractCopilotSpend } = await import('../../src/utils/billingParsers')
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-15T12:00:00Z'))
+
+      try {
+        mockExecAsync
+          .mockResolvedValueOnce({ stdout: '[]', stderr: '' })
+          .mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
+
+        const handler = handlers.get('github:get-copilot-budget')!
+        await handler({}, 'test-org')
+
+        expect(extractCopilotSpend).toHaveBeenCalledWith(expect.anything(), {
+          year: 2026,
+          month: 7,
+        })
+        expect(mockExecFileAsync).toHaveBeenCalledWith(
+          'gh',
+          ['api', '/orgs/test-org/settings/billing/usage?year=2026&month=7'],
+          expect.objectContaining({ encoding: 'utf8', timeout: 15000 })
+        )
+      } finally {
+        vi.useRealTimers()
+      }
     })
 
     it('github:get-copilot-budget marks spend as unavailable when usage fetch fails', async () => {

--- a/electron/ipc/githubHandlers.ts
+++ b/electron/ipc/githubHandlers.ts
@@ -49,6 +49,27 @@ export const PERSONAL_BUDGETS: Record<string, number> = {}
 type ExecAsyncSettledResult = PromiseSettledResult<Awaited<ReturnType<typeof execAsync>>>
 type CliStdoutSettledResult = PromiseSettledResult<{ stdout: string }>
 
+const GITHUB_ACCOUNT_SLUG_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+
+function assertValidGitHubAccountSlug(org: string): void {
+  if (!GITHUB_ACCOUNT_SLUG_PATTERN.test(org)) {
+    throw new Error(`Invalid GitHub account slug: '${org}'`)
+  }
+}
+
+async function runGhApi(
+  endpoint: string,
+  execEnv: NodeJS.ProcessEnv,
+  timeout = API_TIMEOUT_MS,
+  headers: string[] = []
+): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('gh', ['api', endpoint, ...headers.flatMap(header => ['-H', header])], {
+    encoding: 'utf8',
+    timeout,
+    env: execEnv,
+  })
+}
+
 function asCliStdoutSettledResult(result: ExecAsyncSettledResult): CliStdoutSettledResult {
   return result as CliStdoutSettledResult
 }
@@ -91,18 +112,19 @@ async function fetchBillingUsage(
   month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<ParsedBillingUsage> {
+  assertValidGitHubAccountSlug(org)
   let stdout: string
   try {
-    const result = await execAsync(
-      `gh api "/orgs/${org}/settings/billing/usage?year=${year}&month=${month}"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    const result = await runGhApi(
+      `/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`,
+      execEnv
     )
     stdout = result.stdout
   } catch (orgError: unknown) {
     if (!isNotFoundError(orgError)) throw orgError
-    const result = await execAsync(
-      `gh api "/users/${org}/settings/billing/usage?year=${year}&month=${month}"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    const result = await runGhApi(
+      `/users/${org}/settings/billing/usage?year=${year}&month=${month}`,
+      execEnv
     )
     stdout = result.stdout
   }
@@ -118,16 +140,12 @@ async function fetchBudgetAndSpend(
   month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<{ budgetAmount: number | null; spent: number }> {
+  assertValidGitHubAccountSlug(org)
   const [budgetResult, spendResult] = await Promise.allSettled([
-    execAsync(
-      `gh api /organizations/${org}/settings/billing/budgets -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
-    ),
-    execAsync(`gh api "/orgs/${org}/settings/billing/usage?year=${year}&month=${month}"`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    }),
+    runGhApi(`/organizations/${org}/settings/billing/budgets`, execEnv, API_TIMEOUT_MS, [
+      'X-GitHub-Api-Version: 2022-11-28',
+    ]),
+    runGhApi(`/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`, execEnv),
   ])
 
   return {
@@ -205,19 +223,20 @@ async function fetchOrgOrUserBillingUsage(
   month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<string> {
+  assertValidGitHubAccountSlug(org)
   try {
-    const result = await execAsync(
-      `gh api "/orgs/${org}/settings/billing/usage?year=${year}&month=${month}"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    const result = await runGhApi(
+      `/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`,
+      execEnv
     )
     return result.stdout
   } catch (orgError: unknown) {
     if (!isNotFoundError(orgError)) throw orgError
 
     try {
-      const result = await execAsync(
-        `gh api "/users/${org}/settings/billing/usage?year=${year}&month=${month}"`,
-        { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+      const result = await runGhApi(
+        `/users/${org}/settings/billing/usage?year=${year}&month=${month}`,
+        execEnv
       )
       return result.stdout
     } catch (userError: unknown) {
@@ -298,9 +317,11 @@ async function resolveEnterpriseBudgetFallback(
 
 function resolveSpendState(
   org: string,
-  usageResult: ExecAsyncSettledResult
+  usageResult: ExecAsyncSettledResult,
+  year: number,
+  month: number
 ): { spent: number; gross: number; spentError: string | null } {
-  const { net, gross } = extractCopilotSpend(asCliStdoutSettledResult(usageResult))
+  const { net, gross } = extractCopilotSpend(asCliStdoutSettledResult(usageResult), { year, month })
   return {
     spent: net,
     gross,
@@ -311,8 +332,8 @@ function resolveSpendState(
 /** Fetch budget + spend for an org via billing APIs, with enterprise budget fallback. */
 async function fetchOrgBudgetAndSpend(
   org: string,
-  _year: number,
-  _month: number,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<{
   budgetAmount: number | null
@@ -322,16 +343,12 @@ async function fetchOrgBudgetAndSpend(
   gross: number
   spentError: string | null
 }> {
+  assertValidGitHubAccountSlug(org)
   const [budgetResult, usageResult] = await Promise.allSettled([
-    execAsync(
-      `gh api /organizations/${org}/settings/billing/budgets -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
-    ),
-    execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    }),
+    runGhApi(`/organizations/${org}/settings/billing/budgets`, execEnv, API_TIMEOUT_MS, [
+      'X-GitHub-Api-Version: 2022-11-28',
+    ]),
+    runGhApi(`/orgs/${org}/settings/billing/usage?year=${year}&month=${month}`, execEnv),
   ])
 
   const extractedBudget = extractBudgetFromResult(asCliStdoutSettledResult(budgetResult))
@@ -341,7 +358,7 @@ async function fetchOrgBudgetAndSpend(
     extractedBudget.preventFurtherUsage,
     execEnv
   )
-  const spentState = resolveSpendState(org, usageResult)
+  const spentState = resolveSpendState(org, usageResult, year, month)
 
   return {
     ...budgetState,

--- a/electron/ipc/githubHandlers.ts
+++ b/electron/ipc/githubHandlers.ts
@@ -87,35 +87,35 @@ async function getTokenEnv(username?: string): Promise<NodeJS.ProcessEnv> {
  *  Returns ParsedBillingUsage. Throws on non-404 errors. */
 async function fetchBillingUsage(
   org: string,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<ParsedBillingUsage> {
   let stdout: string
   try {
-    const result = await execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    })
+    const result = await execAsync(
+      `gh api "/orgs/${org}/settings/billing/usage?year=${year}&month=${month}"`,
+      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    )
     stdout = result.stdout
   } catch (orgError: unknown) {
     if (!isNotFoundError(orgError)) throw orgError
-    const result = await execAsync(`gh api /users/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    })
+    const result = await execAsync(
+      `gh api "/users/${org}/settings/billing/usage?year=${year}&month=${month}"`,
+      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    )
     stdout = result.stdout
   }
 
   const data = JSON.parse(stdout.trim()) as { usageItems: BillingUsageItem[] }
-  return parseBillingUsage(data.usageItems)
+  return parseBillingUsage(data.usageItems, { year, month })
 }
 
 /** Fetch budget + Copilot usage spend (net, AI Credits billing) for a non-personal org. */
 async function fetchBudgetAndSpend(
   org: string,
-  _year: number,
-  _month: number,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<{ budgetAmount: number | null; spent: number }> {
   const [budgetResult, spendResult] = await Promise.allSettled([
@@ -123,7 +123,7 @@ async function fetchBudgetAndSpend(
       `gh api /organizations/${org}/settings/billing/budgets -H "X-GitHub-Api-Version: 2022-11-28"`,
       { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
     ),
-    execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
+    execAsync(`gh api "/orgs/${org}/settings/billing/usage?year=${year}&month=${month}"`, {
       encoding: 'utf8',
       timeout: API_TIMEOUT_MS,
       env: execEnv,
@@ -132,7 +132,7 @@ async function fetchBudgetAndSpend(
 
   return {
     budgetAmount: extractBudgetFromResult(budgetResult).budgetAmount,
-    spent: extractCopilotSpend(spendResult).net,
+    spent: extractCopilotSpend(spendResult, { year, month }).net,
   }
 }
 
@@ -161,7 +161,7 @@ export async function fetchCopilotMetrics(
   let usageOk = false
 
   try {
-    usage = await fetchBillingUsage(org, execEnv)
+    usage = await fetchBillingUsage(org, year, month, execEnv)
     usageOk = true
   } catch (error: unknown) {
     if (!isNotFoundError(error)) {
@@ -201,24 +201,24 @@ export async function fetchCopilotMetrics(
 /** Try org billing endpoint, fall back to user. Throws descriptive error on double-404. */
 async function fetchOrgOrUserBillingUsage(
   org: string,
+  year: number,
+  month: number,
   execEnv: NodeJS.ProcessEnv
 ): Promise<string> {
   try {
-    const result = await execAsync(`gh api /orgs/${org}/settings/billing/usage`, {
-      encoding: 'utf8',
-      timeout: API_TIMEOUT_MS,
-      env: execEnv,
-    })
+    const result = await execAsync(
+      `gh api "/orgs/${org}/settings/billing/usage?year=${year}&month=${month}"`,
+      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    )
     return result.stdout
   } catch (orgError: unknown) {
     if (!isNotFoundError(orgError)) throw orgError
 
     try {
-      const result = await execAsync(`gh api /users/${org}/settings/billing/usage`, {
-        encoding: 'utf8',
-        timeout: API_TIMEOUT_MS,
-        env: execEnv,
-      })
+      const result = await execAsync(
+        `gh api "/users/${org}/settings/billing/usage?year=${year}&month=${month}"`,
+        { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+      )
       return result.stdout
     } catch (userError: unknown) {
       if (isNotFoundError(userError)) {
@@ -665,12 +665,17 @@ function registerCopilotUsageHandlers(): void {
     async (_event, org: string, username?: string) => {
       try {
         const execEnv = await getTokenEnv(username)
-        const stdout = await fetchOrgOrUserBillingUsage(org, execEnv)
+        const now = new Date()
+        const billingYear = now.getUTCFullYear()
+        const billingMonth = now.getUTCMonth() + 1
+        const stdout = await fetchOrgOrUserBillingUsage(org, billingYear, billingMonth, execEnv)
 
         const data = JSON.parse(stdout.trim()) as { usageItems: BillingUsageItem[] }
-        const parsed = parseBillingUsage(data.usageItems)
+        const parsed = parseBillingUsage(data.usageItems, {
+          year: billingYear,
+          month: billingMonth,
+        })
         const seatCount = await fetchSeatCount(org, execEnv)
-        const now = new Date()
 
         let userCredits: number | null = null
         if (username) {
@@ -690,8 +695,8 @@ function registerCopilotUsageHandlers(): void {
             org,
             ...parsed,
             seats: seatCount ?? parsed.businessSeats,
-            billingMonth: now.getUTCMonth() + 1,
-            billingYear: now.getUTCFullYear(),
+            billingMonth,
+            billingYear,
             userCredits,
             allItems: data.usageItems.filter(item => item.product === 'copilot'),
             fetchedAt: Date.now(),

--- a/src/utils/billingParsers.period.test.ts
+++ b/src/utils/billingParsers.period.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { parseBillingUsage, type BillingUsageItem } from './billingParsers'
+
+const usageItem = (overrides: Partial<BillingUsageItem>): BillingUsageItem => ({
+  date: '2026-07-01',
+  product: 'copilot',
+  sku: 'Copilot AI Credits',
+  quantity: 1,
+  unitType: 'request',
+  pricePerUnit: 0.01,
+  grossAmount: 0.01,
+  discountAmount: 0,
+  netAmount: 0.01,
+  organizationName: 'test',
+  repositoryName: '',
+  ...overrides,
+})
+
+describe('parseBillingUsage billing-period filtering', () => {
+  it('limits usage and seat totals to the requested billing month', () => {
+    const items = [
+      usageItem({
+        date: '2026-06-30',
+        quantity: 11,
+        grossAmount: 0.11,
+        discountAmount: 0.01,
+        netAmount: 0.1,
+      }),
+      usageItem({
+        quantity: 7,
+        grossAmount: 0.07,
+        discountAmount: 0.02,
+        netAmount: 0.05,
+      }),
+      usageItem({ date: '2026-06-01', sku: 'Copilot Business', unitType: 'seat', quantity: 2 }),
+      usageItem({ sku: 'Copilot Business', unitType: 'seat', quantity: 3 }),
+    ]
+
+    expect(parseBillingUsage(items, { year: 2026, month: 7 })).toEqual({
+      premiumRequests: 7,
+      grossCost: 0.07,
+      discount: 0.02,
+      netCost: 0.05,
+      businessSeats: 3,
+      seatPlan: 'business',
+    })
+  })
+
+  it('does not mix the same month across billing years', () => {
+    const items = [
+      usageItem({ date: '2025-01-31', quantity: 13 }),
+      usageItem({ date: '2026-01-01', quantity: 5 }),
+    ]
+
+    expect(parseBillingUsage(items, { year: 2026, month: 1 }).premiumRequests).toBe(5)
+  })
+})

--- a/src/utils/billingParsers.test.ts
+++ b/src/utils/billingParsers.test.ts
@@ -214,45 +214,6 @@ describe('parseBillingUsage', () => {
     expect(result.netCost).toBe(0.25)
   })
 
-  it('limits usage and seat totals to the requested billing month', () => {
-    const items = [
-      makePremiumItem({
-        date: '2026-06-30',
-        quantity: 11,
-        grossAmount: 0.11,
-        discountAmount: 0.01,
-        netAmount: 0.1,
-      }),
-      makePremiumItem({
-        date: '2026-07-01',
-        quantity: 7,
-        grossAmount: 0.07,
-        discountAmount: 0.02,
-        netAmount: 0.05,
-      }),
-      makeSeatItem({ date: '2026-06-01', quantity: 2 }),
-      makeSeatItem({ date: '2026-07-01', quantity: 3 }),
-    ]
-
-    expect(parseBillingUsage(items, { year: 2026, month: 7 })).toEqual({
-      premiumRequests: 7,
-      grossCost: 0.07,
-      discount: 0.02,
-      netCost: 0.05,
-      businessSeats: 3,
-      seatPlan: 'business',
-    })
-  })
-
-  it('does not mix the same month across billing years', () => {
-    const items = [
-      makePremiumItem({ date: '2025-01-31', quantity: 13 }),
-      makePremiumItem({ date: '2026-01-01', quantity: 5 }),
-    ]
-
-    expect(parseBillingUsage(items, { year: 2026, month: 1 }).premiumRequests).toBe(5)
-  })
-
   it('parses the June 2026 "Copilot AI Credits" SKU', () => {
     const result = parseBillingUsage([makePremiumItem({ sku: 'Copilot AI Credits' })])
     expect(result.premiumRequests).toBe(10)

--- a/src/utils/billingParsers.test.ts
+++ b/src/utils/billingParsers.test.ts
@@ -214,6 +214,45 @@ describe('parseBillingUsage', () => {
     expect(result.netCost).toBe(0.25)
   })
 
+  it('limits usage and seat totals to the requested billing month', () => {
+    const items = [
+      makePremiumItem({
+        date: '2026-06-30',
+        quantity: 11,
+        grossAmount: 0.11,
+        discountAmount: 0.01,
+        netAmount: 0.1,
+      }),
+      makePremiumItem({
+        date: '2026-07-01',
+        quantity: 7,
+        grossAmount: 0.07,
+        discountAmount: 0.02,
+        netAmount: 0.05,
+      }),
+      makeSeatItem({ date: '2026-06-01', quantity: 2 }),
+      makeSeatItem({ date: '2026-07-01', quantity: 3 }),
+    ]
+
+    expect(parseBillingUsage(items, { year: 2026, month: 7 })).toEqual({
+      premiumRequests: 7,
+      grossCost: 0.07,
+      discount: 0.02,
+      netCost: 0.05,
+      businessSeats: 3,
+      seatPlan: 'business',
+    })
+  })
+
+  it('does not mix the same month across billing years', () => {
+    const items = [
+      makePremiumItem({ date: '2025-01-31', quantity: 13 }),
+      makePremiumItem({ date: '2026-01-01', quantity: 5 }),
+    ]
+
+    expect(parseBillingUsage(items, { year: 2026, month: 1 }).premiumRequests).toBe(5)
+  })
+
   it('parses the June 2026 "Copilot AI Credits" SKU', () => {
     const result = parseBillingUsage([makePremiumItem({ sku: 'Copilot AI Credits' })])
     expect(result.premiumRequests).toBe(10)

--- a/src/utils/billingParsers.ts
+++ b/src/utils/billingParsers.ts
@@ -27,6 +27,11 @@ export interface ParsedBillingUsage {
   seatPlan: string
 }
 
+export interface BillingPeriod {
+  year: number
+  month: number
+}
+
 /** Shape returned by enterprise/org premium request usage APIs. */
 export interface PremiumUsageItem {
   grossQuantity: number
@@ -107,11 +112,25 @@ function inferSeatPlan(items: BillingUsageItem[]): string {
   return ''
 }
 
-export function parseBillingUsage(items: BillingUsageItem[]): ParsedBillingUsage {
-  const premiumItems = items.filter(
+function filterBillingPeriod(
+  items: BillingUsageItem[],
+  period?: BillingPeriod
+): BillingUsageItem[] {
+  if (!period) return items
+  const month = String(period.month).padStart(2, '0')
+  const prefix = `${period.year}-${month}-`
+  return items.filter(item => item.date.startsWith(prefix))
+}
+
+export function parseBillingUsage(
+  items: BillingUsageItem[],
+  period?: BillingPeriod
+): ParsedBillingUsage {
+  const periodItems = filterBillingPeriod(items, period)
+  const premiumItems = periodItems.filter(
     item => item.product === 'copilot' && COPILOT_USAGE_SKUS.has(item.sku)
   )
-  const seatItems = items.filter(
+  const seatItems = periodItems.filter(
     item => item.product === 'copilot' && COPILOT_SEAT_SKUS.has(item.sku)
   )
 
@@ -121,7 +140,7 @@ export function parseBillingUsage(items: BillingUsageItem[]): ParsedBillingUsage
     discount: roundCents(sumBy(premiumItems, item => item.discountAmount)),
     netCost: roundCents(sumBy(premiumItems, item => item.netAmount)),
     businessSeats: roundCents(sumBy(seatItems, item => item.quantity)),
-    seatPlan: inferSeatPlan(items),
+    seatPlan: inferSeatPlan(periodItems),
   }
 }
 
@@ -130,12 +149,15 @@ export function parseBillingUsage(items: BillingUsageItem[]): ParsedBillingUsage
  * `/orgs/{org}/settings/billing/usage` result. Filters to Copilot *usage* SKUs
  * so per-seat subscription cost is excluded from "spend".
  */
-export function extractCopilotSpend(result: PromiseSettledResult<{ stdout: string }>): {
+export function extractCopilotSpend(
+  result: PromiseSettledResult<{ stdout: string }>,
+  period?: BillingPeriod
+): {
   net: number
   gross: number
 } {
   const data = parseFulfilledStdout<{ usageItems?: BillingUsageItem[] }>(result)
-  const parsed = parseBillingUsage(data?.usageItems ?? [])
+  const parsed = parseBillingUsage(data?.usageItems ?? [], period)
   return { net: parsed.netCost, gross: parsed.grossCost }
 }
 


### PR DESCRIPTION
Closes #275

## Summary
- request the current UTC year and month from the organization/user billing endpoints
- defensively filter returned billing rows by both year and month before calculating usage, spend, seats, overage, and projections
- cover mixed-month and year-boundary regressions

## Verification
- `bun run test` — 289 files, 6480 tests passed
- `bun run test:electron` — 44 files, 856 tests passed
- `bun run test:convex` — 19 files, 241 tests passed
- `bun run test:ipc-contracts` — 2 files, 34 tests passed
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run knip` — passed
- `bun run e18e` — no undocumented direct dependency findings
- `bun run deps:check` — no dependency violations
- `bunx vite build` — passed
- `git diff --check` — passed

## Known baseline
`bun run format:check` still reports the five pre-existing untouched `shared/utils/*` formatting failures; all files changed by this PR pass Prettier and ESLint.

## Risk Acknowledgment
**Risk: medium.** This changes financial usage calculations shown in the dashboard. The implementation uses both server-side period parameters and local date filtering to prevent historical rows from inflating the current month.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Copilot usage billing-period totals to scope to the current UTC billing month
> - Adds a `BillingPeriod` interface and `filterBillingPeriod` helper in [`billingParsers.ts`](https://github.com/HemSoft/hs-buddy/pull/287/files#diff-a86a4333baa1378c3d0e0675fb61df4dfedda72abdf4170c1522bcb5f657dc39) to filter usage items to a specific year/month before computing metrics.
> - Updates `parseBillingUsage` and `extractCopilotSpend` to accept an optional `BillingPeriod`, and threads the current UTC billing month through all IPC and fetch utilities in [`githubHandlers.ts`](https://github.com/HemSoft/hs-buddy/pull/287/files#diff-f84a9b8e1b26a344ab9375a65a775761c30264af180eb417a49006ace6a28034).
> - Adds `assertValidGitHubAccountSlug` to reject invalid org/user slugs before any `gh api` invocation, and replaces shell-string execution with explicit argument-vector `execFileAsync` calls via a new `runGhApi` helper.
> - Behavioral Change: `github:get-copilot-usage` and budget spend now return totals scoped strictly to the current billing month rather than all available data.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01b8cf6.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->