### PR TITLE
Fix React state updater side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.887] - 2026-07-23
+
+### Changed
+
+- Keep refresh indicator suite within quality gate
+
 ## [0.1.886] - 2026-07-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.886] - 2026-07-23
+
+### Fixed
+
+- Make state updaters side-effect free
+
 ## [0.1.884] - 2026-07-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.885",
+  "version": "0.1.886",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.886",
+  "version": "0.1.887",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/InlineDropdown.tsx
+++ b/src/components/InlineDropdown.tsx
@@ -388,18 +388,16 @@ export function InlineDropdown(rawProps: InlineDropdownProps) {
     /* v8 ignore start -- button's disabled HTML attr prevents onClick from firing */
     if (disabled) return
     /* v8 ignore stop */
-    setIsOpen(prev => {
-      if (!prev) {
-        setFocusIndex(
-          Math.max(
-            0,
-            enabledOptions.findIndex(o => o.value === value)
-          )
+    if (!isOpen) {
+      setFocusIndex(
+        Math.max(
+          0,
+          enabledOptions.findIndex(o => o.value === value)
         )
-      }
-      return !prev
-    })
-  }, [disabled, enabledOptions, value])
+      )
+    }
+    setIsOpen(prev => !prev)
+  }, [disabled, enabledOptions, isOpen, value])
   const handleSelect = useCallback(
     (optValue: string) => {
       onChange(optValue)

--- a/src/components/pull-request-list/usePRListData.test.ts
+++ b/src/components/pull-request-list/usePRListData.test.ts
@@ -943,6 +943,34 @@ describe('usePRListData', () => {
     expect(result.current.totalPrsFound).toBe(0)
   })
 
+  it('accumulates completed progress events outside React state updaters', async () => {
+    mockFetchMyPRs.mockImplementation(async (progressCb?: (p: unknown) => void) => {
+      progressCb?.({
+        currentAccount: 1,
+        totalAccounts: 2,
+        accountName: 'alice',
+        org: 'first-org',
+        status: 'done',
+        prsFound: 2,
+      })
+      progressCb?.({
+        currentAccount: 2,
+        totalAccounts: 2,
+        accountName: 'alice',
+        org: 'second-org',
+        status: 'done',
+        prsFound: 3,
+      })
+      return [makePR()]
+    })
+
+    const { result } = renderHook(() => usePRListData('my-prs'))
+    await waitFor(() => expect(result.current.prs).toHaveLength(1))
+
+    expect(result.current.totalPrsFound).toBe(5)
+    expect(result.current.progress?.totalPrsFound).toBe(5)
+  })
+
   // --- Branch coverage: null/falsy guards ---
 
   it('handles null bookmarks in bookmarkedRepoKeys and handleBookmarkRepo', async () => {

--- a/src/components/pull-request-list/usePRListData.ts
+++ b/src/components/pull-request-list/usePRListData.ts
@@ -558,7 +558,7 @@ export function usePRListData(mode: PRSearchMode, onCountChange?: (count: number
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [progress, setProgress] = useState<LoadingProgress | null>(null)
-  const [totalPrsFound, setTotalPrsFound] = useState(0)
+  const [totalPrsFound, setTotalPrsFoundState] = useState(0)
   const [forceRefresh, setForceRefresh] = useState(0)
   const [updateTimes, setUpdateTimes] = useState<{
     lastUpdated: string
@@ -577,6 +577,12 @@ export function usePRListData(mode: PRSearchMode, onCountChange?: (count: number
   const { enqueue, cancelAll } = useTaskQueue('github')
   const fetchIdRef = useRef(0)
   const fetchInProgressRef = useRef(false)
+  const totalPrsFoundRef = useRef(0)
+
+  const setTotalPrsFound = useCallback((value: number) => {
+    totalPrsFoundRef.current = value
+    setTotalPrsFoundState(value)
+  }, [])
 
   const bookmarkedRepoKeys = useMemo(
     () => new Set((bookmarks ?? []).map(b => `${b.owner}/${b.repo}`)),
@@ -626,16 +632,15 @@ export function usePRListData(mode: PRSearchMode, onCountChange?: (count: number
     return () => clearInterval(interval)
   }, [mode, prs, refreshInterval])
 
-  const handleProgress: ProgressCallback = useCallback(p => {
-    setProgress(prev => {
-      let newTotal = prev?.totalPrsFound ?? 0
-      if (p.status === 'done' && p.prsFound !== undefined) {
-        newTotal += p.prsFound
-      }
+  const handleProgress: ProgressCallback = useCallback(
+    p => {
+      const increment = p.status === 'done' && p.prsFound !== undefined ? p.prsFound : 0
+      const newTotal = totalPrsFoundRef.current + increment
       setTotalPrsFound(newTotal)
-      return { ...p, totalPrsFound: newTotal }
-    })
-  }, [])
+      setProgress({ ...p, totalPrsFound: newTotal })
+    },
+    [setTotalPrsFound]
+  )
 
   const handleManualRefresh = useCallback(() => {
     setForceRefresh(prev => prev + 1)
@@ -750,6 +755,7 @@ export function usePRListData(mode: PRSearchMode, onCountChange?: (count: number
     cancelAllRef,
     prsRef,
     handleProgress,
+    setTotalPrsFound,
   ])
 
   useEffect(() => {

--- a/src/components/ralph-loops/RalphLaunchForm.tsx
+++ b/src/components/ralph-loops/RalphLaunchForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useRef } from 'react'
 import { Play, FolderOpen } from 'lucide-react'
 import { useRalphModels, useRalphAgents, useRalphProviders } from '../../hooks/useRalphConfig'
 import { safeGetItem, safeSetItem } from '../../utils/storage'
@@ -757,6 +757,7 @@ export function RalphLaunchForm({
   const [provider, setProvider] = useState('')
   const [devAgent, setDevAgent] = useState('anvil')
   const [reviewAgents, setReviewAgents] = useState<string[]>([])
+  const reviewAgentsRef = useRef(reviewAgents)
   const [reviewerModels, setReviewerModels] = useState<Record<string, string>>({})
   const [iterations, setIterations] = useState(3)
   const [repeats, setRepeats] = useState(1)
@@ -795,17 +796,18 @@ export function RalphLaunchForm({
   } = useRalphFormOptions(models, providers, agents, provider)
 
   const toggleReviewAgent = (key: string) => {
-    setReviewAgents(prev => {
-      if (prev.includes(key)) {
-        setReviewerModels(rm => {
-          const next = { ...rm }
-          delete next[key]
-          return next
-        })
-        return prev.filter(a => a !== key)
-      }
-      return [...prev, key]
-    })
+    const current = reviewAgentsRef.current
+    const isSelected = current.includes(key)
+    const next = isSelected ? current.filter(a => a !== key) : [...current, key]
+    reviewAgentsRef.current = next
+    if (isSelected) {
+      setReviewerModels(rm => {
+        const remaining = { ...rm }
+        delete remaining[key]
+        return remaining
+      })
+    }
+    setReviewAgents(next)
   }
 
   const setReviewerModel = (role: string, m: string) => {

--- a/src/hooks/useRefreshIndicators.test.ts
+++ b/src/hooks/useRefreshIndicators.test.ts
@@ -83,6 +83,18 @@ describe('useRefreshIndicators', () => {
     expect(result.current['my-prs']).toBe('active')
   })
 
+  it('preserves state identity when the queue is unchanged', () => {
+    mockGetRunning.mockReturnValue(['prefetch-my-prs'])
+    const { result } = renderHook(() => useRefreshIndicators())
+    const initialIndicators = result.current
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+
+    expect(result.current).toBe(initialIndicators)
+  })
+
   it('clears indicators when queue becomes empty', () => {
     mockGetRunning.mockReturnValue(['prefetch-my-prs'])
     const { result } = renderHook(() => useRefreshIndicators())

--- a/src/hooks/useRefreshIndicators.test.ts
+++ b/src/hooks/useRefreshIndicators.test.ts
@@ -13,18 +13,18 @@ vi.mock('../services/taskQueue', () => ({
 
 import { useRefreshIndicators } from './useRefreshIndicators'
 
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.useFakeTimers()
+  mockGetRunning.mockReturnValue([])
+  mockGetPending.mockReturnValue([])
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
 describe('useRefreshIndicators', () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-    vi.useFakeTimers()
-    mockGetRunning.mockReturnValue([])
-    mockGetPending.mockReturnValue([])
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
-  })
-
   it('starts with empty indicators', () => {
     const { result } = renderHook(() => useRefreshIndicators())
     expect(result.current).toEqual({})
@@ -87,11 +87,7 @@ describe('useRefreshIndicators', () => {
     mockGetRunning.mockReturnValue(['prefetch-my-prs'])
     const { result } = renderHook(() => useRefreshIndicators())
     const initialIndicators = result.current
-
-    act(() => {
-      vi.advanceTimersByTime(200)
-    })
-
+    act(() => vi.advanceTimersByTime(200))
     expect(result.current).toBe(initialIndicators)
   })
 

--- a/src/hooks/useRefreshIndicators.ts
+++ b/src/hooks/useRefreshIndicators.ts
@@ -61,18 +61,18 @@ function applyPendingRefreshIndicators(next: RefreshIndicators, pending: string[
   }
 }
 
-function buildRefreshIndicators(
-  running: string[],
-  pending: string[],
-  previous: RefreshIndicators
-): RefreshIndicators {
-  if (running.length === 0 && pending.length === 0) {
-    return Object.keys(previous).length === 0 ? previous : {}
-  }
+function buildRefreshIndicators(running: string[], pending: string[]): RefreshIndicators {
+  if (running.length === 0 && pending.length === 0) return {}
 
   const next = buildActiveRefreshIndicators(running)
   applyPendingRefreshIndicators(next, pending)
   return next
+}
+
+function refreshIndicatorsEqual(left: RefreshIndicators, right: RefreshIndicators): boolean {
+  const leftKeys = Object.keys(left)
+  const rightKeys = Object.keys(right)
+  return leftKeys.length === rightKeys.length && leftKeys.every(key => left[key] === right[key])
 }
 
 /**
@@ -87,7 +87,8 @@ export function useRefreshIndicators(): RefreshIndicators {
       const queue = getTaskQueue('github')
       const running = queue.getRunningTaskNames()
       const pending = queue.getPendingTaskNames()
-      setIndicators(prev => buildRefreshIndicators(running, pending, prev))
+      const next = buildRefreshIndicators(running, pending)
+      setIndicators(prev => (refreshIndicatorsEqual(prev, next) ? prev : next))
     }
 
     compute()

--- a/src/hooks/useTerminalPanel.test.ts
+++ b/src/hooks/useTerminalPanel.test.ts
@@ -738,6 +738,26 @@ describe('useTerminalPanel', () => {
     expect(result.current.terminalTabs[0].color).toBeUndefined()
   })
 
+  it('composes consecutive tab updates from the latest committed snapshot', async () => {
+    const { result } = renderHook(() => useTerminalPanel())
+    await vi.waitFor(() => expect(result.current.loaded).toBe(true))
+
+    let tab: Awaited<ReturnType<typeof result.current.addTerminalTab>>
+    await act(async () => {
+      tab = await result.current.addTerminalTab(null)
+    })
+
+    act(() => {
+      result.current.renameTerminalTab(tab!.id, 'Renamed')
+      result.current.setTerminalTabColor(tab!.id, '#ff0000')
+    })
+
+    expect(result.current.terminalTabs[0]).toMatchObject({
+      title: 'Renamed',
+      color: '#ff0000',
+    })
+  })
+
   it('reorderTerminalTabs with same ID should be no-op', async () => {
     const { result } = renderHook(() => useTerminalPanel())
     await vi.waitFor(() => expect(result.current.loaded).toBe(true))

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -423,12 +423,10 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
   /** Apply a transform to the tabs array, syncing ref + state in one place. */
   const applyTabsUpdate = useCallback(
     (transform: (tabs: TerminalTab[]) => TerminalTab[] | null) => {
-      setTerminalTabs(prev => {
-        const next = transform(prev)
-        if (!next) return prev
-        terminalTabsRef.current = next
-        return next
-      })
+      const next = transform(terminalTabsRef.current)
+      if (!next) return
+      terminalTabsRef.current = next
+      setTerminalTabs(next)
     },
     []
   )

--- a/src/hooks/useTerminalWorkspace.test.tsx
+++ b/src/hooks/useTerminalWorkspace.test.tsx
@@ -447,7 +447,7 @@ describe('useTerminalWorkspace', () => {
     expect(targetLayout).toMatchObject({
       type: 'split',
       direction: 'vertical',
-      children: [expect.any(Object), { type: 'pane', id: sourcePaneId, cwd: '' }],
+      children: [expect.any(Object), { type: 'pane', id: sourcePaneId, cwd: 'D:/source' }],
     })
   })
 

--- a/src/hooks/useTerminalWorkspace.tsx
+++ b/src/hooks/useTerminalWorkspace.tsx
@@ -244,18 +244,16 @@ function useTerminalWorkspaceInternal(): UseTerminalWorkspaceReturn {
       transform: (prev: TerminalTreeNode[]) => TerminalTreeNode[],
       newActiveNodeId?: string | null
     ) => {
-      setNodes(prev => {
-        const next = transform(prev)
-        nodesRef.current = next
-        const hasNewActiveNodeId = newActiveNodeId !== undefined
-        const activeId = hasNewActiveNodeId ? newActiveNodeId : activeNodeIdRef.current
-        if (hasNewActiveNodeId) {
-          setActiveNodeId(activeId)
-          activeNodeIdRef.current = activeId
-        }
-        persistToConvex({ nodes: next, activeNodeId: activeId })
-        return next
-      })
+      const next = transform(nodesRef.current)
+      nodesRef.current = next
+      const hasNewActiveNodeId = newActiveNodeId !== undefined
+      const activeId = hasNewActiveNodeId ? newActiveNodeId : activeNodeIdRef.current
+      if (hasNewActiveNodeId) {
+        setActiveNodeId(activeId)
+        activeNodeIdRef.current = activeId
+      }
+      persistToConvex({ nodes: next, activeNodeId: activeId })
+      setNodes(next)
     },
     [persistToConvex]
   )


### PR DESCRIPTION
Closes #281

## Summary
- move nested setters, ref synchronization, and persistence out of React state updater callbacks
- preserve synchronous composition through canonical refs for PR progress, terminal tabs, terminal workspace nodes, and reviewer selections
- add regression coverage for accumulated progress, stable refresh identity, consecutive terminal updates, and pane move ordering

## Verification
- React Doctor 0.8.3: zero `no-impure-state-updater` findings
- React Doctor 0.8.3: zero `no-side-effect-in-state-updater-function` findings
- 6 focused files: 237 tests passed
- repository coverage: 291 files / 6,500 tests passed; coverage ratchet passed
- ESLint, Prettier, TypeScript, Knip, and Vite production build passed

## Risk
Medium: state transition ordering changed intentionally so event-path effects use the latest canonical snapshot; focused tests cover back-to-back updates and persisted payloads.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix side effects in React state updaters across hooks and components
> - Replaces functional state updater patterns with ref-backed state in [`useTerminalPanel`](https://github.com/HemSoft/hs-buddy/pull/288/files#diff-73bd824b91e56036b13a14fcd5186d0b68dede2f725f90e2fca25b5d7aa841bb), [`useTerminalWorkspace`](https://github.com/HemSoft/hs-buddy/pull/288/files#diff-66809267a937f8bdfbf7817a600fe6984c5b4c58ae998ceb2efc3ac81ee21cd5), [`usePRListData`](https://github.com/HemSoft/hs-buddy/pull/288/files#diff-41097abba92150f9046468aacdb41a10131ae7fd54bf7300518a338bc70c20ff), [`RalphLaunchForm`](https://github.com/HemSoft/hs-buddy/pull/288/files#diff-ccab906f9d13e1fefb50ef66a3bd81838802a09d53f4f12b32dc292681a6551e), and [`InlineDropdown`](https://github.com/HemSoft/hs-buddy/pull/288/files#diff-6bd42edb395042d2dffad73559ed92acf75de20edb6008aaaa409b2174bc60f4) to ensure sequential updates compose from the latest committed state.
> - Adds a ref alongside state in each affected hook/component so that rapid or same-tick updates read the current value rather than a stale closure.
> - [`useRefreshIndicators`](https://github.com/HemSoft/hs-buddy/pull/288/files#diff-d2ae5ad29f6660470a469c70005766cb1633e82897195eac716b82bf689db12e) now skips `setIndicators` when computed indicators are unchanged, preserving object identity and avoiding unnecessary re-renders.
> - Behavioral Change: `totalPrsFound` and `progress.totalPrsFound` in `usePRListData` now accumulate deterministically; tab and workspace updates within the same tick now consistently apply all changes rather than dropping intermediate ones.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 509e2c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->