### PR TITLE
Fix React Doctor accessibility findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.891] - 2026-07-23
+
+### Fixed
+
+- Resolve React accessibility findings
+
 ## [0.1.890] - 2026-07-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.890",
+  "version": "0.1.891",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/PRReviewPanel.tsx
+++ b/src/components/PRReviewPanel.tsx
@@ -156,6 +156,7 @@ export function PRReviewPanel({ prInfo, onSubmitted, onClose }: PRReviewPanelPro
           <div className="pr-review-schedule-delay">
             <span>in</span>
             <select
+              aria-label="Schedule delay"
               className="pr-review-delay-select"
               value={scheduleDelay}
               onChange={e => setScheduleDelay(Number(e.target.value))}

--- a/src/components/PullRequestList.listview.test.tsx
+++ b/src/components/PullRequestList.listview.test.tsx
@@ -212,6 +212,46 @@ describe('PullRequestList — list view', () => {
     expect(window.shell.openExternal).toHaveBeenCalledWith('https://github.com/test/repo/pull/1')
   })
 
+  it('is keyboard-focusable and opens the PR on Enter', () => {
+    const onOpenPR = vi.fn()
+    mockUsePRListData.mockReturnValue({
+      ...defaultData,
+      prs: [makePr({ id: 99, source: 'gh', repository: 'org/repo' })],
+    })
+    render(<PullRequestList mode="my-prs" onOpenPR={onOpenPR} />)
+    const row = screen.getByText(/Fix login bug/).closest('tr')!
+    expect(row).toHaveAttribute('tabindex', '0')
+
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(onOpenPR).toHaveBeenCalled()
+  })
+
+  it('opens the PR on Space key', () => {
+    const onOpenPR = vi.fn()
+    mockUsePRListData.mockReturnValue({
+      ...defaultData,
+      prs: [makePr({ id: 99, source: 'gh', repository: 'org/repo' })],
+    })
+    render(<PullRequestList mode="my-prs" onOpenPR={onOpenPR} />)
+    const row = screen.getByText(/Fix login bug/).closest('tr')!
+
+    fireEvent.keyDown(row, { key: ' ' })
+    expect(onOpenPR).toHaveBeenCalled()
+  })
+
+  it('does not open the PR for other keys', () => {
+    const onOpenPR = vi.fn()
+    mockUsePRListData.mockReturnValue({
+      ...defaultData,
+      prs: [makePr({ id: 99, source: 'gh', repository: 'org/repo' })],
+    })
+    render(<PullRequestList mode="my-prs" onOpenPR={onOpenPR} />)
+    const row = screen.getByText(/Fix login bug/).closest('tr')!
+
+    fireEvent.keyDown(row, { key: 'ArrowDown' })
+    expect(onOpenPR).not.toHaveBeenCalled()
+  })
+
   it('triggers context menu on right-click', () => {
     mockUsePRListData.mockReturnValue({
       ...defaultData,

--- a/src/components/PullRequestList.listview.test.tsx
+++ b/src/components/PullRequestList.listview.test.tsx
@@ -222,6 +222,9 @@ describe('PullRequestList — list view', () => {
     const row = screen.getByText(/Fix login bug/).closest('tr')!
     expect(row).toHaveAttribute('tabindex', '0')
 
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: 'Enter' })
     expect(onOpenPR).toHaveBeenCalled()
   })
@@ -235,6 +238,9 @@ describe('PullRequestList — list view', () => {
     render(<PullRequestList mode="my-prs" onOpenPR={onOpenPR} />)
     const row = screen.getByText(/Fix login bug/).closest('tr')!
 
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: ' ' })
     expect(onOpenPR).toHaveBeenCalled()
   })
@@ -247,6 +253,9 @@ describe('PullRequestList — list view', () => {
     })
     render(<PullRequestList mode="my-prs" onOpenPR={onOpenPR} />)
     const row = screen.getByText(/Fix login bug/).closest('tr')!
+
+    row.focus()
+    expect(row).toHaveFocus()
 
     fireEvent.keyDown(row, { key: 'ArrowDown' })
     expect(onOpenPR).not.toHaveBeenCalled()

--- a/src/components/PullRequestList.tsx
+++ b/src/components/PullRequestList.tsx
@@ -16,6 +16,7 @@ import { PRStateIcon } from './shared/PRStateIcon'
 import { useViewMode, type ViewMode } from '../hooks/useViewMode'
 import { formatDistanceToNow } from '../utils/dateUtils'
 import { createPRDetailViewId } from '../utils/prDetailView'
+import { onKeyboardActivate } from '../utils/keyboard'
 import type { PullRequest } from '../types/pullRequest'
 import type { PRSearchMode } from '../api/github'
 
@@ -103,42 +104,48 @@ function PRListTableView({ prs, onOpenPR, handleContextMenu }: PRListTableViewPr
           </tr>
         </thead>
         <tbody>
-          {prs.map(pr => (
-            <tr
-              key={`${pr.source}-${pr.id}-${pr.repository}`}
-              onClick={() =>
-                onOpenPR ? onOpenPR(createPRDetailViewId(pr)) : window.shell.openExternal(pr.url)
-              }
-              onContextMenu={e => handleContextMenu(e, pr)}
-            >
-              <td className="col-status">
-                <PRStateIcon state={pr.state} />
-              </td>
-              <td className="col-title">
-                <span className="col-number">#{pr.id}</span> {pr.title}
-              </td>
-              <td className="col-author">
-                {pr.authorAvatarUrl && (
-                  <img
-                    src={pr.authorAvatarUrl}
-                    alt={pr.author}
-                    className="list-view-avatar"
-                    width={18}
-                    height={18}
-                  />
-                )}
-                {pr.author}
-              </td>
-              <td className="col-number">{pr.repository}</td>
-              <td className="col-date">{pr.updatedAt ? formatDistanceToNow(pr.updatedAt) : '—'}</td>
-              <td>
-                <ThreadsStatusCell threadsUnaddressed={pr.threadsUnaddressed} />
-              </td>
-              <td>
-                <ApprovalCell approvalCount={pr.approvalCount} iApproved={pr.iApproved} />
-              </td>
-            </tr>
-          ))}
+          {prs.map(pr => {
+            const openPR = () =>
+              onOpenPR ? onOpenPR(createPRDetailViewId(pr)) : window.shell.openExternal(pr.url)
+            return (
+              <tr
+                key={`${pr.source}-${pr.id}-${pr.repository}`}
+                onClick={openPR}
+                onContextMenu={e => handleContextMenu(e, pr)}
+                tabIndex={0}
+                onKeyDown={onKeyboardActivate(openPR)}
+              >
+                <td className="col-status">
+                  <PRStateIcon state={pr.state} />
+                </td>
+                <td className="col-title">
+                  <span className="col-number">#{pr.id}</span> {pr.title}
+                </td>
+                <td className="col-author">
+                  {pr.authorAvatarUrl && (
+                    <img
+                      src={pr.authorAvatarUrl}
+                      alt={pr.author}
+                      className="list-view-avatar"
+                      width={18}
+                      height={18}
+                    />
+                  )}
+                  {pr.author}
+                </td>
+                <td className="col-number">{pr.repository}</td>
+                <td className="col-date">
+                  {pr.updatedAt ? formatDistanceToNow(pr.updatedAt) : '—'}
+                </td>
+                <td>
+                  <ThreadsStatusCell threadsUnaddressed={pr.threadsUnaddressed} />
+                </td>
+                <td>
+                  <ApprovalCell approvalCount={pr.approvalCount} iApproved={pr.iApproved} />
+                </td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/RepoIssueDetailPanel.tsx
+++ b/src/components/RepoIssueDetailPanel.tsx
@@ -208,6 +208,7 @@ function IssueCommentItem({ comment }: { comment: RepoIssueDetail['comments'][nu
           type="button"
           className="repo-issue-detail-link-btn"
           onClick={() => window.shell?.openExternal(comment.url)}
+          aria-label="Open comment on GitHub"
         >
           <ExternalLink size={13} />
         </button>

--- a/src/components/RepoIssueList.test.tsx
+++ b/src/components/RepoIssueList.test.tsx
@@ -349,6 +349,9 @@ describe('RepoIssueList', () => {
     const row = screen.getByText('Bug report').closest('tr')!
     expect(row).toHaveAttribute('tabindex', '0')
 
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: 'Enter' })
     expect(onOpenIssue).toHaveBeenCalledWith(1)
   })
@@ -364,6 +367,9 @@ describe('RepoIssueList', () => {
     })
 
     const row = screen.getByText('Bug report').closest('tr')!
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: ' ' })
     expect(onOpenIssue).toHaveBeenCalledWith(1)
   })
@@ -379,6 +385,9 @@ describe('RepoIssueList', () => {
     })
 
     const row = screen.getByText('Bug report').closest('tr')!
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: 'ArrowDown' })
     expect(onOpenIssue).not.toHaveBeenCalled()
   })

--- a/src/components/RepoIssueList.test.tsx
+++ b/src/components/RepoIssueList.test.tsx
@@ -336,6 +336,53 @@ describe('RepoIssueList', () => {
     )
   })
 
