### PR TITLE
Fix React effect lifecycle stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.889] - 2026-07-23
+
+### Fixed
+
+- Stabilize React effect lifecycles
+
 ## [0.1.887] - 2026-07-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.890] - 2026-07-23
+
+### Changed
+
+- Strengthen effect lifecycle coverage
+
 ## [0.1.889] - 2026-07-23
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.889",
+  "version": "0.1.890",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.887",
+  "version": "0.1.889",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/OrgDetailPanel.tsx
+++ b/src/components/OrgDetailPanel.tsx
@@ -72,6 +72,9 @@ interface RateLimitSnapshot {
   used: number
 }
 
+const fetchOrgOverview = (client: GitHubClient, org: string) => client.fetchOrgOverview(org)
+const fetchOrgMembers = (client: GitHubClient, org: string) => client.fetchOrgMembers(org)
+
 function buildMetricsFromRepos(org: string, cachedRepos: OrgRepoResult): OrgOverviewResult {
   const repos = cachedRepos.repos
   const lastPushAt = repos.reduce<string | null>((latest, repo) => {
@@ -698,7 +701,7 @@ function useOrgOverviewData({
     taskName: overviewTaskName,
     initialData: initialOverview,
     normalize: normalizeOverview,
-    fetchFn: (client, o) => client.fetchOrgOverview(o),
+    fetchFn: fetchOrgOverview,
   })
 
   return {
@@ -729,7 +732,7 @@ function useOrgMembersData({
     enqueue,
     cacheKey: membersCacheKey,
     taskName: membersTaskName,
-    fetchFn: (client, o) => client.fetchOrgMembers(o),
+    fetchFn: fetchOrgMembers,
   })
 
   return {

--- a/src/components/terminal/TerminalPane.test.tsx
+++ b/src/components/terminal/TerminalPane.test.tsx
@@ -276,6 +276,7 @@ describe('TerminalPane', () => {
     await vi.waitFor(() => {
       expect(mockOn).toHaveBeenCalledWith('terminal:data', expect.any(Function))
       expect(mockOn).toHaveBeenCalledWith('terminal:exit', expect.any(Function))
+      expect(mockOn).toHaveBeenCalledWith('terminal:cwd-changed', expect.any(Function))
     })
   })
 
@@ -290,6 +291,7 @@ describe('TerminalPane', () => {
 
     expect(mockOff).toHaveBeenCalledWith('terminal:data', expect.any(Function))
     expect(mockOff).toHaveBeenCalledWith('terminal:exit', expect.any(Function))
+    expect(mockOff).toHaveBeenCalledWith('terminal:cwd-changed', expect.any(Function))
   })
 
   it('disposes terminal on unmount', () => {

--- a/src/components/terminal/TerminalPane.tsx
+++ b/src/components/terminal/TerminalPane.tsx
@@ -164,6 +164,28 @@ function hasResizeChanged(
   return !last || last.cols !== next.cols || last.rows !== next.rows
 }
 
+interface TerminalEventHandlers {
+  onData: (_event: unknown, sid: string, data: string, seq?: number) => void
+  onExit: (_event: unknown, sid: string, exitCode: number) => void
+  onCwdChanged: (_event: unknown, sid: string, newCwd: string) => void
+}
+
+function subscribeToTerminalEvents({
+  onData,
+  onExit,
+  onCwdChanged,
+}: TerminalEventHandlers): () => void {
+  window.ipcRenderer.on(IPC_PUSH.TERMINAL_DATA, onData)
+  window.ipcRenderer.on(IPC_PUSH.TERMINAL_EXIT, onExit)
+  window.ipcRenderer.on(IPC_PUSH.TERMINAL_CWD_CHANGED, onCwdChanged)
+
+  return () => {
+    window.ipcRenderer.off(IPC_PUSH.TERMINAL_DATA, onData)
+    window.ipcRenderer.off(IPC_PUSH.TERMINAL_EXIT, onExit)
+    window.ipcRenderer.off(IPC_PUSH.TERMINAL_CWD_CHANGED, onCwdChanged)
+  }
+}
+
 export function TerminalPane({
   viewKey,
   cwd,
@@ -183,6 +205,7 @@ export function TerminalPane({
     // Per-invocation flag — set to false in cleanup so stale async flows
     // from React StrictMode's double-mount don't register duplicate listeners.
     let active = true
+    let unsubscribeTerminalEvents: (() => void) | null = null
     const container = containerRef.current
     /* v8 ignore start */
     if (!container) return
@@ -331,9 +354,11 @@ export function TerminalPane({
     void (async () => {
       await initSession()
       if (!active) return
-      window.ipcRenderer.on(IPC_PUSH.TERMINAL_DATA, onData)
-      window.ipcRenderer.on(IPC_PUSH.TERMINAL_EXIT, onSessionExit)
-      window.ipcRenderer.on(IPC_PUSH.TERMINAL_CWD_CHANGED, onCwdChanged)
+      unsubscribeTerminalEvents = subscribeToTerminalEvents({
+        onData,
+        onExit: onSessionExit,
+        onCwdChanged,
+      })
     })()
 
     // Debounced resize
@@ -372,9 +397,7 @@ export function TerminalPane({
       cursorMoveDisposable.dispose()
       renderDisposable.dispose()
       inputDisposable.dispose()
-      window.ipcRenderer.off(IPC_PUSH.TERMINAL_DATA, onData)
-      window.ipcRenderer.off(IPC_PUSH.TERMINAL_EXIT, onSessionExit)
-      window.ipcRenderer.off(IPC_PUSH.TERMINAL_CWD_CHANGED, onCwdChanged)
+      unsubscribeTerminalEvents?.()
 
       // Do NOT kill PTY here — session survives tab switches.
       // PTY is killed only via killTerminalSession() on explicit tab close.

--- a/src/hooks/useMigration.test.ts
+++ b/src/hooks/useMigration.test.ts
@@ -194,6 +194,38 @@ describe('useMigrateToConvex', () => {
     expect(mockBulkImportAccounts).toHaveBeenCalledTimes(callCount)
   })
 
+  it('waits for the in-flight migration when dependencies change', async () => {
+    mockExistingAccounts = []
+    mockExistingSettings = {}
+    let resolveConfig!: (value: {
+      github: { accounts: Array<{ username: string; org: string }> }
+      pr: { refreshInterval: number; autoRefresh: boolean }
+    }) => void
+    mockInvoke.mockReturnValue(
+      new Promise(resolve => {
+        resolveConfig = resolve
+      })
+    )
+    mockBulkImportAccounts.mockResolvedValue([{ id: '1', username: 'user1' }])
+    mockInitSettings.mockResolvedValue(undefined)
+
+    const { result, rerender } = renderHook(() => useMigrateToConvex())
+    mockExistingAccounts = []
+    rerender()
+
+    expect(result.current.isComplete).toBe(false)
+
+    resolveConfig({
+      github: { accounts: [{ username: 'user1', org: 'org1' }] },
+      pr: { refreshInterval: 10, autoRefresh: true },
+    })
+
+    await waitFor(() => {
+      expect(result.current.isComplete).toBe(true)
+    })
+    expect(mockInvoke).toHaveBeenCalledTimes(1)
+  })
+
   it('skips import when electron-store has no accounts', async () => {
     mockExistingAccounts = []
     mockExistingSettings = {}

--- a/src/hooks/useMigration.test.ts
+++ b/src/hooks/useMigration.test.ts
@@ -210,15 +210,21 @@ describe('useMigrateToConvex', () => {
     mockInitSettings.mockResolvedValue(undefined)
 
     const { result, rerender } = renderHook(() => useMigrateToConvex())
-    mockExistingAccounts = []
+    mockExistingAccounts = undefined
     rerender()
-
-    expect(result.current.isComplete).toBe(false)
 
     resolveConfig({
       github: { accounts: [{ username: 'user1', org: 'org1' }] },
       pr: { refreshInterval: 10, autoRefresh: true },
     })
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(result.current.isComplete).toBe(false)
+
+    mockExistingAccounts = []
+    rerender()
 
     await waitFor(() => {
       expect(result.current.isComplete).toBe(true)

--- a/src/hooks/useMigration.ts
+++ b/src/hooks/useMigration.ts
@@ -46,7 +46,7 @@ export function useMigrateToConvex() {
   const initSettings = useMutation(api.settings.initFromMigration)
   const [isComplete, setIsComplete] = useState(false)
   const [timedOut, setTimedOut] = useState(false)
-  const migrationAttempted = useRef(false)
+  const migrationPromiseRef = useRef<Promise<void> | null>(null)
 
   // Check if Convex already has data (skip migration if so)
   const existingAccounts = useQuery(api.githubAccounts.list)
@@ -73,28 +73,31 @@ export function useMigrateToConvex() {
       return
     }
 
-    // Only attempt migration once per session
-    if (migrationAttempted.current) {
-      setIsComplete(true)
-      return
+    let cancelled = false
+
+    if (!migrationPromiseRef.current) {
+      migrationPromiseRef.current = (async () => {
+        try {
+          // Get data from electron-store
+          const config = await window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_GET_CONFIG)
+
+          await migrateAccounts(config.github?.accounts, existingAccounts, bulkImportAccounts)
+          await migrateSettings(config.pr, existingSettings, initSettings)
+        } catch (error: unknown) {
+          console.error('[Migration] Failed to migrate from electron-store:', error)
+        }
+      })()
     }
-    migrationAttempted.current = true
 
-    const migrate = async () => {
-      try {
-        // Get data from electron-store
-        const config = await window.ipcRenderer.invoke(IPC_INVOKE.CONFIG_GET_CONFIG)
-
-        await migrateAccounts(config.github?.accounts, existingAccounts, bulkImportAccounts)
-        await migrateSettings(config.pr, existingSettings, initSettings)
-      } catch (error: unknown) {
-        console.error('[Migration] Failed to migrate from electron-store:', error)
-      } finally {
+    void migrationPromiseRef.current.then(() => {
+      if (!cancelled) {
         setIsComplete(true)
       }
-    }
+    })
 
-    migrate()
+    return () => {
+      cancelled = true
+    }
   }, [isLoading, existingAccounts, existingSettings, bulkImportAccounts, initSettings])
 
   return { isComplete, isLoading }

--- a/src/hooks/useTerminalPanel.test.ts
+++ b/src/hooks/useTerminalPanel.test.ts
@@ -77,6 +77,73 @@ describe('useTerminalPanel', () => {
     expect(result.current.panelHeight).toBe(400)
   })
 
+  it('ignores a stale Convex height lookup after settings change', async () => {
+    let heightReadCount = 0
+    let resolveStaleHeight!: (value: null) => void
+    mockInvoke.mockImplementation((channel: string) => {
+      if (channel === 'config:get-terminal-open') return Promise.resolve(false)
+      if (channel === 'config:get-terminal-panel-height') {
+        heightReadCount += 1
+        if (heightReadCount === 1) return Promise.resolve(300)
+        if (heightReadCount === 2) {
+          return new Promise(resolve => {
+            resolveStaleHeight = resolve
+          })
+        }
+        return Promise.resolve(null)
+      }
+      return Promise.resolve()
+    })
+
+    const { result, rerender } = renderHook(() => useTerminalPanel())
+    await vi.waitFor(() => expect(result.current.loaded).toBe(true))
+
+    mockSettingsReturn = { terminalPanelHeight: 400 }
+    rerender()
+    await vi.waitFor(() => expect(heightReadCount).toBe(2))
+
+    mockSettingsReturn = { terminalPanelHeight: 500 }
+    rerender()
+    await vi.waitFor(() => expect(result.current.panelHeight).toBe(500))
+
+    await act(async () => {
+      resolveStaleHeight(null)
+      await Promise.resolve()
+    })
+    expect(result.current.panelHeight).toBe(500)
+  })
+
+  it('ignores stale terminal tab restoration after settings change', async () => {
+    let resolveStalePath!: (value: { path: string }) => void
+    mockResolveRepoPath.mockReturnValueOnce(
+      new Promise(resolve => {
+        resolveStalePath = resolve
+      })
+    )
+
+    const { result, rerender } = renderHook(() => useTerminalPanel())
+    await vi.waitFor(() => expect(result.current.loaded).toBe(true))
+
+    mockSettingsReturn = {
+      terminalTabs: [{ title: 'Old', cwd: '/old', repoSlug: 'acme/old' }],
+    }
+    rerender()
+    await vi.waitFor(() => expect(mockResolveRepoPath).toHaveBeenCalledWith('acme', 'old'))
+
+    mockResolveRepoPath.mockResolvedValueOnce({ path: '/new' })
+    mockSettingsReturn = {
+      terminalTabs: [{ title: 'New', cwd: '/new', repoSlug: 'acme/new' }],
+    }
+    rerender()
+    await vi.waitFor(() => expect(result.current.terminalTabs[0]?.title).toBe('New'))
+
+    await act(async () => {
+      resolveStalePath({ path: '/old' })
+      await Promise.resolve()
+    })
+    expect(result.current.terminalTabs[0]?.title).toBe('New')
+  })
+
   it('ignores invalid config values', async () => {
     mockInvoke.mockImplementation((channel: string) => {
       if (channel === 'config:get-terminal-open') return Promise.resolve('not-boolean')

--- a/src/hooks/useTerminalPanel.ts
+++ b/src/hooks/useTerminalPanel.ts
@@ -177,16 +177,26 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
   // Sync from Convex when available (fills in on new machines with no local config)
   /* v8 ignore start -- Convex sync only fires on new devices; tested via integration */
   useEffect(() => {
-    if (settings?.terminalPanelHeight != null && loaded) {
-      // Only apply Convex value if local didn't have one (first launch on new device)
-      window.ipcRenderer
-        .invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_PANEL_HEIGHT)
-        .then((local: unknown) => {
-          if (local == null) {
-            setPanelHeight(clampPanelHeight(settings.terminalPanelHeight!))
-          }
-        })
-        .catch(() => {})
+    const terminalPanelHeight = settings?.terminalPanelHeight
+    if (terminalPanelHeight == null || !loaded) {
+      return
+    }
+
+    let cancelled = false
+    // Only apply Convex value if local didn't have one (first launch on new device)
+    void window.ipcRenderer
+      .invoke(IPC_INVOKE.CONFIG_GET_TERMINAL_PANEL_HEIGHT)
+      .then((local: unknown) => {
+        if (!cancelled && local == null) {
+          setPanelHeight(clampPanelHeight(terminalPanelHeight))
+        }
+      })
+      .catch((error: unknown) => {
+        console.warn('Failed to sync terminal panel height:', error)
+      })
+
+    return () => {
+      cancelled = true
     }
   }, [settings?.terminalPanelHeight, loaded])
   /* v8 ignore stop */
@@ -205,7 +215,7 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
       )
     )
       return
-    restoredRef.current = true
+    let cancelled = false
 
     async function restoreTabs() {
       const restored: TerminalTab[] = await Promise.all(
@@ -217,11 +227,16 @@ export function useTerminalPanel(activeViewId?: string | null): UseTerminalPanel
           color: saved.color,
         }))
       )
+      if (cancelled) return
+      restoredRef.current = true
       terminalTabsRef.current = restored
       setTerminalTabs(restored)
       if (restored.length > 0) setActiveTerminalTabId(restored[0].id)
     }
     void restoreTabs()
+    return () => {
+      cancelled = true
+    }
   }, [settings?.terminalTabs, loaded])
   /* v8 ignore stop */
 


### PR DESCRIPTION
Closes #282

## Summary
- stabilize organization fetch dependencies with module-level callbacks
- give terminal IPC subscriptions a single explicit disposer
- prevent stale migration and terminal settings effects from writing state
- add regression coverage for dependency changes during in-flight async work

## Verification
- `bun run test` (291 files, 6503 tests)
- `bun run typecheck`
- `bun run lint`
- `bun run knip`
- `bunx vite build`
- `npx --yes react-doctor@latest . --verbose` (all issue-specific effect lifecycle findings cleared)

## Risk
Medium: effect timing and cleanup changed around migration, terminal restoration, and terminal event subscriptions. Focused tests cover in-flight dependency changes and existing subscription cleanup behavior.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix React effect lifecycle race conditions in terminal, migration, and org data hooks
> - Adds cancellation guards to async effects in [`useTerminalPanel`](https://github.com/HemSoft/hs-buddy/pull/289/files#diff-73bd824b91e56036b13a14fcd5186d0b68dede2f725f90e2fca25b5d7aa841bb) and [`useMigrateToConvex`](https://github.com/HemSoft/hs-buddy/pull/289/files#diff-648475ac3bf217358f1365d97f85bbf2d2ef77b10c5889654036fae8d6e44cab) so stale IPC responses are discarded when dependencies change mid-flight.
> - Replaces `migrationAttempted` ref with `migrationPromiseRef` in `useMigrateToConvex` to track in-flight migrations and prevent duplicate `CONFIG_GET_CONFIG` invokes; `isComplete` is only set after the single migration promise resolves.
> - Extracts `subscribeToTerminalEvents` in [`TerminalPane`](https://github.com/HemSoft/hs-buddy/pull/289/files#diff-cf06eab42ef89399f4dc4036a6d2e224efb833b15a613436ab70bba5ed8a7542) to consolidate IPC listener registration and cleanup, adding `terminal:cwd-changed` to the subscription set.
> - Replaces inline arrow fetch functions in [`OrgDetailPanel`](https://github.com/HemSoft/hs-buddy/pull/289/files#diff-da823981ac5723f32047620c1b9f990c11200b8a493c715942c33c3437039fc3) with stable top-level helpers to avoid re-creating fetch functions on each render.
> - Behavioral Change: `useMigrateToConvex` no longer marks migration complete on dependency re-runs while a migration is in flight; `useTerminalPanel` will not overwrite `panelHeight` or restore terminal tabs from stale async results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f1d2c8f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->