### PR TITLE
Batch GitHub account PR requests safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.892] - 2026-07-23
+
+### Changed
+
+- Batch GitHub account PR requests
+
 ## [0.1.891] - 2026-07-23
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.893] - 2026-07-23
+
+### Changed
+
+- Satisfy GitHub quality lint gate
+
 ## [0.1.892] - 2026-07-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.891",
+  "version": "0.1.892",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.892",
+  "version": "0.1.893",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/api/github.test.ts
+++ b/src/api/github.test.ts
@@ -113,6 +113,78 @@ const TEST_CONFIG = {
   ],
 }
 
+function makeSearchPRItem(org: string, number: number) {
+  return {
+    number,
+    title: `PR ${number}`,
+    html_url: `https://github.com/${org}/repo/pull/${number}`,
+    user: { login: `author${number}`, avatar_url: '' },
+    state: 'open',
+    assignees: [],
+    created_at: `2026-01-0${number}T00:00:00Z`,
+    updated_at: `2026-01-0${number}T00:00:00Z`,
+    closed_at: null,
+  }
+}
+
+function makeViewerPRNode(org: string, number: number) {
+  return {
+    number,
+    title: `PR ${number}`,
+    url: `https://github.com/${org}/repo/pull/${number}`,
+    state: 'OPEN',
+    createdAt: `2026-01-0${number}T00:00:00Z`,
+    updatedAt: `2026-01-0${number}T00:00:00Z`,
+    closedAt: null,
+    mergedAt: null,
+    author: { login: `author${number}`, avatarUrl: '' },
+    assignees: { totalCount: 0 },
+    repository: { nameWithOwner: `${org}/repo`, owner: { login: org } },
+    headRefName: `feature-${number}`,
+    baseRefName: 'main',
+  }
+}
+
+function handleConcurrentFallbackGraphql(
+  query: string,
+  variables: { after?: string | null; headers?: { authorization?: string } }
+) {
+  const reviewThreads = {
+    totalCount: 0,
+    pageInfo: { hasNextPage: false, endCursor: null },
+    nodes: [],
+  }
+  if (!query.includes('query ViewerPRs')) {
+    return Promise.resolve({
+      pr0: { pullRequest: { reviewThreads } },
+      pr1: { pullRequest: { reviewThreads } },
+    })
+  }
+  if (variables.headers?.authorization === 'token token-user2') {
+    return Promise.reject(new Error('429 secondary rate limit'))
+  }
+  if (variables.after === 'org1-page-2') {
+    return Promise.resolve({
+      viewer: {
+        pullRequests: {
+          totalCount: 2,
+          pageInfo: { hasNextPage: false, endCursor: null },
+          nodes: [makeViewerPRNode('org1', 2)],
+        },
+      },
+    })
+  }
+  return Promise.resolve({
+    viewer: {
+      pullRequests: {
+        totalCount: 2,
+        pageInfo: { hasNextPage: true, endCursor: 'org1-page-2' },
+        nodes: [makeViewerPRNode('org1', 1)],
+      },
+    },
+  })
+}
+
 describe('GitHubClient', () => {
   let client: GitHubClient
 
@@ -2577,23 +2649,7 @@ describe('GitHubClient', () => {
       mockOctokit.search.issuesAndPullRequests.mockImplementation(({ q }: { q: string }) => {
         const org = /org:([^\s]+)/.exec(q)?.[1] ?? 'unknown'
         const number = Number(org.replace('org', ''))
-        return Promise.resolve({
-          data: {
-            items: [
-              {
-                number,
-                title: `PR for ${org}`,
-                html_url: `https://github.com/${org}/repo/pull/${number}`,
-                user: { login: `author${number}`, avatar_url: '' },
-                state: 'open',
-                assignees: [],
-                created_at: `2026-01-0${number}T00:00:00Z`,
-                updated_at: `2026-01-0${number}T00:00:00Z`,
-                closed_at: null,
-              },
-            ],
-          },
-        })
+        return Promise.resolve({ data: { items: [makeSearchPRItem(org, number)] } })
       })
       mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] })
       mockOctokit.pulls.get.mockResolvedValue({
@@ -2640,93 +2696,17 @@ describe('GitHubClient', () => {
           ],
         }
         const concurrentClient = new GitHubClient(config)
-        const viewerNode = (org: string, number: number) => ({
-          number,
-          title: `PR ${number}`,
-          url: `https://github.com/${org}/repo/pull/${number}`,
-          state: 'OPEN',
-          createdAt: `2026-01-0${number}T00:00:00Z`,
-          updatedAt: `2026-01-0${number}T00:00:00Z`,
-          closedAt: null,
-          mergedAt: null,
-          author: { login: `author${number}`, avatarUrl: '' },
-          assignees: { totalCount: 0 },
-          repository: { nameWithOwner: `${org}/repo`, owner: { login: org } },
-          headRefName: `feature-${number}`,
-          baseRefName: 'main',
-        })
 
         mockOctokit.orgs.get.mockResolvedValue({ data: { avatar_url: null } })
         mockOctokit.search.issuesAndPullRequests.mockImplementation(({ q }: { q: string }) => {
           if (!q.includes('org:org3')) return Promise.resolve({ data: { items: [] } })
-          return Promise.resolve({
-            data: {
-              items: [
-                {
-                  number: 3,
-                  title: 'PR 3',
-                  html_url: 'https://github.com/org3/repo/pull/3',
-                  user: { login: 'author3', avatar_url: '' },
-                  state: 'open',
-                  assignees: [],
-                  created_at: '2026-01-03T00:00:00Z',
-                  updated_at: '2026-01-03T00:00:00Z',
-                  closed_at: null,
-                },
-              ],
-            },
-          })
+          return Promise.resolve({ data: { items: [makeSearchPRItem('org3', 3)] } })
         })
         mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] })
         mockOctokit.pulls.get.mockResolvedValue({
           data: { head: { ref: 'feature' }, base: { ref: 'main' } },
         })