+  it('is keyboard-focusable and calls onOpenIssue on Enter in list view', async () => {
+    mockUseViewMode.mockReturnValue(['list', vi.fn()])
+    const onOpenIssue = vi.fn()
+    mockEnqueue.mockResolvedValue([makeIssue()])
+    render(<RepoIssueList owner="test-org" repo="hs-buddy" onOpenIssue={onOpenIssue} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Bug report')).toBeInTheDocument()
+    })
+
+    const row = screen.getByText('Bug report').closest('tr')!
+    expect(row).toHaveAttribute('tabindex', '0')
+
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(onOpenIssue).toHaveBeenCalledWith(1)
+  })
+
+  it('calls onOpenIssue on Space key in list view', async () => {
+    mockUseViewMode.mockReturnValue(['list', vi.fn()])
+    const onOpenIssue = vi.fn()
+    mockEnqueue.mockResolvedValue([makeIssue()])
+    render(<RepoIssueList owner="test-org" repo="hs-buddy" onOpenIssue={onOpenIssue} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Bug report')).toBeInTheDocument()
+    })
+
+    const row = screen.getByText('Bug report').closest('tr')!
+    fireEvent.keyDown(row, { key: ' ' })
+    expect(onOpenIssue).toHaveBeenCalledWith(1)
+  })
+
+  it('does not call onOpenIssue for other keys in list view', async () => {
+    mockUseViewMode.mockReturnValue(['list', vi.fn()])
+    const onOpenIssue = vi.fn()
+    mockEnqueue.mockResolvedValue([makeIssue()])
+    render(<RepoIssueList owner="test-org" repo="hs-buddy" onOpenIssue={onOpenIssue} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('Bug report')).toBeInTheDocument()
+    })
+
+    const row = screen.getByText('Bug report').closest('tr')!
+    fireEvent.keyDown(row, { key: 'ArrowDown' })
+    expect(onOpenIssue).not.toHaveBeenCalled()
+  })
+
   it('retries fetch on retry button click', async () => {
     mockEnqueue.mockRejectedValueOnce(new Error('Network error'))
     render(<RepoIssueList owner="test-org" repo="hs-buddy" />)

--- a/src/components/RepoIssueList.tsx
+++ b/src/components/RepoIssueList.tsx
@@ -10,6 +10,7 @@ import { ViewModeToggle } from './shared/ViewModeToggle'
 import { PanelLoadingState, PanelErrorState, PanelEmptyState } from './shared/PanelStates'
 import { useViewMode, type ViewMode } from '../hooks/useViewMode'
 import { IssueContextMenu } from './IssueContextMenu'
+import { onKeyboardActivate } from '../utils/keyboard'
 import './RepoIssueList.css'
 import './shared/ListView.css'
 
@@ -42,48 +43,53 @@ function IssueTableView({
           </tr>
         </thead>
         <tbody>
-          {issues.map(issue => (
-            <tr
-              key={issue.number}
-              onClick={() => {
-                if (onOpenIssue) {
-                  onOpenIssue(issue.number)
-                  return
-                }
-                window.shell?.openExternal(issue.url)
-              }}
-              onContextMenu={e => onContextMenu(e, issue)}
-            >
-              <td className="col-status">
-                <CircleDot size={14} className={`list-view-status-${issue.state}`} />
-              </td>
-              <td className="col-title">
-                <span className="col-number">#{issue.number}</span> {issue.title}
-              </td>
-              <td className="col-author">
-                {issue.authorAvatarUrl && (
-                  <img
-                    src={issue.authorAvatarUrl}
-                    alt={issue.author}
-                    className="list-view-avatar"
-                  />
-                )}
-                {issue.author}
-              </td>
-              <td className="col-labels">
-                {issue.labels.map(label => (
-                  <span
-                    key={label.name}
-                    className="list-view-label"
-                    style={getLabelStyle(label.color)}
-                  >
-                    {label.name}
-                  </span>
-                ))}
-              </td>
-              <td className="col-date">{formatDistanceToNow(issue.updatedAt)}</td>
-            </tr>
-          ))}
+          {issues.map(issue => {
+            const openIssue = () => {
+              if (onOpenIssue) {
+                onOpenIssue(issue.number)
+                return
+              }
+              window.shell?.openExternal(issue.url)
+            }
+            return (
+              <tr
+                key={issue.number}
+                onClick={openIssue}
+                onContextMenu={e => onContextMenu(e, issue)}
+                tabIndex={0}
+                onKeyDown={onKeyboardActivate(openIssue)}
+              >
+                <td className="col-status">
+                  <CircleDot size={14} className={`list-view-status-${issue.state}`} />
+                </td>
+                <td className="col-title">
+                  <span className="col-number">#{issue.number}</span> {issue.title}
+                </td>
+                <td className="col-author">
+                  {issue.authorAvatarUrl && (
+                    <img
+                      src={issue.authorAvatarUrl}
+                      alt={issue.author}
+                      className="list-view-avatar"
+                    />
+                  )}
+                  {issue.author}
+                </td>
+                <td className="col-labels">
+                  {issue.labels.map(label => (
+                    <span
+                      key={label.name}
+                      className="list-view-label"
+                      style={getLabelStyle(label.color)}
+                    >
+                      {label.name}
+                    </span>
+                  ))}
+                </td>
+                <td className="col-date">{formatDistanceToNow(issue.updatedAt)}</td>
+              </tr>
+            )
+          })}
         </tbody>
       </table>
     </div>

--- a/src/components/RepoPullRequestList.test.tsx
+++ b/src/components/RepoPullRequestList.test.tsx
@@ -232,6 +232,9 @@ describe('RepoPullRequestList', () => {
     const row = screen.getByText('Add feature').closest('tr')!
     expect(row).toHaveAttribute('tabindex', '0')
 
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: 'Enter' })
     expect(onOpenPR).toHaveBeenCalled()
   })
@@ -243,6 +246,9 @@ describe('RepoPullRequestList', () => {
     render(<RepoPullRequestList owner="test-org" repo="hs-buddy" onOpenPR={onOpenPR} />)
 
     const row = screen.getByText('Add feature').closest('tr')!
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: ' ' })
     expect(onOpenPR).toHaveBeenCalled()
   })
@@ -254,6 +260,9 @@ describe('RepoPullRequestList', () => {
     render(<RepoPullRequestList owner="test-org" repo="hs-buddy" onOpenPR={onOpenPR} />)
 
     const row = screen.getByText('Add feature').closest('tr')!
+    row.focus()
+    expect(row).toHaveFocus()
+
     fireEvent.keyDown(row, { key: 'ArrowDown' })
     expect(onOpenPR).not.toHaveBeenCalled()
   })

--- a/src/components/RepoPullRequestList.test.tsx
+++ b/src/components/RepoPullRequestList.test.tsx
@@ -223,6 +223,41 @@ describe('RepoPullRequestList', () => {
     expect(onOpenPR).toHaveBeenCalled()
   })
 
+  it('is keyboard-focusable and handles PR activation on Enter in list view', () => {
+    mockViewMode.mockReturnValue(['list', vi.fn()])
+    const onOpenPR = vi.fn()
+    setupHook({ data: [makePR()], loading: false })
+    render(<RepoPullRequestList owner="test-org" repo="hs-buddy" onOpenPR={onOpenPR} />)
+
+    const row = screen.getByText('Add feature').closest('tr')!
+    expect(row).toHaveAttribute('tabindex', '0')
+
+    fireEvent.keyDown(row, { key: 'Enter' })
+    expect(onOpenPR).toHaveBeenCalled()
+  })
+
+  it('handles PR activation on Space key in list view', () => {
+    mockViewMode.mockReturnValue(['list', vi.fn()])
+    const onOpenPR = vi.fn()
+    setupHook({ data: [makePR()], loading: false })
+    render(<RepoPullRequestList owner="test-org" repo="hs-buddy" onOpenPR={onOpenPR} />)
+
+    const row = screen.getByText('Add feature').closest('tr')!
+    fireEvent.keyDown(row, { key: ' ' })
+    expect(onOpenPR).toHaveBeenCalled()
+  })
+
+  it('does not handle PR activation for other keys in list view', () => {
+    mockViewMode.mockReturnValue(['list', vi.fn()])
+    const onOpenPR = vi.fn()
+    setupHook({ data: [makePR()], loading: false })
+    render(<RepoPullRequestList owner="test-org" repo="hs-buddy" onOpenPR={onOpenPR} />)
+
+    const row = screen.getByText('Add feature').closest('tr')!
+    fireEvent.keyDown(row, { key: 'ArrowDown' })
+    expect(onOpenPR).not.toHaveBeenCalled()
+  })
+
   it('shows empty state for closed PRs', () => {
     setupHook({ data: [], loading: false })
     render(<RepoPullRequestList owner="test-org" repo="hs-buddy" prState="closed" />)

--- a/src/components/RepoPullRequestList.tsx
+++ b/src/components/RepoPullRequestList.tsx
@@ -94,7 +94,9 @@ function PRTableView({
               key={pr.number}
               onClick={() => handlePRClick(pr)}
               tabIndex={0}
-              onKeyDown={onKeyboardActivate(() => handlePRClick(pr))}
+              onKeyDown={onKeyboardActivate(() => {
+                handlePRClick(pr)
+              })}
             >
               <td className="col-status">
                 <PRStatusCell pr={pr} />

--- a/src/components/RepoPullRequestList.tsx
+++ b/src/components/RepoPullRequestList.tsx
@@ -15,6 +15,7 @@ import { formatDistanceToNow } from '../utils/dateUtils'
 import { createPRDetailViewId } from '../utils/prDetailView'
 import { mapRepoPRToPullRequest } from '../utils/prMapper'
 import { getLabelStyle } from '../utils/labelStyle'
+import { onKeyboardActivate } from '../utils/keyboard'
 import { ViewModeToggle } from './shared/ViewModeToggle'
 import {
   PanelLoadingState,
@@ -89,7 +90,12 @@ function PRTableView({
         </thead>
         <tbody>
           {prs.map(pr => (
-            <tr key={pr.number} onClick={() => handlePRClick(pr)}>
+            <tr
+              key={pr.number}
+              onClick={() => handlePRClick(pr)}
+              tabIndex={0}
+              onKeyDown={onKeyboardActivate(() => handlePRClick(pr))}
+            >
               <td className="col-status">
                 <PRStatusCell pr={pr} />
               </td>

--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -29,12 +29,12 @@
 .tab {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 12px;
+  gap: 0;
+  padding: 0;
   background-color: var(--bg-tertiary);
   color: var(--text-secondary);
   border-right: 1px solid var(--border-secondary);
-  cursor: pointer;
+  cursor: default;
   user-select: none;
   white-space: nowrap;
   transition: background-color 0.15s ease;
@@ -68,7 +68,7 @@
   background: none;
   border: none;
   margin: 0;
-  padding: 0;
+  padding: 6px 8px 6px 12px;
   font: inherit;
   color: inherit;
   text-align: left;
@@ -81,7 +81,8 @@
   justify-content: center;
   background: none;
   border: none;
-  padding: 2px;
+  align-self: stretch;
+  padding: 2px 12px 2px 4px;
   cursor: pointer;
   color: var(--text-secondary);
   border-radius: 4px;

--- a/src/components/TabBar.css
+++ b/src/components/TabBar.css
@@ -60,6 +60,21 @@
   font-size: 13px;
 }
 
+.tab-select {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
 .tab-close {
   display: flex;
   align-items: center;

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -56,13 +56,13 @@ describe('TabBar', () => {
     renderTabBar({ activeTabId: 'tab-2' })
     const tabs = screen.getAllByRole('tab')
 
-    expect(tabs[0]).not.toHaveClass('active')
+    expect(tabs[0].closest('.tab')).not.toHaveClass('active')
     expect(tabs[0]).toHaveAttribute('aria-selected', 'false')
 
-    expect(tabs[1]).toHaveClass('active')
+    expect(tabs[1].closest('.tab')).toHaveClass('active')
     expect(tabs[1]).toHaveAttribute('aria-selected', 'true')
 
-    expect(tabs[2]).not.toHaveClass('active')
+    expect(tabs[2].closest('.tab')).not.toHaveClass('active')
     expect(tabs[2]).toHaveAttribute('aria-selected', 'false')
   })
 
@@ -70,7 +70,7 @@ describe('TabBar', () => {
     renderTabBar({ activeTabId: null })
 
     for (const tab of screen.getAllByRole('tab')) {
-      expect(tab).not.toHaveClass('active')
+      expect(tab.closest('.tab')).not.toHaveClass('active')
       expect(tab).toHaveAttribute('aria-selected', 'false')
     }
   })
@@ -139,6 +139,18 @@ describe('TabBar', () => {
     }
   })
 
+  it('renders the tab and its close button as independent, non-nested focus targets', () => {
+    renderTabBar()
+
+    const tab = screen.getByRole('tab', { name: 'Settings' })
+    const closeButton = screen.getByRole('button', { name: 'Close Settings' })
+
+    expect(tab.tagName).toBe('BUTTON')
+    expect(closeButton.tagName).toBe('BUTTON')
+    expect(tab.contains(closeButton)).toBe(false)
+    expect(closeButton.contains(tab)).toBe(false)
+  })
+
   it('renders a single active tab correctly', () => {
     const singleTab: Tab[] = [{ id: 'only', label: 'Only Tab', viewId: 'view-only' }]
 
@@ -146,7 +158,7 @@ describe('TabBar', () => {
 
     expect(screen.getAllByRole('tab')).toHaveLength(1)
     expect(screen.getByText('Only Tab')).toBeInTheDocument()
-    expect(screen.getByRole('tab')).toHaveClass('active')
+    expect(screen.getByRole('tab').closest('.tab')).toHaveClass('active')
   })
 
   describe('context menu', () => {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -123,6 +123,52 @@ describe('TabBar', () => {
     expect(onTabSelect).toHaveBeenCalledWith('tab-3')
   })
 
+  it('moves focus to the next tab on ArrowRight and wraps from the last to the first', () => {
+    const { onTabSelect } = renderTabBar()
+    const tabs = screen.getAllByRole('tab')
+
+    tabs[0].focus()
+    fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+    expect(tabs[1]).toHaveFocus()
+
+    fireEvent.keyDown(tabs[1], { key: 'ArrowRight' })
+    expect(tabs[2]).toHaveFocus()
+
+    // Wraps around from the last tab back to the first
+    fireEvent.keyDown(tabs[2], { key: 'ArrowRight' })
+    expect(tabs[0]).toHaveFocus()
+
+    // Arrow navigation only moves focus; it must not select the tab
+    expect(onTabSelect).not.toHaveBeenCalled()
+  })
+
+  it('moves focus to the previous tab on ArrowLeft and wraps from the first to the last', () => {
+    const { onTabSelect } = renderTabBar()
+    const tabs = screen.getAllByRole('tab')
+
+    tabs[0].focus()
+    // Wraps around from the first tab back to the last
+    fireEvent.keyDown(tabs[0], { key: 'ArrowLeft' })
+    expect(tabs[2]).toHaveFocus()
+
+    fireEvent.keyDown(tabs[2], { key: 'ArrowLeft' })
+    expect(tabs[1]).toHaveFocus()
+
+    expect(onTabSelect).not.toHaveBeenCalled()
+  })
+
+  it('moves focus to the first tab on Home and the last tab on End', () => {
+    renderTabBar()
+    const tabs = screen.getAllByRole('tab')
+
+    tabs[1].focus()
+    fireEvent.keyDown(tabs[1], { key: 'End' })
+    expect(tabs[2]).toHaveFocus()
+
+    fireEvent.keyDown(tabs[2], { key: 'Home' })
+    expect(tabs[0]).toHaveFocus()
+  })
+
   it('gives each close button an accessible label', () => {
     renderTabBar()
 
@@ -131,12 +177,22 @@ describe('TabBar', () => {
     expect(screen.getByRole('button', { name: 'Close Profile' })).toBeInTheDocument()
   })
 
-  it('gives every tab a keyboard-focusable tabIndex of 0', () => {
-    renderTabBar()
+  it('gives only the active tab a tabIndex of 0 (roving tabindex) and inactive tabs -1', () => {
+    renderTabBar({ activeTabId: 'tab-2' })
+    const tabs = screen.getAllByRole('tab')
 
-    for (const tab of screen.getAllByRole('tab')) {
-      expect(tab).toHaveAttribute('tabindex', '0')
-    }
+    expect(tabs[0]).toHaveAttribute('tabindex', '-1')
+    expect(tabs[1]).toHaveAttribute('tabindex', '0')
+    expect(tabs[2]).toHaveAttribute('tabindex', '-1')
+  })
+
+  it('falls back to making the first tab the roving tab stop when there is no active tab', () => {
+    renderTabBar({ activeTabId: null })
+    const tabs = screen.getAllByRole('tab')
+
+    expect(tabs[0]).toHaveAttribute('tabindex', '0')
+    expect(tabs[1]).toHaveAttribute('tabindex', '-1')
+    expect(tabs[2]).toHaveAttribute('tabindex', '-1')
   })
 
   it('renders the tab and its close button as independent, non-nested focus targets', () => {

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -151,6 +151,16 @@ describe('TabBar', () => {
     expect(closeButton.contains(tab)).toBe(false)
   })
 
+  it('renders the tabs inside a tablist with an accessible name', () => {
+    renderTabBar()
+
+    const tablist = screen.getByRole('tablist', { name: 'Open tabs' })
+    expect(tablist).toBeInTheDocument()
+    for (const tab of screen.getAllByRole('tab')) {
+      expect(tablist.contains(tab)).toBe(true)
+    }
+  })
+
   it('renders a single active tab correctly', () => {
     const singleTab: Tab[] = [{ id: 'only', label: 'Only Tab', viewId: 'view-only' }]
 

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -81,7 +81,7 @@ export function TabBar({
 
   return (
     <div className="tab-bar">
-      <div className="tab-bar-tabs">
+      <div className="tab-bar-tabs" role="tablist" aria-label="Open tabs">
         {tabs.map(tab => (
           <div
             key={tab.id}

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { X } from 'lucide-react'
 import { onKeyboardActivate } from '../utils/keyboard'
 import './TabBar.css'
@@ -45,7 +46,33 @@ export function TabBar({
 }: TabBarProps) {
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null)
   const menuRef = useRef<HTMLDivElement>(null)
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
   const closeContextMenu = useCallback(() => setContextMenu(null), [])
+
+  const focusTabAt = (index: number) => {
+    tabRefs.current[index]?.focus()
+  }
+
+  const handleTabArrowKeyDown = (event: ReactKeyboardEvent<HTMLButtonElement>, index: number) => {
+    switch (event.key) {
+      case 'ArrowRight':
+        event.preventDefault()
+        focusTabAt((index + 1) % tabs.length)
+        break
+      case 'ArrowLeft':
+        event.preventDefault()
+        focusTabAt((index - 1 + tabs.length) % tabs.length)
+        break
+      case 'Home':
+        event.preventDefault()
+        focusTabAt(0)
+        break
+      case 'End':
+        event.preventDefault()
+        focusTabAt(tabs.length - 1)
+        break
+    }
+  }
 
   const handleContextMenu = useCallback((e: React.MouseEvent, tabId: string) => {
     e.preventDefault()
@@ -82,22 +109,28 @@ export function TabBar({
   return (
     <div className="tab-bar">
       <div className="tab-bar-tabs" role="tablist" aria-label="Open tabs">
-        {tabs.map(tab => (
+        {tabs.map((tab, index) => (
           <div
             key={tab.id}
             className={`tab ${activeTabId === tab.id ? 'active' : ''}`}
             onContextMenu={e => handleContextMenu(e, tab.id)}
           >
             <button
+              ref={el => {
+                tabRefs.current[index] = el
+              }}
               type="button"
               className="tab-select"
               role="tab"
-              tabIndex={0}
+              tabIndex={(activeTabId === null ? index === 0 : activeTabId === tab.id) ? 0 : -1}
               aria-selected={activeTabId === tab.id}
               onClick={() => onTabSelect(tab.id)}
-              onKeyDown={onKeyboardActivate(() => {
-                onTabSelect(tab.id)
-              })}
+              onKeyDown={e => {
+                handleTabArrowKeyDown(e, index)
+                onKeyboardActivate(() => {
+                  onTabSelect(tab.id)
+                })(e)
+              }}
             >
               <span className="tab-label">{tab.label}</span>
             </button>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -95,7 +95,9 @@ export function TabBar({
               tabIndex={0}
               aria-selected={activeTabId === tab.id}
               onClick={() => onTabSelect(tab.id)}
-              onKeyDown={onKeyboardActivate(() => onTabSelect(tab.id))}
+              onKeyDown={onKeyboardActivate(() => {
+                onTabSelect(tab.id)
+              })}
             >
               <span className="tab-label">{tab.label}</span>
             </button>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { X } from 'lucide-react'
+import { onKeyboardActivate } from '../utils/keyboard'
 import './TabBar.css'
 
 export interface Tab {
@@ -85,19 +86,19 @@ export function TabBar({
           <div
             key={tab.id}
             className={`tab ${activeTabId === tab.id ? 'active' : ''}`}
-            onClick={() => onTabSelect(tab.id)}
             onContextMenu={e => handleContextMenu(e, tab.id)}
-            role="tab"
-            tabIndex={0}
-            aria-selected={activeTabId === tab.id}
-            onKeyDown={e => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault()
-                onTabSelect(tab.id)
-              }
-            }}
           >
-            <span className="tab-label">{tab.label}</span>
+            <button
+              type="button"
+              className="tab-select"
+              role="tab"
+              tabIndex={0}
+              aria-selected={activeTabId === tab.id}
+              onClick={() => onTabSelect(tab.id)}
+              onKeyDown={onKeyboardActivate(() => onTabSelect(tab.id))}
+            >
+              <span className="tab-label">{tab.label}</span>
+            </button>
             <button
               type="button"
               className="tab-close"

--- a/src/components/automation/CronBuilder.tsx
+++ b/src/components/automation/CronBuilder.tsx
@@ -99,7 +99,11 @@ function HourlyCronOptions({ minute, updateCron }: CronOptionsProps) {
   return (
     <div className="cron-option">
       <span className="option-label">At minute</span>
-      <select value={minute} onChange={e => updateCron({ minute: parseInt(e.target.value) })}>
+      <select
+        aria-label="Minute of hour"
+        value={minute}
+        onChange={e => updateCron({ minute: parseInt(e.target.value) })}
+      >
         {Array.from({ length: 60 }, (_, min) => (
           <option key={min} value={min}>
             {min.toString().padStart(2, '0')}
@@ -151,6 +155,7 @@ function MonthlyCronOptions({
       <div className="cron-option">
         <span className="option-label">On day</span>
         <select
+          aria-label="Day of month"
           value={dayOfMonth}
           onChange={e => updateCron({ dayOfMonth: parseInt(e.target.value) })}
         >
@@ -207,7 +212,11 @@ export function CronBuilder({ value, onChange }: CronBuilderProps) {
 
   const hourSelect = (
     /* v8 ignore start */
-    <select value={hour} onChange={e => updateCron({ hour: parseInt(e.target.value) })}>
+    <select
+      aria-label="Hour"
+      value={hour}
+      onChange={e => updateCron({ hour: parseInt(e.target.value) })}
+    >
       {Array.from({ length: 24 }, (_, h) => (
         <option key={h} value={h}>
           {formatHour12(h)}
@@ -218,7 +227,11 @@ export function CronBuilder({ value, onChange }: CronBuilderProps) {
   )
   const minuteSelect = (
     /* v8 ignore start */
-    <select value={minute} onChange={e => updateCron({ minute: parseInt(e.target.value) })}>
+    <select
+      aria-label="Minute"
+      value={minute}
+      onChange={e => updateCron({ minute: parseInt(e.target.value) })}
+    >
       {MINUTE_INCREMENTS.map(m => (
         <option key={m} value={m}>
           {m.toString().padStart(2, '0')}

--- a/src/components/automation/RunList.css
+++ b/src/components/automation/RunList.css
@@ -201,6 +201,29 @@
   cursor: default;
 }
 
+/* List-view row toggle: a labelled native button that fills the title
+   cell, reset to look like the plain text it replaces. */
+.run-row-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.run-list .list-view-table tbody tr {
+  cursor: default;
+}
+
+.run-list-details-row > td {
+  padding: 0 12px 8px;
+}
+
 .run-card-expand {
   display: flex;
   align-items: center;

--- a/src/components/automation/RunList.test.tsx
+++ b/src/components/automation/RunList.test.tsx
@@ -319,6 +319,18 @@ describe('RunList', () => {
     fireEvent.click(rows[1])
   })
 
+  it('is keyboard-focusable and toggles the row on Enter in list view', () => {
+    mockUseViewMode.mockReturnValue(['list', vi.fn()])
+    render(<RunList />)
+    const rows = screen.getAllByRole('row')
+    const dataRow = rows[1]
+    expect(dataRow).toHaveAttribute('tabindex', '0')
+
+    // Enter should toggle without crashing, same effect as a click
+    fireEvent.keyDown(dataRow, { key: 'Enter' })
+    fireEvent.keyDown(dataRow, { key: ' ' })
+  })
+
   it('catches errors when cancel fails', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
     mockCancel.mockRejectedValue(new Error('cancel failed'))

--- a/src/components/automation/RunList.test.tsx
+++ b/src/components/automation/RunList.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { RunList } from './RunList'
 
 // --- Hoisted configurable mocks ---
@@ -45,6 +46,11 @@ vi.mock('./run-list/RunCard', () => ({
         </button>
       )}
     </div>
+  ),
+  hasRunDetails: (run: { input?: unknown; output?: unknown; error?: string }) =>
+    run.input !== undefined || run.output !== undefined || run.error !== undefined,
+  RunCardDetails: ({ run }: { run: { _id: string; error?: string } }) => (
+    <div data-testid={`run-details-${run._id}`}>{run.error}</div>
   ),
 }))
 
@@ -309,26 +315,48 @@ describe('RunList', () => {
     expect(screen.getByText('—')).toBeTruthy()
   })
 
-  it('toggles expanded row on list view row click', () => {
+  it('toggles expanded row when clicking the toggle button in list view', () => {
     mockUseViewMode.mockReturnValue(['list', vi.fn()])
     render(<RunList />)
-    const rows = screen.getAllByRole('row')
-    // First row is header, click data row
-    fireEvent.click(rows[1])
-    // Re-clicking should toggle (no crash)
-    fireEvent.click(rows[1])
+    const toggle = screen.getByRole('button', { name: 'Expand details for Build Check' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(toggle)
+    expect(
+      screen.getByRole('button', { name: 'Collapse details for Build Check' })
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('run-details-run-3')).toHaveTextContent('Timeout')
+
+    // Re-clicking should collapse it again
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse details for Build Check' }))
+    expect(screen.getByRole('button', { name: 'Expand details for Build Check' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    expect(screen.queryByTestId('run-details-run-3')).not.toBeInTheDocument()
   })
 
-  it('is keyboard-focusable and toggles the row on Enter in list view', () => {
+  it('is keyboard-focusable and toggles the row on Enter and Space in list view', async () => {
+    const user = userEvent.setup()
     mockUseViewMode.mockReturnValue(['list', vi.fn()])
     render(<RunList />)
-    const rows = screen.getAllByRole('row')
-    const dataRow = rows[1]
-    expect(dataRow).toHaveAttribute('tabindex', '0')
+    const toggle = screen.getByRole('button', { name: 'Expand details for Build Check' })
 
-    // Enter should toggle without crashing, same effect as a click
-    fireEvent.keyDown(dataRow, { key: 'Enter' })
-    fireEvent.keyDown(dataRow, { key: ' ' })
+    toggle.focus()
+    expect(toggle).toHaveFocus()
+
+    await user.keyboard('{Enter}')
+    expect(
+      screen.getByRole('button', { name: 'Collapse details for Build Check' })
+    ).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('run-details-run-3')).toHaveTextContent('Timeout')
+
+    await user.keyboard(' ')
+    expect(screen.getByRole('button', { name: 'Expand details for Build Check' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    expect(screen.queryByTestId('run-details-run-3')).not.toBeInTheDocument()
   })
 
   it('catches errors when cancel fails', async () => {

--- a/src/components/automation/RunList.tsx
+++ b/src/components/automation/RunList.tsx
@@ -98,7 +98,9 @@ function RunListTable({
             key={run._id}
             onClick={() => onToggle(run._id)}
             tabIndex={0}
-            onKeyDown={onKeyboardActivate(() => onToggle(run._id))}
+            onKeyDown={onKeyboardActivate(() => {
+              onToggle(run._id)
+            })}
           >
             <td className="col-status">{getStatusIcon(run.status)}</td>
             <td className="col-title">

--- a/src/components/automation/RunList.tsx
+++ b/src/components/automation/RunList.tsx
@@ -11,6 +11,7 @@ import { useViewMode } from '../../hooks/useViewMode'
 import { getStatusIcon, getStatusLabel } from '../shared/statusDisplay'
 import { getWorkerIcon } from './job-list/jobRowUtils'
 import { formatDistanceToNow, formatDuration } from '../../utils/dateUtils'
+import { onKeyboardActivate } from '../../utils/keyboard'
 import './RunList.css'
 import '../shared/ListView.css'
 
@@ -93,7 +94,12 @@ function RunListTable({
       </thead>
       <tbody>
         {filteredRuns.map(run => (
-          <tr key={run._id} onClick={() => onToggle(run._id)}>
+          <tr
+            key={run._id}
+            onClick={() => onToggle(run._id)}
+            tabIndex={0}
+            onKeyDown={onKeyboardActivate(() => onToggle(run._id))}
+          >
             <td className="col-status">{getStatusIcon(run.status)}</td>
             <td className="col-title">
               <RunListRowTitle run={run} />

--- a/src/components/automation/RunList.tsx
+++ b/src/components/automation/RunList.tsx
@@ -1,17 +1,16 @@
-import { useState, useMemo } from 'react'
+import { Fragment, useState, useMemo } from 'react'
 import { History, Trash2 } from 'lucide-react'
 import { useRecentRuns, useRunMutations } from '../../hooks/useConvex'
 import { useConfirm } from '../../hooks/useConfirm'
 import { ConfirmDialog } from '../ConfirmDialog'
 import type { Id } from '../../../convex/_generated/dataModel'
-import { RunCard, type RunWithJob } from './run-list/RunCard'
+import { RunCard, RunCardDetails, type RunWithJob } from './run-list/RunCard'
 import { RunFilterBar, type StatusFilter } from './run-list/RunFilterBar'
 import { ViewModeToggle } from '../shared/ViewModeToggle'
 import { useViewMode } from '../../hooks/useViewMode'
 import { getStatusIcon, getStatusLabel } from '../shared/statusDisplay'
 import { getWorkerIcon } from './job-list/jobRowUtils'
 import { formatDistanceToNow, formatDuration } from '../../utils/dateUtils'
-import { onKeyboardActivate } from '../../utils/keyboard'
 import './RunList.css'
 import '../shared/ListView.css'
 
@@ -74,11 +73,52 @@ function RunListRowTitle({ run }: { run: RunWithJob }) {
   )
 }
 
+function getRunTitleText(run: RunWithJob): string {
+  return run.job?.name ?? 'Deleted Job'
+}
+
+function hasRunDetails(run: RunWithJob): boolean {
+  return run.output !== undefined || run.error !== undefined || run.input !== undefined
+}
+
+function RunListRowToggle({
+  run,
+  isExpanded,
+  onToggle,
+}: {
+  run: RunWithJob
+  isExpanded: boolean
+  onToggle: (runId: string) => void
+}) {
+  if (!hasRunDetails(run)) {
+    return <RunListRowTitle run={run} />
+  }
+
+  const detailsId = `run-list-details-${run._id}`
+
+  return (
+    <button
+      type="button"
+      className="run-row-toggle"
+      aria-expanded={isExpanded}
+      aria-controls={detailsId}
+      aria-label={`${isExpanded ? 'Collapse' : 'Expand'} details for ${getRunTitleText(run)}`}
+      onClick={() => {
+        onToggle(run._id)
+      }}
+    >
+      <RunListRowTitle run={run} />
+    </button>
+  )
+}
+
 function RunListTable({
   filteredRuns,
+  expandedRows,
   onToggle,
 }: {
   filteredRuns: RunWithJob[]
+  expandedRows: Set<string>
   onToggle: (runId: string) => void
 }) {
   return (
@@ -93,30 +133,35 @@ function RunListTable({
         </tr>
       </thead>
       <tbody>
-        {filteredRuns.map(run => (
-          <tr
-            key={run._id}
-            onClick={() => onToggle(run._id)}
-            tabIndex={0}
-            onKeyDown={onKeyboardActivate(() => {
-              onToggle(run._id)
-            })}
-          >
-            <td className="col-status">{getStatusIcon(run.status)}</td>
-            <td className="col-title">
-              <RunListRowTitle run={run} />
-            </td>
-            <td>
-              <span className={`run-status-badge status-${run.status}`}>
-                {getStatusLabel(run.status)}
-              </span>
-            </td>
-            <td className="col-date">
-              {run.duration !== undefined ? formatDuration(run.duration) : '—'}
-            </td>
-            <td className="col-date">{formatDistanceToNow(run.startedAt)}</td>
-          </tr>
-        ))}
+        {filteredRuns.map(run => {
+          const isExpanded = expandedRows.has(run._id)
+          return (
+            <Fragment key={run._id}>
+              <tr>
+                <td className="col-status">{getStatusIcon(run.status)}</td>
+                <td className="col-title">
+                  <RunListRowToggle run={run} isExpanded={isExpanded} onToggle={onToggle} />
+                </td>
+                <td>
+                  <span className={`run-status-badge status-${run.status}`}>
+                    {getStatusLabel(run.status)}
+                  </span>
+                </td>
+                <td className="col-date">
+                  {run.duration !== undefined ? formatDuration(run.duration) : '—'}
+                </td>
+                <td className="col-date">{formatDistanceToNow(run.startedAt)}</td>
+              </tr>
+              {isExpanded && hasRunDetails(run) && (
+                <tr className="run-list-details-row">
+                  <td id={`run-list-details-${run._id}`} colSpan={5}>
+                    <RunCardDetails run={run} />
+                  </td>
+                </tr>
+              )}
+            </Fragment>
+          )
+        })}
       </tbody>
     </table>
   )
@@ -176,7 +221,7 @@ function RunListContent({
     <div className="run-list-content">
       <RunListNoResults statusFilter={statusFilter} />
       {viewMode === 'list' ? (
-        <RunListTable filteredRuns={filteredRuns} onToggle={onToggle} />
+        <RunListTable filteredRuns={filteredRuns} expandedRows={expandedRows} onToggle={onToggle} />
       ) : (
         <RunCardsView
           filteredRuns={filteredRuns}

--- a/src/components/automation/run-list/RunCard.tsx
+++ b/src/components/automation/run-list/RunCard.tsx
@@ -194,7 +194,7 @@ function RunCardHeader({
   )
 }
 
-function RunCardDetails({ run }: { run: RunWithJob }) {
+export function RunCardDetails({ run }: { run: RunWithJob }) {
   return (
     <div className="run-card-details">
       {run.error && (

--- a/src/components/bookmarks/BookmarkDialog.tsx
+++ b/src/components/bookmarks/BookmarkDialog.tsx
@@ -260,6 +260,7 @@ function NewCategoryRow({
   return (
     <div className="bookmark-category-row">
       <select
+        aria-label="Parent category"
         className="bookmark-dialog-select"
         style={{ flex: '0 0 auto', minWidth: 120 }}
         value=""

--- a/src/components/crew/CrewProjectView.tsx
+++ b/src/components/crew/CrewProjectView.tsx
@@ -257,6 +257,7 @@ function MessageComposer({
         onClick={onSendMessage}
         disabled={sendDisabled}
         className="crew-chat-send-btn"
+        aria-label="Send message"
       >
         <Send size={16} />
       </button>

--- a/src/components/ralph-loops/RalphLaunchForm.tsx
+++ b/src/components/ralph-loops/RalphLaunchForm.tsx
@@ -896,7 +896,12 @@ export function RalphLaunchForm({
             onChange={e => setRepoPath(e.target.value)}
             placeholder="D:\github\org\repo"
           />
-          <button type="button" className="ralph-browse-btn" onClick={handleBrowse}>
+          <button
+            type="button"
+            className="ralph-browse-btn"
+            onClick={handleBrowse}
+            aria-label="Browse for folder"
+          >
             <FolderOpen size={14} />
           </button>
         </div>

--- a/src/components/settings/SettingsPullRequests.tsx
+++ b/src/components/settings/SettingsPullRequests.tsx
@@ -83,6 +83,7 @@ export function SettingsPullRequests() {
           </p>
           <div className="select-control">
             <select
+              aria-label="Refresh interval"
               value={refreshInterval}
               onChange={e => handleRefreshIntervalChange(Number(e.target.value))}
               className="settings-select"
@@ -105,6 +106,7 @@ export function SettingsPullRequests() {
           <p className="section-description">How far back to look for recently merged PRs.</p>
           <div className="select-control">
             <select
+              aria-label="Recently merged days range"
               value={recentlyMergedDays}
               onChange={e => handleMergedDaysChange(Number(e.target.value))}
               className="settings-select"

--- a/src/components/shared/AccountPicker.test.tsx
+++ b/src/components/shared/AccountPicker.test.tsx
@@ -78,6 +78,11 @@ describe('AccountPicker', () => {
     expect((screen.getByRole('combobox') as HTMLSelectElement).disabled).toBe(true)
   })
 
+  it('keeps an accessible name on the select when title is explicitly undefined', () => {
+    render(<AccountPicker value="" onChange={vi.fn()} variant="select" title={undefined} />)
+    expect(screen.getByRole('combobox', { name: 'GitHub account' })).toBeTruthy()
+  })
+
   it('persists account selection when persist prop is true', () => {
     const onChange = vi.fn()
     render(<AccountPicker value="" onChange={onChange} variant="select" persist />)

--- a/src/components/shared/AccountPicker.tsx
+++ b/src/components/shared/AccountPicker.tsx
@@ -83,6 +83,7 @@ export function AccountPicker(props: AccountPickerProps) {
       <div className={`select-control ${className}`}>
         <select
           id={id}
+          aria-label={title}
           value={value}
           onChange={e => handleChange(e.target.value)}
           className="settings-select"

--- a/src/components/shared/AccountPicker.tsx
+++ b/src/components/shared/AccountPicker.tsx
@@ -41,10 +41,14 @@ const ACCOUNT_PICKER_DEFAULTS = {
 }
 
 export function AccountPicker(props: AccountPickerProps) {
-  const { value, onChange, persist, disabled, title, className, variant, align, id } = {
+  const { value, onChange, persist, disabled, className, variant, align, id } = {
     ...ACCOUNT_PICKER_DEFAULTS,
     ...props,
   }
+  // Explicitly fall back on `??` (not just the spread above) so an explicit
+  // `title={undefined}` from a caller can't strip the accessible name off the
+  // select variant's <select aria-label>.
+  const title = props.title ?? ACCOUNT_PICKER_DEFAULTS.title
   const { setGhAccount } = useCopilotSettings()
   const { uniqueUsernames: uniqueAccounts } = useGitHubAccounts()
   const [activeCliAccount, setActiveCliAccount] = useState<string | null>(null)

--- a/src/components/shared/ModelPicker.test.tsx
+++ b/src/components/shared/ModelPicker.test.tsx
@@ -85,6 +85,16 @@ describe('ModelPicker', () => {
     expect(screen.getByRole('option', { name: 'Gemini 2.5 (disabled)' })).toBeDisabled()
   })
 
+  it('keeps an accessible name on the select when title is explicitly undefined', async () => {
+    mocks.listModels.mockResolvedValueOnce([
+      { id: 'claude-sonnet-4.5', name: 'Claude Sonnet', isDisabled: false, billingMultiplier: 1 },
+    ])
+
+    render(<ModelPicker value="" onChange={vi.fn()} variant="select" title={undefined} />)
+
+    expect(await screen.findByRole('combobox', { name: 'Copilot model' })).toBeInTheDocument()
+  })
+
   it('persists a changed model selection in select mode', async () => {
     const onChange = vi.fn()
     mocks.listModels.mockResolvedValueOnce([

--- a/src/components/shared/ModelPicker.tsx
+++ b/src/components/shared/ModelPicker.tsx
@@ -470,7 +470,6 @@ export function ModelPicker(props: ModelPickerProps) {
     ghAccount,
     persist,
     disabled,
-    title,
     className,
     variant,
     align,
@@ -480,6 +479,10 @@ export function ModelPicker(props: ModelPickerProps) {
     ...MODEL_PICKER_DEFAULTS,
     ...props,
   }
+  // Explicitly fall back on `??` (not just the spread above) so an explicit
+  // `title={undefined}` from a caller can't strip the accessible name off the
+  // select variant's <select aria-label>.
+  const title = props.title ?? MODEL_PICKER_DEFAULTS.title
   const { modelsLoading, modelsError, fetchModels, handleChange, enabledModels, disabledModels } =
     useModelPickerSetup(ghAccount, value, onChange, persist)
 

--- a/src/components/shared/ModelPicker.tsx
+++ b/src/components/shared/ModelPicker.tsx
@@ -300,6 +300,7 @@ function ModelPickerSelectVariant({
   handleChange,
   className,
   id,
+  title,
 }: {
   value: string
   enabledModels: SdkModel[]
@@ -313,6 +314,7 @@ function ModelPickerSelectVariant({
   handleChange: (v: string) => void
   className: string
   id?: string
+  title?: string
 }) {
   const statusContent = renderSelectVariantState({
     modelsLoading,
@@ -335,6 +337,7 @@ function ModelPickerSelectVariant({
         <div className="select-control" style={{ flex: 1 }}>
           <select
             id={id}
+            aria-label={title}
             value={value}
             onChange={e => handleChange(e.target.value)}
             className="settings-select"
@@ -512,6 +515,7 @@ export function ModelPicker(props: ModelPickerProps) {
         handleChange={handleChange}
         className={className}
         id={id}
+        title={title}
       />
     )
   }

--- a/src/components/shared/RepoPicker.test.tsx
+++ b/src/components/shared/RepoPicker.test.tsx
@@ -71,6 +71,14 @@ describe('RepoPicker', () => {
     expect(onChange).toHaveBeenCalledWith('relias-engineering/hs-buddy')
   })
 
+  it('keeps an accessible name on the select when title is explicitly undefined', () => {
+    mocks.useRepoBookmarks.mockReturnValue([])
+
+    render(<RepoPicker value="" onChange={vi.fn()} variant="select" title={undefined} />)
+
+    expect(screen.getByRole('combobox', { name: 'Target repository' })).toBeInTheDocument()
+  })
+
   it('shows the empty state hint when no bookmarks exist', () => {
     mocks.useRepoBookmarks.mockReturnValue([])
 

--- a/src/components/shared/RepoPicker.tsx
+++ b/src/components/shared/RepoPicker.tsx
@@ -171,18 +171,14 @@ const REPO_PICKER_DEFAULTS = {
 }
 
 export function RepoPicker(rawProps: RepoPickerProps) {
-  const {
-    value,
-    onChange,
-    disabled,
-    title,
-    className,
-    variant,
-    align,
-    placeholder,
-    allowNone,
-    id,
-  } = { ...REPO_PICKER_DEFAULTS, ...rawProps }
+  const { value, onChange, disabled, className, variant, align, placeholder, allowNone, id } = {
+    ...REPO_PICKER_DEFAULTS,
+    ...rawProps,
+  }
+  // Explicitly fall back on `??` (not just the spread above) so an explicit
+  // `title={undefined}` from a caller can't strip the accessible name off the
+  // select variant's <select aria-label>.
+  const title = rawProps.title ?? REPO_PICKER_DEFAULTS.title
   const bookmarks = useRepoBookmarks()
 
   const { options, selectGroups } = useMemo(

--- a/src/components/shared/RepoPicker.tsx
+++ b/src/components/shared/RepoPicker.tsx
@@ -120,6 +120,7 @@ function SelectVariant({
   selectGroups,
   bookmarks,
   className,
+  title,
 }: {
   id?: string
   value: string
@@ -131,6 +132,7 @@ function SelectVariant({
   selectGroups: { folder: string; repos: RepoBookmarkList }[]
   bookmarks: ReturnType<typeof useRepoBookmarks>
   className: string
+  title?: string
 }) {
   const showHint = shouldShowRepoPickerHint(bookmarks, loading)
 
@@ -138,6 +140,7 @@ function SelectVariant({
     <div className={`select-control ${className}`}>
       <select
         id={id}
+        aria-label={title}
         value={value}
         onChange={e => onChange(e.target.value)}
         className="settings-select"
@@ -202,6 +205,7 @@ export function RepoPicker(rawProps: RepoPickerProps) {
         selectGroups={selectGroups}
         bookmarks={bookmarks}
         className={className}
+        title={title}
       />
     )
   }

--- a/src/components/sidebar/BookmarksSidebar.test.tsx
+++ b/src/components/sidebar/BookmarksSidebar.test.tsx
@@ -173,6 +173,21 @@ describe('BookmarksSidebar', () => {
     expect(screen.getByText('Example')).toBeInTheDocument()
   })
 
+  it('reflects expanded state via aria-expanded on the category chevron', () => {
+    render(<BookmarksSidebar onItemSelect={vi.fn()} selectedItem={null} />)
+
+    const chevron = screen
+      .getByText('Dev Tools')
+      .closest('.sidebar-item')!
+      .querySelector('button.sidebar-item-chevron') as HTMLElement
+
+    expect(chevron.getAttribute('aria-expanded')).toBe('false')
+    fireEvent.click(chevron)
+    expect(chevron.getAttribute('aria-expanded')).toBe('true')
+    fireEvent.click(chevron)
+    expect(chevron.getAttribute('aria-expanded')).toBe('false')
+  })
+
   it('applies selected class to a selected bookmark', () => {
     const selectedItem = `browser:${encodeURIComponent('https://example.com')}|${encodeURIComponent('Example')}`
     render(<BookmarksSidebar onItemSelect={vi.fn()} selectedItem={selectedItem} />)

--- a/src/components/sidebar/BookmarksSidebar.test.tsx
+++ b/src/components/sidebar/BookmarksSidebar.test.tsx
@@ -164,10 +164,7 @@ describe('BookmarksSidebar', () => {
   it('toggles a category via keyboard Space on chevron', () => {
     render(<BookmarksSidebar onItemSelect={vi.fn()} selectedItem={null} />)
 
-    const chevron = screen
-      .getByText('Dev Tools')
-      .closest('.sidebar-item')!
-      .querySelector('button.sidebar-item-chevron') as HTMLElement
+    const chevron = screen.getByRole('button', { name: 'Expand Dev Tools' })
 
     fireEvent.keyDown(chevron, { key: ' ' })
     expect(screen.getByText('Example')).toBeInTheDocument()

--- a/src/components/sidebar/BookmarksSidebar.tsx
+++ b/src/components/sidebar/BookmarksSidebar.tsx
@@ -260,6 +260,7 @@ function CategoryChevron({
       }}
       onKeyDown={e => handleCategoryChevronKeyDown(e, sectionId, toggleSection)}
       aria-label={buildCategoryDisclosureLabel(isExpanded, label)}
+      aria-expanded={isExpanded}
     >
       {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
     </button>

--- a/src/components/sidebar/BookmarksSidebar.tsx
+++ b/src/components/sidebar/BookmarksSidebar.tsx
@@ -69,6 +69,7 @@ interface CategoryChevronProps {
   isExpanded: boolean
   sectionId: string
   toggleSection: (sectionId: string) => void
+  label: string
 }
 
 interface BookmarksContextMenuProps {
@@ -109,6 +110,10 @@ function categoryHasContent(node: CategoryNode, directCount: number) {
 function categoryLabel(name: string) {
   if (!name) return 'Uncategorized'
   return name
+}
+
+function buildCategoryDisclosureLabel(isExpanded: boolean, label: string): string {
+  return isExpanded ? `Collapse ${label}` : `Expand ${label}`
 }
 
 function getBookmarkCount(bookmarks: readonly unknown[] | undefined): number {
@@ -239,6 +244,7 @@ function CategoryChevron({
   isExpanded,
   sectionId,
   toggleSection,
+  label,
 }: CategoryChevronProps) {
   if (!hasChildren) {
     return <span className="sidebar-item-chevron" style={{ width: 12 }} />
@@ -253,6 +259,7 @@ function CategoryChevron({
         toggleSection(sectionId)
       }}
       onKeyDown={e => handleCategoryChevronKeyDown(e, sectionId, toggleSection)}
+      aria-label={buildCategoryDisclosureLabel(isExpanded, label)}
     >
       {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
     </button>
@@ -415,6 +422,7 @@ function CategoryTreeNodeItem({
           isExpanded={isExpanded}
           sectionId={sectionId}
           toggleSection={toggleSection}
+          label={categoryLabel(node.name)}
         />
         <button
           type="button"

--- a/src/components/tempo/TempoDashboard.css
+++ b/src/components/tempo/TempoDashboard.css
@@ -442,6 +442,28 @@
     inset -2px 0 0 #4fc3f7;
 }
 
+/* Native button filling the actionable day cell, reset to look like the
+   plain cell content it replaces (see finding #3: labelled native control
+   instead of a focusable <td>). */
+.tempo-grid-cell-btn {
+  display: block;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 5px 4px;
+  margin: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: center;
+  cursor: pointer;
+}
+
+.tempo-grid-row td.tempo-grid-cell {
+  padding: 0;
+}
+
 /* Totals row */
 .tempo-grid-totals td {
   padding: 6px 4px;
@@ -498,6 +520,28 @@
   box-shadow:
     inset 2px 0 0 #4fc3f7,
     inset -2px 0 0 #4fc3f7;
+}
+
+/* Native button filling a copyable footer total cell, reset to look like
+   the plain cell content it replaces. */
+.tempo-grid-total-btn {
+  display: block;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  padding: 6px 4px;
+  margin: 0;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: inherit;
+  text-align: center;
+  cursor: copy;
+}
+
+.tempo-grid-totals td.tempo-grid-total-cell.actionable {
+  padding: 0;
 }
 
 /* --- Issue pill and account badge --- */

--- a/src/components/tempo/TempoTimesheetGrid.test.tsx
+++ b/src/components/tempo/TempoTimesheetGrid.test.tsx
@@ -127,6 +127,63 @@ describe('TempoTimesheetGrid', () => {
     expect(screen.getByTitle('Team Holiday')).toBeInTheDocument()
   })
 
+  it('is keyboard-focusable and triggers the same click handler on Enter/Space', () => {
+    const onCellClick = vi.fn()
+    const onWorklogEdit = vi.fn()
+
+    render(
+      <TempoTimesheetGrid
+        issueSummaries={issueSummaries}
+        worklogs={[worklog]}
+        totalHours={2}
+        monthDate={new Date(2026, 2, 1)}
+        holidays={{}}
+        loading={false}
+        capexMap={{}}
+        onCellClick={onCellClick}
+        onWorklogEdit={onWorklogEdit}
+        onWorklogDelete={vi.fn()}
+        onCopyToToday={vi.fn()}
+      />
+    )
+
+    const emptyCell = screen.getByTitle('Click to log time on 2026-03-06')
+    expect(emptyCell).toHaveAttribute('tabindex', '0')
+
+    fireEvent.keyDown(emptyCell, { key: 'Enter' })
+    expect(onCellClick).toHaveBeenCalledWith('2026-03-06', 'PE-101')
+
+    const filledCell = screen.getByTitle(
+      title => title.includes('PE-101') && title.includes('2026-03-05')
+    )
+    fireEvent.keyDown(filledCell, { key: ' ' })
+    expect(onWorklogEdit).toHaveBeenCalledWith(worklog)
+  })
+
+  it('does not trigger the cell click handler for other keys', () => {
+    const onCellClick = vi.fn()
+
+    render(
+      <TempoTimesheetGrid
+        issueSummaries={issueSummaries}
+        worklogs={[worklog]}
+        totalHours={2}
+        monthDate={new Date(2026, 2, 1)}
+        holidays={{}}
+        loading={false}
+        capexMap={{}}
+        onCellClick={onCellClick}
+        onWorklogEdit={vi.fn()}
+        onWorklogDelete={vi.fn()}
+        onCopyToToday={vi.fn()}
+      />
+    )
+
+    const emptyCell = screen.getByTitle('Click to log time on 2026-03-06')
+    fireEvent.keyDown(emptyCell, { key: 'ArrowRight' })
+    expect(onCellClick).not.toHaveBeenCalled()
+  })
+
   it('renders footer totals with full-day check, partial total, and zero', () => {
     const fullDayWorklog: TempoWorklog = {
       ...worklog,
@@ -529,6 +586,64 @@ describe('TempoTimesheetGrid', () => {
 
     expect(emptyFooterCell).toBeDefined()
     fireEvent.click(emptyFooterCell, { ctrlKey: true })
+    expect(onCopyToToday).not.toHaveBeenCalled()
+  })
+
+  it('is keyboard-focusable and fires onCopyToToday on Enter for a filled footer cell', () => {
+    const onCopyToToday = vi.fn()
+
+    const { container } = render(
+      <TempoTimesheetGrid
+        issueSummaries={issueSummaries}
+        worklogs={[worklog]}
+        totalHours={2}
+        monthDate={new Date(2026, 2, 1)}
+        holidays={{}}
+        loading={false}
+        capexMap={{}}
+        onCellClick={vi.fn()}
+        onWorklogEdit={vi.fn()}
+        onWorklogDelete={vi.fn()}
+        onCopyToToday={onCopyToToday}
+      />
+    )
+
+    const footerCells = container.querySelectorAll('.tempo-grid-total-cell')
+    const filledFooterCell = Array.from(footerCells).find(
+      cell => (cell as HTMLElement).style.cursor === 'copy'
+    ) as HTMLElement
+
+    expect(filledFooterCell).toHaveAttribute('tabindex', '0')
+    fireEvent.keyDown(filledFooterCell, { key: 'Enter' })
+    expect(onCopyToToday).toHaveBeenCalledWith([worklog])
+  })
+
+  it('does not fire onCopyToToday on Enter for an empty footer cell', () => {
+    const onCopyToToday = vi.fn()
+
+    const { container } = render(
+      <TempoTimesheetGrid
+        issueSummaries={issueSummaries}
+        worklogs={[worklog]}
+        totalHours={2}
+        monthDate={new Date(2026, 2, 1)}
+        holidays={{}}
+        loading={false}
+        capexMap={{}}
+        onCellClick={vi.fn()}
+        onWorklogEdit={vi.fn()}
+        onWorklogDelete={vi.fn()}
+        onCopyToToday={onCopyToToday}
+      />
+    )
+
+    const footerCells = container.querySelectorAll('.tempo-grid-total-cell')
+    const emptyFooterCell = Array.from(footerCells).find(
+      cell => !(cell as HTMLElement).style.cursor
+    ) as HTMLElement
+
+    expect(emptyFooterCell).not.toHaveAttribute('tabindex')
+    fireEvent.keyDown(emptyFooterCell, { key: 'Enter' })
     expect(onCopyToToday).not.toHaveBeenCalled()
   })
 

--- a/src/components/tempo/TempoTimesheetGrid.test.tsx
+++ b/src/components/tempo/TempoTimesheetGrid.test.tsx
@@ -500,7 +500,7 @@ describe('TempoTimesheetGrid', () => {
     expect(document.querySelector('.tempo-cell-tooltip')).not.toBeInTheDocument()
   })
 
-  it('fires onCopyToToday when ctrl+clicking footer cell with hours', () => {
+  it('fires onCopyToToday when ctrl+clicking footer total button with hours', () => {
     const onCopyToToday = vi.fn()
 
     const { container } = render(
@@ -519,18 +519,15 @@ describe('TempoTimesheetGrid', () => {
       />
     )
 
-    // Footer cell for a day with hours (cursor: copy means dayTotal > 0)
-    const footerCells = container.querySelectorAll('.tempo-grid-total-cell')
-    const filledFooterCell = Array.from(footerCells).find(
-      cell => (cell as HTMLElement).style.cursor === 'copy'
-    ) as HTMLElement
+    // Footer total button for a day with hours (only rendered when dayTotal > 0)
+    const filledFooterButton = container.querySelector('.tempo-grid-total-btn') as HTMLElement
 
-    expect(filledFooterCell).toBeDefined()
-    fireEvent.click(filledFooterCell, { ctrlKey: true })
+    expect(filledFooterButton).toBeDefined()
+    fireEvent.click(filledFooterButton, { ctrlKey: true })
     expect(onCopyToToday).toHaveBeenCalledWith([worklog])
   })
 
-  it('fires onCopyToToday when ctrl+clicking footer cell with hours', () => {
+  it('does not fire onCopyToToday when clicking footer total button without the modifier', () => {
     const onCopyToToday = vi.fn()
 
     const { container } = render(
@@ -549,14 +546,11 @@ describe('TempoTimesheetGrid', () => {
       />
     )
 
-    const footerCells = container.querySelectorAll('.tempo-grid-total-cell')
-    const filledFooterCell = Array.from(footerCells).find(
-      cell => (cell as HTMLElement).style.cursor === 'copy'
-    ) as HTMLElement
+    const filledFooterButton = container.querySelector('.tempo-grid-total-btn') as HTMLElement
 
-    expect(filledFooterCell).toBeDefined()
-    fireEvent.click(filledFooterCell, { ctrlKey: true })
-    expect(onCopyToToday).toHaveBeenCalledWith([worklog])
+    expect(filledFooterButton).toBeDefined()
+    fireEvent.click(filledFooterButton)
+    expect(onCopyToToday).not.toHaveBeenCalled()
   })
 
   it('does not fire onCopyToToday when ctrl+clicking footer cell with zero hours', () => {
@@ -589,7 +583,7 @@ describe('TempoTimesheetGrid', () => {
     expect(onCopyToToday).not.toHaveBeenCalled()
   })
 
-  it('is keyboard-focusable and fires onCopyToToday on Enter for a filled footer cell', () => {
+  it('does not fire onCopyToToday on plain Enter for a focused filled footer total button', () => {
     const onCopyToToday = vi.fn()
 
     const { container } = render(
@@ -608,13 +602,49 @@ describe('TempoTimesheetGrid', () => {
       />
     )
 
-    const footerCells = container.querySelectorAll('.tempo-grid-total-cell')
-    const filledFooterCell = Array.from(footerCells).find(
-      cell => (cell as HTMLElement).style.cursor === 'copy'
-    ) as HTMLElement
+    const filledFooterButton = container.querySelector('.tempo-grid-total-btn') as HTMLElement
 
-    expect(filledFooterCell).toHaveAttribute('tabindex', '0')
-    fireEvent.keyDown(filledFooterCell, { key: 'Enter' })
+    expect(filledFooterButton).toHaveAttribute('tabindex', '0')
+    filledFooterButton.focus()
+    expect(filledFooterButton).toHaveFocus()
+
+    fireEvent.keyDown(filledFooterButton, { key: 'Enter' })
+    expect(onCopyToToday).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(filledFooterButton, { key: ' ' })
+    expect(onCopyToToday).not.toHaveBeenCalled()
+  })
+
+  it('fires onCopyToToday when the modifier is held with Enter or Space on a focused filled footer total button', () => {
+    const onCopyToToday = vi.fn()
+
+    const { container } = render(
+      <TempoTimesheetGrid
+        issueSummaries={issueSummaries}
+        worklogs={[worklog]}
+        totalHours={2}
+        monthDate={new Date(2026, 2, 1)}
+        holidays={{}}
+        loading={false}
+        capexMap={{}}
+        onCellClick={vi.fn()}
+        onWorklogEdit={vi.fn()}
+        onWorklogDelete={vi.fn()}
+        onCopyToToday={onCopyToToday}
+      />
+    )
+
+    const filledFooterButton = container.querySelector('.tempo-grid-total-btn') as HTMLElement
+    filledFooterButton.focus()
+    expect(filledFooterButton).toHaveFocus()
+
+    fireEvent.keyDown(filledFooterButton, { key: 'Enter', ctrlKey: true })
+    expect(onCopyToToday).toHaveBeenCalledTimes(1)
+    expect(onCopyToToday).toHaveBeenCalledWith([worklog])
+
+    onCopyToToday.mockClear()
+    fireEvent.keyDown(filledFooterButton, { key: ' ', ctrlKey: true })
+    expect(onCopyToToday).toHaveBeenCalledTimes(1)
     expect(onCopyToToday).toHaveBeenCalledWith([worklog])
   })
 

--- a/src/components/tempo/TempoTimesheetGrid.tsx
+++ b/src/components/tempo/TempoTimesheetGrid.tsx
@@ -376,7 +376,9 @@ function TimesheetFooterRow({
             className={buildTotalCellClass(col, isDayComplete, dayTotal)}
             tabIndex={dayTotal > 0 ? 0 : undefined}
             onClick={e => handleTotalClick(e, col, dayTotal)}
-            onKeyDown={e => handleTotalKeyDown(e, col, dayTotal)}
+            onKeyDown={e => {
+              handleTotalKeyDown(e, col, dayTotal)
+            }}
             onMouseEnter={e => handleTotalMouseEnter(e, dayTotal)}
             onMouseLeave={hideTooltip}
             style={dayTotal > 0 ? { cursor: 'copy' } : undefined}

--- a/src/components/tempo/TempoTimesheetGrid.tsx
+++ b/src/components/tempo/TempoTimesheetGrid.tsx
@@ -4,7 +4,8 @@ import type { TempoIssueSummary, TempoWorklog } from '../../types/tempo'
 import { formatDateKey } from '../../utils/dateUtils'
 import { isModKey, modLabel } from '../../utils/platform'
 import { getHoursClasses } from '../../utils/tempoUtils'
-import { Check, Copy, Loader2 } from 'lucide-react'
+import { Copy, Loader2 } from 'lucide-react'
+import { TimesheetFooterRow } from './TimesheetFooterRow'
 
 interface TooltipState {
   text: string
@@ -57,7 +58,7 @@ interface TempoTimesheetGridProps {
   onCopyFromPreviousMonth?: () => void
 }
 
-interface DayColumn {
+export interface DayColumn {
   date: string // YYYY-MM-DD
   dayNum: number
   dayLabel: string // MON, TUE, ...
@@ -65,28 +66,6 @@ interface DayColumn {
   isToday: boolean
   isHoliday: boolean
   holidayName?: string
-}
-
-function buildTotalCellClass(col: DayColumn, isDayComplete: boolean, dayTotal: number): string {
-  return [
-    'tempo-grid-total-cell',
-    col.isWeekend ? 'weekend' : '',
-    col.isHoliday ? 'holiday' : '',
-    col.isToday ? 'today' : '',
-    totalCellCompletionClass(isDayComplete, dayTotal),
-  ]
-    .filter(Boolean)
-    .join(' ')
-}
-
-function totalCellCompletionClass(isDayComplete: boolean, dayTotal: number): string {
-  if (isDayComplete) return 'full'
-  return dayTotal > 0 ? 'partial' : ''
-}
-
-function renderTotalCellContent(isDayComplete: boolean, dayTotal: number) {
-  if (isDayComplete) return <Check size={14} className="tempo-day-check" />
-  return dayTotal > 0 ? dayTotal : 0
 }
 
 function buildDayHeaderClass(col: DayColumn): string {
@@ -282,26 +261,33 @@ function TimesheetCell({
 }) {
   const hours = issue.hoursByDate[col.date] || 0
   const cellWorklogs = hours > 0 ? findWorklogsForCell(worklogs, issue.issueKey, col.date) : []
+  const cellLabel = buildCellTitle(issue.issueKey, hours, col.date, cellWorklogs.length)
 
   return (
     <td
       className={getCellClassName(col, hours, isCapex)}
-      title={buildCellTitle(issue.issueKey, hours, col.date, cellWorklogs.length)}
-      tabIndex={0}
-      onClick={e => onClick(e, col, issue.issueKey, hours, cellWorklogs)}
-      onKeyDown={e => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault()
-          onClick(e, col, issue.issueKey, hours, cellWorklogs)
-        }
-      }}
-      onContextMenu={e => handleCellContextMenu(e, cellWorklogs, onWorklogDelete)}
       onMouseEnter={e =>
         showTooltip(e, buildCellTooltip(issue.issueKey, hours, col, cellWorklogs.length))
       }
       onMouseLeave={hideTooltip}
     >
-      {hours > 0 ? hours : ''}
+      <button
+        type="button"
+        className="tempo-grid-cell-btn"
+        title={cellLabel}
+        aria-label={cellLabel}
+        tabIndex={0}
+        onClick={e => onClick(e, col, issue.issueKey, hours, cellWorklogs)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault()
+            onClick(e, col, issue.issueKey, hours, cellWorklogs)
+          }
+        }}
+        onContextMenu={e => handleCellContextMenu(e, cellWorklogs, onWorklogDelete)}
+      >
+        {hours > 0 ? hours : ''}
+      </button>
     </td>
   )
 }
@@ -326,69 +312,6 @@ function handleCellContextMenu(
   if (cellWorklogs.length !== 1) return
   event.preventDefault()
   onWorklogDelete(cellWorklogs[0])
-}
-
-function TimesheetFooterRow({
-  columns,
-  totalHours,
-  dailyTotals,
-  worklogs,
-  showTooltip,
-  hideTooltip,
-  onCopyToToday,
-}: {
-  columns: DayColumn[]
-  totalHours: number
-  dailyTotals: Record<string, number>
-  worklogs: TempoWorklog[]
-  showTooltip: (e: React.MouseEvent, text: string) => void
-  hideTooltip: () => void
-  onCopyToToday: (worklogs: TempoWorklog[]) => void
-}) {
-  const handleTotalClick = (event: React.MouseEvent, col: DayColumn, dayTotal: number) => {
-    if (!isModKey(event) || dayTotal <= 0) return
-    onCopyToToday(worklogs.filter(w => w.date === col.date))
-  }
-
-  const handleTotalKeyDown = (event: React.KeyboardEvent, col: DayColumn, dayTotal: number) => {
-    if (dayTotal <= 0 || (event.key !== 'Enter' && event.key !== ' ')) return
-    event.preventDefault()
-    onCopyToToday(worklogs.filter(w => w.date === col.date))
-  }
-
-  const handleTotalMouseEnter = (event: React.MouseEvent, dayTotal: number) => {
-    if (dayTotal <= 0) return
-    showTooltip(event, `${dayTotal}h total\n${modLabel}+click — copy all worklogs to today`)
-  }
-
-  return (
-    <tr className="tempo-grid-totals">
-      <td className="tempo-grid-total-label">Total</td>
-      <td className="tempo-grid-total-key" aria-label="Total row"></td>
-      <td className="tempo-grid-total-logged">{totalHours}</td>
-      {columns.map(col => {
-        const dayTotal = dailyTotals[col.date] || 0
-        const isDayComplete = dayTotal >= 8
-        return (
-          <td
-            key={col.date}
-            aria-label={`${col.date} total ${dayTotal} hours`}
-            className={buildTotalCellClass(col, isDayComplete, dayTotal)}
-            tabIndex={dayTotal > 0 ? 0 : undefined}
-            onClick={e => handleTotalClick(e, col, dayTotal)}
-            onKeyDown={e => {
-              handleTotalKeyDown(e, col, dayTotal)
-            }}
-            onMouseEnter={e => handleTotalMouseEnter(e, dayTotal)}
-            onMouseLeave={hideTooltip}
-            style={dayTotal > 0 ? { cursor: 'copy' } : undefined}
-          >
-            {renderTotalCellContent(isDayComplete, dayTotal)}
-          </td>
-        )
-      })}
-    </tr>
-  )
 }
 
 export function TempoTimesheetGrid({

--- a/src/components/tempo/TempoTimesheetGrid.tsx
+++ b/src/components/tempo/TempoTimesheetGrid.tsx
@@ -212,7 +212,7 @@ function TimesheetRow({
   onCopyToToday: (worklogs: TempoWorklog[]) => void
 }) {
   const handleCellClick = (
-    event: React.MouseEvent,
+    event: React.MouseEvent | React.KeyboardEvent,
     col: DayColumn,
     issueKey: string,
     hours: number,
@@ -270,7 +270,7 @@ function TimesheetCell({
   worklogs: TempoWorklog[]
   isCapex: boolean
   onClick: (
-    event: React.MouseEvent,
+    event: React.MouseEvent | React.KeyboardEvent,
     col: DayColumn,
     issueKey: string,
     hours: number,
@@ -287,7 +287,14 @@ function TimesheetCell({
     <td
       className={getCellClassName(col, hours, isCapex)}
       title={buildCellTitle(issue.issueKey, hours, col.date, cellWorklogs.length)}
+      tabIndex={0}
       onClick={e => onClick(e, col, issue.issueKey, hours, cellWorklogs)}
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          onClick(e, col, issue.issueKey, hours, cellWorklogs)
+        }
+      }}
       onContextMenu={e => handleCellContextMenu(e, cellWorklogs, onWorklogDelete)}
       onMouseEnter={e =>
         showTooltip(e, buildCellTooltip(issue.issueKey, hours, col, cellWorklogs.length))
@@ -343,6 +350,12 @@ function TimesheetFooterRow({
     onCopyToToday(worklogs.filter(w => w.date === col.date))
   }
 
+  const handleTotalKeyDown = (event: React.KeyboardEvent, col: DayColumn, dayTotal: number) => {
+    if (dayTotal <= 0 || (event.key !== 'Enter' && event.key !== ' ')) return
+    event.preventDefault()
+    onCopyToToday(worklogs.filter(w => w.date === col.date))
+  }
+
   const handleTotalMouseEnter = (event: React.MouseEvent, dayTotal: number) => {
     if (dayTotal <= 0) return
     showTooltip(event, `${dayTotal}h total\n${modLabel}+click — copy all worklogs to today`)
@@ -361,7 +374,9 @@ function TimesheetFooterRow({
             key={col.date}
             aria-label={`${col.date} total ${dayTotal} hours`}
             className={buildTotalCellClass(col, isDayComplete, dayTotal)}
+            tabIndex={dayTotal > 0 ? 0 : undefined}
             onClick={e => handleTotalClick(e, col, dayTotal)}
+            onKeyDown={e => handleTotalKeyDown(e, col, dayTotal)}
             onMouseEnter={e => handleTotalMouseEnter(e, dayTotal)}
             onMouseLeave={hideTooltip}
             style={dayTotal > 0 ? { cursor: 'copy' } : undefined}

--- a/src/components/tempo/TimesheetFooterRow.tsx
+++ b/src/components/tempo/TimesheetFooterRow.tsx
@@ -1,0 +1,111 @@
+import { Check } from 'lucide-react'
+import type { TempoWorklog } from '../../types/tempo'
+import { isModKey, modLabel } from '../../utils/platform'
+import type { DayColumn } from './TempoTimesheetGrid'
+
+function buildTotalCellClass(col: DayColumn, isDayComplete: boolean, dayTotal: number): string {
+  return [
+    'tempo-grid-total-cell',
+    col.isWeekend ? 'weekend' : '',
+    col.isHoliday ? 'holiday' : '',
+    col.isToday ? 'today' : '',
+    totalCellCompletionClass(isDayComplete, dayTotal),
+  ]
+    .filter(Boolean)
+    .join(' ')
+}
+
+function totalCellCompletionClass(isDayComplete: boolean, dayTotal: number): string {
+  if (isDayComplete) return 'full'
+  return dayTotal > 0 ? 'partial' : ''
+}
+
+function renderTotalCellContent(isDayComplete: boolean, dayTotal: number) {
+  if (isDayComplete) return <Check size={14} className="tempo-day-check" />
+  return dayTotal > 0 ? dayTotal : 0
+}
+
+export function TimesheetFooterRow({
+  columns,
+  totalHours,
+  dailyTotals,
+  worklogs,
+  showTooltip,
+  hideTooltip,
+  onCopyToToday,
+}: {
+  columns: DayColumn[]
+  totalHours: number
+  dailyTotals: Record<string, number>
+  worklogs: TempoWorklog[]
+  showTooltip: (e: React.MouseEvent, text: string) => void
+  hideTooltip: () => void
+  onCopyToToday: (worklogs: TempoWorklog[]) => void
+}) {
+  const handleTotalClick = (event: React.MouseEvent, col: DayColumn, dayTotal: number) => {
+    if (!isModKey(event) || dayTotal <= 0) return
+    onCopyToToday(worklogs.filter(w => w.date === col.date))
+  }
+
+  const handleTotalKeyDown = (event: React.KeyboardEvent, col: DayColumn, dayTotal: number) => {
+    if (dayTotal <= 0 || (event.key !== 'Enter' && event.key !== ' ')) return
+    // Keyboard activation must require the same platform modifier as mouse click
+    // (see handleTotalClick) — otherwise Enter/Space would trigger the
+    // copy-all-worklogs-to-today action without the confirmation the tooltip
+    // and mouse handler both advertise.
+    if (!isModKey(event)) return
+    event.preventDefault()
+    onCopyToToday(worklogs.filter(w => w.date === col.date))
+  }
+
+  const handleTotalMouseEnter = (event: React.MouseEvent, dayTotal: number) => {
+    if (dayTotal <= 0) return
+    showTooltip(event, `${dayTotal}h total\n${modLabel}+click — copy all worklogs to today`)
+  }
+
+  return (
+    <tr className="tempo-grid-totals">
+      <td className="tempo-grid-total-label">Total</td>
+      <td className="tempo-grid-total-key" aria-label="Total row"></td>
+      <td className="tempo-grid-total-logged">{totalHours}</td>
+      {columns.map(col => {
+        const dayTotal = dailyTotals[col.date] || 0
+        const isDayComplete = dayTotal >= 8
+        const totalLabel = `${col.date} total ${dayTotal} hours`
+        return (
+          <td
+            key={col.date}
+            aria-label={dayTotal > 0 ? undefined : totalLabel}
+            className={`${buildTotalCellClass(col, isDayComplete, dayTotal)} ${
+              dayTotal > 0 ? 'actionable' : ''
+            }`.trim()}
+            onMouseEnter={e => {
+              handleTotalMouseEnter(e, dayTotal)
+            }}
+            onMouseLeave={hideTooltip}
+            style={dayTotal > 0 ? { cursor: 'copy' } : undefined}
+          >
+            {dayTotal > 0 ? (
+              <button
+                type="button"
+                className="tempo-grid-total-btn"
+                aria-label={`${totalLabel}. ${modLabel}+click or ${modLabel}+Enter to copy all worklogs to today.`}
+                tabIndex={0}
+                onClick={e => {
+                  handleTotalClick(e, col, dayTotal)
+                }}
+                onKeyDown={e => {
+                  handleTotalKeyDown(e, col, dayTotal)
+                }}
+              >
+                {renderTotalCellContent(isDayComplete, dayTotal)}
+              </button>
+            ) : (
+              renderTotalCellContent(isDayComplete, dayTotal)
+            )}
+          </td>
+        )
+      })}
+    </tr>
+  )
+}


### PR DESCRIPTION
Closes #283

## Summary
- Add accessible names to all 15 controls reported by React Doctor.
- Add keyboard activation to six clickable rows/cells while preserving mouse and modifier-key behavior.
- Restructure TabBar into independent tab and close-button focus targets under an accessible tablist.
- Add focused interaction, focus, and ARIA hierarchy coverage.

## Verification
- `npx --yes react-doctor@0.9.0 . --category Accessibility --no-score` - 0 findings
- `bun run test:coverage` - 291 files, 6,519 tests passed
- `bun run lint`
- `bun run typecheck`
- `bun run knip`
- `bun run format:check`
- `bunx vite build`

## Risk
Medium: DOM and keyboard behavior changed across several controls. Focus order, Enter/Space activation, modifier-key behavior, and independent TabBar focus targets are covered by tests.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix accessibility issues in React components for keyboard navigation and ARIA attributes
> - Adds `tabIndex=0` and `onKeyDown` handlers (Enter/Space) to table rows in PR, issue, and repo list views so they are keyboard-navigable
> - Reworks `TabBar` to use roving tabindex, arrow key (Left/Right/Home/End) focus navigation, and `role="tablist"` with an accessible name
> - Wraps Tempo timesheet day cells in focusable `<button>` elements; footer total cells with hours become buttons activated by modifier+Enter/Space or modifier+click
> - Adds `aria-label` to unlabelled `<select>` elements across `CronBuilder`, `PRReviewPanel`, `SettingsPullRequests`, `BookmarkDialog`, and picker components
> - Adds `aria-expanded` and `aria-label` to the `BookmarksSidebar` category chevron; replaces row-click expansion in `RunList` with a dedicated accessible toggle button
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #290 opened
>
> - Replaced DOM traversal and `querySelector`-based element lookup with accessible query method in test [32397e8]
> - Adjusted `.tab`, `.tab-select`, and `.tab-close` CSS styling to modify tab layout, cursor behavior, padding, and clickable target areas [c29a298]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7d927c9.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->