-        mockGraphql.mockImplementation(
-          (
-            query: string,
-            variables: {
-              after?: string | null
-              headers?: { authorization?: string }
-            }
-          ) => {
-            if (!query.includes('query ViewerPRs')) {
-              const reviewThreads = {
-                totalCount: 0,
-                pageInfo: { hasNextPage: false, endCursor: null },
-                nodes: [],
-              }
-              return Promise.resolve({
-                pr0: { pullRequest: { reviewThreads } },
-                pr1: { pullRequest: { reviewThreads } },
-              })
-            }
-
-            const authorization = variables.headers?.authorization
-            if (authorization === 'token token-user2') {
-              return Promise.reject(new Error('429 secondary rate limit'))
-            }
-            if (variables.after === 'org1-page-2') {
-              return Promise.resolve({
-                viewer: {
-                  pullRequests: {
-                    totalCount: 2,
-                    pageInfo: { hasNextPage: false, endCursor: null },
-                    nodes: [viewerNode('org1', 2)],
-                  },
-                },
-              })
-            }
-            return Promise.resolve({
-              viewer: {
-                pullRequests: {
-                  totalCount: 2,
-                  pageInfo: { hasNextPage: true, endCursor: 'org1-page-2' },
-                  nodes: [viewerNode('org1', 1)],
-                },
-              },
-            })
-          }
-        )
+        mockGraphql.mockImplementation(handleConcurrentFallbackGraphql)
 
         const result = await concurrentClient.fetchMyPRs()
         const org1FallbackCalls = mockGraphql.mock.calls.filter(

--- a/src/api/github.test.ts
+++ b/src/api/github.test.ts
@@ -97,7 +97,12 @@ import {
   clearAllCaches,
   getOrgAvatarCacheEntry,
 } from './github'
-import { getGitHubCLIToken, fetchUserNames, resolveOrgAvatar } from './github/shared'
+import {
+  type ProgressCallback,
+  getGitHubCLIToken,
+  fetchUserNames,
+  resolveOrgAvatar,
+} from './github/shared'
 import { fetchAllOrgOrUserRepos, fetchAllOrgOrUserMembers } from './github/orgs'
 import { fetchBatchThreadStats } from './github/prs'
 
@@ -2466,7 +2471,7 @@ describe('GitHubClient', () => {
       mockOctokit.search.issuesAndPullRequests.mockResolvedValue({ data: { items: [] } })
       mockGraphql.mockResolvedValue({})
 
-      const progress = vi.fn()
+      const progress = vi.fn<ProgressCallback>()
       await client.fetchMyPRs(progress)
       // Should have been called with authenticating, fetching, done for each account
       expect(progress).toHaveBeenCalled()
@@ -2543,7 +2548,205 @@ describe('GitHubClient', () => {
       warnSpy.mockRestore()
     })
 
+    it('bounds concurrent account fetches and preserves configured account order', async () => {
+      const config = {
+        accounts: [
+          { username: 'user1', org: 'org1' },
+          { username: 'user2', org: 'org2' },
+          { username: 'user3', org: 'org3' },
+        ],
+      }
+      const concurrentClient = new GitHubClient(config)
+      const started = new Set<string>()
+      const releases = new Map<string, () => void>()
+      let inFlight = 0
+      let maxInFlight = 0
+
+      mockOctokit.orgs.get.mockImplementation(
+        ({ org }: { org: string }) =>
+          new Promise(resolve => {
+            started.add(org)
+            inFlight += 1
+            maxInFlight = Math.max(maxInFlight, inFlight)
+            releases.set(org, () => {
+              inFlight -= 1
+              resolve({ data: { avatar_url: `https://avatars/${org}` } })
+            })
+          })
+      )
+      mockOctokit.search.issuesAndPullRequests.mockImplementation(({ q }: { q: string }) => {
+        const org = /org:([^\s]+)/.exec(q)?.[1] ?? 'unknown'
+        const number = Number(org.replace('org', ''))
+        return Promise.resolve({
+          data: {
+            items: [
+              {
+                number,
+                title: `PR for ${org}`,
+                html_url: `https://github.com/${org}/repo/pull/${number}`,
+                user: { login: `author${number}`, avatar_url: '' },
+                state: 'open',
+                assignees: [],
+                created_at: `2026-01-0${number}T00:00:00Z`,
+                updated_at: `2026-01-0${number}T00:00:00Z`,
+                closed_at: null,
+              },
+            ],
+          },
+        })
+      })
+      mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] })
+      mockOctokit.pulls.get.mockResolvedValue({
+        data: { head: { ref: 'feature' }, base: { ref: 'main' } },
+      })
+      mockGraphql.mockResolvedValue({
+        pr0: {
+          pullRequest: {
+            reviewThreads: {
+              totalCount: 0,
+              pageInfo: { hasNextPage: false, endCursor: null },
+              nodes: [],
+            },
+          },
+        },
+      })
+
+      const progress = vi.fn()
+      const resultPromise = concurrentClient.fetchMyPRs(progress)
+
+      await vi.waitFor(() => expect(Array.from(started)).toEqual(['org1', 'org2']))
+      expect(started.has('org3')).toBe(false)
+      releases.get('org2')?.()
+      await vi.waitFor(() => expect(inFlight).toBe(1))
+      expect(started.has('org3')).toBe(false)
+      releases.get('org1')?.()
+      await vi.waitFor(() => expect(started.has('org3')).toBe(true))
+      releases.get('org3')?.()
+
+      const result = await resultPromise
+      expect(maxInFlight).toBe(2)
+      expect(result.map(pr => pr.org)).toEqual(['org1', 'org2', 'org3'])
+      const reportedAccounts = progress.mock.calls.map(([update]) => update.currentAccount)
+      expect(reportedAccounts).toEqual([...reportedAccounts].sort((a, b) => a - b))
+    })
+
     describe('GraphQL fallback (search API degraded)', () => {
+      it('keeps pagination ordered and continues after an account is rate limited', async () => {
+        const config = {
+          accounts: [
+            { username: 'user1', org: 'org1' },
+            { username: 'user2', org: 'org2' },
+            { username: 'user3', org: 'org3' },
+          ],
+        }
+        const concurrentClient = new GitHubClient(config)
+        const viewerNode = (org: string, number: number) => ({
+          number,
+          title: `PR ${number}`,
+          url: `https://github.com/${org}/repo/pull/${number}`,
+          state: 'OPEN',
+          createdAt: `2026-01-0${number}T00:00:00Z`,
+          updatedAt: `2026-01-0${number}T00:00:00Z`,
+          closedAt: null,
+          mergedAt: null,
+          author: { login: `author${number}`, avatarUrl: '' },
+          assignees: { totalCount: 0 },
+          repository: { nameWithOwner: `${org}/repo`, owner: { login: org } },
+          headRefName: `feature-${number}`,
+          baseRefName: 'main',
+        })
+
+        mockOctokit.orgs.get.mockResolvedValue({ data: { avatar_url: null } })
+        mockOctokit.search.issuesAndPullRequests.mockImplementation(({ q }: { q: string }) => {
+          if (!q.includes('org:org3')) return Promise.resolve({ data: { items: [] } })
+          return Promise.resolve({
+            data: {
+              items: [
+                {
+                  number: 3,
+                  title: 'PR 3',
+                  html_url: 'https://github.com/org3/repo/pull/3',
+                  user: { login: 'author3', avatar_url: '' },
+                  state: 'open',
+                  assignees: [],
+                  created_at: '2026-01-03T00:00:00Z',
+                  updated_at: '2026-01-03T00:00:00Z',
+                  closed_at: null,
+                },
+              ],
+            },
+          })
+        })
+        mockOctokit.pulls.listReviews.mockResolvedValue({ data: [] })
+        mockOctokit.pulls.get.mockResolvedValue({
+          data: { head: { ref: 'feature' }, base: { ref: 'main' } },
+        })
+        mockGraphql.mockImplementation(
+          (
+            query: string,
+            variables: {
+              after?: string | null
+              headers?: { authorization?: string }
+            }
+          ) => {
+            if (!query.includes('query ViewerPRs')) {
+              const reviewThreads = {
+                totalCount: 0,
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [],
+              }
+              return Promise.resolve({
+                pr0: { pullRequest: { reviewThreads } },
+                pr1: { pullRequest: { reviewThreads } },
+              })
+            }
+
+            const authorization = variables.headers?.authorization
+            if (authorization === 'token token-user2') {
+              return Promise.reject(new Error('429 secondary rate limit'))
+            }
+            if (variables.after === 'org1-page-2') {
+              return Promise.resolve({
+                viewer: {
+                  pullRequests: {
+                    totalCount: 2,
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                    nodes: [viewerNode('org1', 2)],
+                  },
+                },
+              })
+            }
+            return Promise.resolve({
+              viewer: {
+                pullRequests: {
+                  totalCount: 2,
+                  pageInfo: { hasNextPage: true, endCursor: 'org1-page-2' },
+                  nodes: [viewerNode('org1', 1)],
+                },
+              },
+            })
+          }
+        )
+
+        const result = await concurrentClient.fetchMyPRs()
+        const org1FallbackCalls = mockGraphql.mock.calls.filter(
+          ([query, variables]) =>
+            String(query).includes('query ViewerPRs') &&
+            (variables as { headers?: { authorization?: string } }).headers?.authorization ===
+              'token token-user1'
+        )
+
+        expect(org1FallbackCalls.map(([, variables]) => variables.after)).toEqual([
+          null,
+          'org1-page-2',
+        ])
+        expect(result.map(pr => pr.url)).toEqual([
+          'https://github.com/org1/repo/pull/1',
+          'https://github.com/org1/repo/pull/2',
+          'https://github.com/org3/repo/pull/3',
+        ])
+      })
+
       it('falls back to viewer.pullRequests when search returns 0 for my-prs', async () => {
         mockOctokit.orgs.get.mockResolvedValue({ data: { avatar_url: 'https://av/myorg' } })
         mockOctokit.search.issuesAndPullRequests.mockResolvedValue({ data: { items: [] } })

--- a/src/api/github/prs.ts
+++ b/src/api/github/prs.ts
@@ -36,6 +36,8 @@ export interface PRFilesChangedSummary {
 
 export type PRSearchMode = 'my-prs' | 'needs-review' | 'recently-merged' | 'need-a-nudge'
 type PRProgressStatus = 'authenticating' | 'fetching' | 'done' | 'error'
+type PRProgress = Parameters<ProgressCallback>[0]
+const ACCOUNT_FETCH_CONCURRENCY = 2
 
 export interface PRReviewerSummary {
   login: string
@@ -763,6 +765,27 @@ function assertAnyAccountAuthenticated(authenticationErrors: number, accountCoun
   )
 }
 
+function createOrderedProgressReporter(
+  report: ProgressCallback,
+  totalAccounts: number
+): ProgressCallback {
+  const pending: PRProgress[][] = Array.from({ length: totalAccounts }, () => [])
+  const completed = new Set<number>()
+  let nextAccountIndex = 0
+
+  return progress => {
+    const accountIndex = progress.currentAccount - 1
+    pending[accountIndex].push(progress)
+    if (progress.status === 'done' || progress.status === 'error') completed.add(accountIndex)
+
+    while (nextAccountIndex < totalAccounts && pending[nextAccountIndex].length > 0) {
+      for (const update of pending[nextAccountIndex].splice(0)) report(update)
+      if (!completed.has(nextAccountIndex)) break
+      nextAccountIndex += 1
+    }
+  }
+}
+
 /**
  * Core fetch method with mode support — orchestrates multi-account PR fetching.
  */
@@ -773,26 +796,31 @@ async function fetchPRs(
   mode: PRSearchMode,
   onProgress?: ProgressCallback
 ): Promise<PullRequest[]> {
-  const allPrs: PullRequest[] = []
-  let authenticationErrors = 0
   const totalAccounts = config.accounts.length
   const report: ProgressCallback = ensureCallback(onProgress)
+  const orderedReport = createOrderedProgressReporter(report, totalAccounts)
+  const accountResults: Array<{ prs: PullRequest[]; authenticationError: boolean }> = new Array(
+    totalAccounts
+  )
 
-  // Process each configured GitHub account with its own token
-  for (let i = 0; i < config.accounts.length; i++) {
-    const result = await fetchPRsForConfiguredAccount(
-      config,
-      recentlyMergedDays,
-      mode,
-      report,
-      totalAccounts,
-      i
-    )
-    authenticationErrors += result.authenticationError ? 1 : 0
-    allPrs.push(...result.prs)
-  }
+  await batchProcess(
+    config.accounts,
+    async (_account, index) => {
+      accountResults[index] = await fetchPRsForConfiguredAccount(
+        config,
+        recentlyMergedDays,
+        mode,
+        orderedReport,
+        totalAccounts,
+        index
+      )
+    },
+    ACCOUNT_FETCH_CONCURRENCY
+  )
 
-  assertAnyAccountAuthenticated(authenticationErrors, config.accounts.length)
+  const authenticationErrors = accountResults.filter(result => result.authenticationError).length
+  assertAnyAccountAuthenticated(authenticationErrors, totalAccounts)
+  const allPrs = accountResults.flatMap(result => result.prs)
   sortPRsForMode(allPrs, mode)
   return dedupePRsByUrl(allPrs)
 }

--- a/src/api/github/shared.test.ts
+++ b/src/api/github/shared.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import type { Octokit } from '@octokit/rest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   parseLabels,
   mapPRLabel,
@@ -10,8 +11,11 @@ import {
   includesLoginIgnoreCase,
   mapReactionGroups,
   batchProcess,
+  clearOrgAvatarCache,
+  getOrgAvatarCacheEntry,
   mapCommitFileToDiffFile,
   mapReviewCommentFields,
+  resolveOrgAvatar,
 } from './shared'
 
 describe('mapPRLabel', () => {
@@ -279,6 +283,37 @@ describe('batchProcess', () => {
     expect(maxInFlight).toBeLessThanOrEqual(2)
   })
 
+  it('preserves source indexes across multiple batches', async () => {
+    const results: string[] = []
+
+    await batchProcess(
+      ['first', 'second', 'third', 'fourth'],
+      async (item, index) => {
+        results[index] = item
+      },
+      2
+    )
+
+    expect(results).toEqual(['first', 'second', 'third', 'fourth'])
+  })
+
+  it('propagates failures without starting a later batch', async () => {
+    const started: number[] = []
+
+    await expect(
+      batchProcess(
+        [1, 2, 3],
+        async item => {
+          started.push(item)
+          if (item === 2) throw new Error('rate limited')
+        },
+        2
+      )
+    ).rejects.toThrow('rate limited')
+
+    expect(started).toEqual([1, 2])
+  })
+
   it('handles empty array', async () => {
     const processed: number[] = []
     await batchProcess([], async item => {
@@ -294,6 +329,34 @@ describe('batchProcess', () => {
       processed.push(item)
     })
     expect(processed).toHaveLength(25)
+  })
+})
+
+describe('resolveOrgAvatar', () => {
+  it('shares a successful in-flight lookup across accounts', async () => {
+    clearOrgAvatarCache()
+    let resolveSuccessfulLookup!: (value: { data: { avatar_url: string } }) => void
+    const successfulLookup = new Promise<{ data: { avatar_url: string } }>(resolve => {
+      resolveSuccessfulLookup = resolve
+    })
+    const successfulClient = {
+      orgs: { get: vi.fn(() => successfulLookup) },
+      users: { getByUsername: vi.fn() },
+    } as unknown as Octokit
+    const failingClient = {
+      orgs: { get: vi.fn() },
+      users: { getByUsername: vi.fn() },
+    } as unknown as Octokit
+
+    const successfulResult = resolveOrgAvatar(successfulClient, 'shared-org')
+    const failedResult = resolveOrgAvatar(failingClient, 'shared-org')
+
+    resolveSuccessfulLookup({ data: { avatar_url: 'https://avatars/shared-org' } })
+    await expect(successfulResult).resolves.toBe('https://avatars/shared-org')
+    await expect(failedResult).resolves.toBe('https://avatars/shared-org')
+    expect(failingClient.orgs.get).not.toHaveBeenCalled()
+    expect(failingClient.users.getByUsername).not.toHaveBeenCalled()
+    expect(getOrgAvatarCacheEntry('shared-org')).toBe('https://avatars/shared-org')
   })
 })
 

--- a/src/api/github/shared.ts
+++ b/src/api/github/shared.ts
@@ -200,16 +200,19 @@ const OctokitWithPlugins = Octokit.plugin(retry, throttling)
 // Module-level caches (persist across calls)
 const tokenCache: Map<string, string> = new Map()
 const orgAvatarCache: Map<string, string | null> = new Map() // null = tried and failed
+const orgAvatarRequests: Map<string, Promise<string | null>> = new Map()
 
 /** Test-only: reset the org avatar cache between tests. */
 export function clearOrgAvatarCache(): void {
   orgAvatarCache.clear()
+  orgAvatarRequests.clear()
 }
 
 /** Clear all module-level caches (token, avatar). */
 export function clearAllCaches(): void {
   tokenCache.clear()
   orgAvatarCache.clear()
+  orgAvatarRequests.clear()
 }
 
 /** Test-only: inspect the org avatar cache. */
@@ -401,7 +404,7 @@ export async function withFirstAvailableAccount<T>(
  */
 export async function batchProcess<T>(
   items: T[],
-  fn: (item: T) => Promise<void>,
+  fn: (item: T, index: number) => Promise<void>,
   batchSize?: number
 ): Promise<void> {
   const BATCH_SIZE = 10
@@ -410,7 +413,7 @@ export async function batchProcess<T>(
   for (let i = 0; i < items.length; i += size) {
     const batch = items.slice(i, i + size)
     // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Batches intentionally cap concurrency while each batch still runs in parallel.
-    await Promise.all(batch.map(fn))
+    await Promise.all(batch.map((item, batchIndex) => fn(item, i + batchIndex)))
   }
 }
 
@@ -469,6 +472,19 @@ export async function resolveOrgAvatar(octokit: Octokit, org: string): Promise<s
   const cached = orgAvatarCache.get(org)
   if (cached !== undefined) return cached
 
+  const pending = orgAvatarRequests.get(org)
+  if (pending) return pending
+
+  const request = fetchOrgAvatar(octokit, org)
+  orgAvatarRequests.set(org, request)
+  try {
+    return await request
+  } finally {
+    if (orgAvatarRequests.get(org) === request) orgAvatarRequests.delete(org)
+  }
+}
+
+async function fetchOrgAvatar(octokit: Octokit, org: string): Promise<string | null> {
   try {
     const orgData = await octokit.orgs.get({ org })
     orgAvatarCache.set(org, orgData.data.avatar_url)


### PR DESCRIPTION
Closes #284

## Summary
- batch configured-account PR fetches with a concurrency cap of two
- preserve configured result ordering and monotonic account progress
- share in-flight organization-avatar lookups across accounts
- cover batching, pagination, rate-limit failure, and cache-race behavior

## Verification
- 291 test files passed (6,533 tests) with coverage
- TypeScript typecheck passed
- changed-file ESLint passed
- React Doctor reports no `async-await-in-loop` finding for `src/api/github/prs.ts`
- Vite renderer, main, and preload builds passed; Electron packaging remains blocked by the repository's `node-abi` support gap for Electron 43.0.0

## Risk
Medium: request scheduling changed, so review should focus on API pressure, progress ordering, and cache sharing.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Batch GitHub account PR requests with bounded concurrency of 2
> - `fetchPRs` in [prs.ts](https://github.com/HemSoft/hs-buddy/pull/291/files#diff-861d848f1d151af5a15544b21377bc81ff41627c5bac3069f601411b7e6a1625) now fetches up to 2 accounts concurrently using `batchProcess` instead of sequentially, reducing total fetch time for multi-account users.
> - A new `createOrderedProgressReporter` buffers per-account progress updates and emits them in account index order regardless of which account finishes first, keeping progress delivery deterministic.
> - `resolveOrgAvatar` in [shared.ts](https://github.com/HemSoft/hs-buddy/pull/291/files#diff-2e0306c265d74dd4e1363c1462ccbe7986c9c1a932e39a8b6a3046361a65045e) now coalesces concurrent lookups for the same org into a single in-flight request to avoid redundant network calls.
> - `batchProcess` now passes the original source index to its callback, enabling callers to preserve ordering across batched results.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6b18766.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->