### PR TITLE
fix: harden packaged Windows terminal startup

### DIFF
--- a/electron/ipc/terminalHandlers.test.ts
+++ b/electron/ipc/terminalHandlers.test.ts
@@ -50,7 +50,7 @@ vi.mock('../../src/utils/terminalPathUtils', () => ({
   getOrgCandidates: vi.fn((owner: string) => [owner]),
   processOsc7Buffer: vi.fn(() => ({ cwd: null, remainingBuffer: '' })),
   buildTerminalShellArgs: vi.fn(() => []),
-  buildTerminalStartupCommand: vi.fn(() => undefined),
+  buildTerminalStartupCommand: vi.fn((): undefined => {}),
   buildPtySpawnOptions: vi.fn(() => ({ env: {} })),
   findRepoPath: vi.fn(() => null),
 }))
@@ -73,7 +73,7 @@ describe('terminalHandlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
-    vi.mocked(accessSync).mockImplementation(() => undefined)
+    vi.mocked(accessSync).mockImplementation((): undefined => {})
     vi.mocked(existsSync).mockImplementation(() => true)
     vi.mocked(statSync).mockImplementation(
       candidate =>

--- a/electron/ipc/terminalHandlers.test.ts
+++ b/electron/ipc/terminalHandlers.test.ts
@@ -11,8 +11,13 @@ vi.mock('node:child_process', () => ({
 }))
 
 vi.mock('node:fs', () => ({
+  accessSync: vi.fn(),
   existsSync: vi.fn(() => true),
-  statSync: vi.fn(() => ({ isDirectory: () => true })),
+  constants: { R_OK: 4, X_OK: 1 },
+  statSync: vi.fn((candidate: string) => ({
+    isDirectory: () => !String(candidate).toLowerCase().endsWith('.exe'),
+    isFile: () => String(candidate).toLowerCase().endsWith('.exe'),
+  })),
 }))
 
 vi.mock('node:module', () => ({
@@ -45,15 +50,19 @@ vi.mock('../../src/utils/terminalPathUtils', () => ({
   getOrgCandidates: vi.fn((owner: string) => [owner]),
   processOsc7Buffer: vi.fn(() => ({ cwd: null, remainingBuffer: '' })),
   buildTerminalShellArgs: vi.fn(() => []),
+  buildTerminalStartupCommand: vi.fn(() => undefined),
   buildPtySpawnOptions: vi.fn(() => ({ env: {} })),
   findRepoPath: vi.fn(() => null),
 }))
 
 vi.mock('../../src/utils/errorUtils', () => ({
-  getErrorMessageWithFallback: vi.fn((_err: unknown, fallback: string) => fallback),
+  getErrorMessageWithFallback: vi.fn((err: unknown, fallback: string) =>
+    err instanceof Error && err.message ? err.message : fallback
+  ),
 }))
 
 import { ipcMain } from 'electron'
+import { accessSync, existsSync, statSync } from 'node:fs'
 import { registerTerminalHandlers } from './terminalHandlers'
 
 describe('terminalHandlers', () => {
@@ -64,6 +73,15 @@ describe('terminalHandlers', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(accessSync).mockImplementation(() => undefined)
+    vi.mocked(existsSync).mockImplementation(() => true)
+    vi.mocked(statSync).mockImplementation(
+      candidate =>
+        ({
+          isDirectory: () => !String(candidate).toLowerCase().endsWith('.exe'),
+          isFile: () => String(candidate).toLowerCase().endsWith('.exe'),
+        }) as ReturnType<typeof statSync>
+    )
     handlers = new Map()
     listeners = new Map()
     vi.mocked(ipcMain.handle).mockImplementation((channel, handler) => {
@@ -369,30 +387,82 @@ describe('terminalHandlers', () => {
     }
   }
 
-  it('terminal:spawn returns error when pty.spawn throws', async () => {
+  it('terminal:spawn reports safe launch context when Windows denies process creation', async () => {
     const ptyHarness = createTrackedPtyHarness()
-    ptyHarness.spawn.mockImplementationOnce(() => {
-      throw new Error('PTY spawn failed')
+    ptyHarness.spawn.mockImplementation(() => {
+      throw new Error('Cannot create process, error code: 5')
     })
 
     const { freshHandlers, restore } = await registerFreshTerminalHandlers(
       ptyHarness.createRequireImpl
     )
 
+    const originalPlatform = process.platform
+    const originalPath = process.env.PATH
     try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      process.env.PATH = 'C:\\Program Files\\PowerShell\\7'
+
       const spawnHandler = freshHandlers.get('terminal:spawn')!
       const result = await spawnHandler(
         { sender: { isDestroyed: vi.fn(() => false), send: vi.fn() } },
-        { cols: 80, rows: 24 }
+        { cwd: 'C:\\repos\\SFL', cols: 80, rows: 24 }
       )
 
-      expect(result).toEqual({ success: false, error: 'Failed to spawn terminal' })
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining('Cannot create process, error code: 5'),
+      })
+      expect(result.error).toContain('stage=native-pty-spawn')
+      expect(result.error).toContain('shell=C:\\Program Files\\PowerShell\\7\\pwsh.exe')
+      expect(result.error).toContain('cwdExists=true')
+      expect(result.error).toContain('cwdAccessible=true')
+      expect(result.error).not.toContain('PATH=')
     } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      process.env.PATH = originalPath
       restore()
     }
   })
 
-  it('terminal:spawn falls back to powershell.exe when pwsh.exe is unavailable', async () => {
+  it('terminal:spawn distinguishes an existing but inaccessible cwd in diagnostics', async () => {
+    const ptyHarness = createTrackedPtyHarness()
+    ptyHarness.spawn.mockImplementation(() => {
+      throw new Error('Cannot create process, error code: 5')
+    })
+
+    const { freshHandlers, restore } = await registerFreshTerminalHandlers(
+      ptyHarness.createRequireImpl
+    )
+
+    const originalPlatform = process.platform
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+      vi.mocked(accessSync).mockImplementation(candidate => {
+        if (String(candidate).includes('restricted')) {
+          throw Object.assign(new Error('access denied'), { code: 'EACCES' })
+        }
+      })
+
+      const spawnHandler = freshHandlers.get('terminal:spawn')!
+      const result = await spawnHandler(
+        { sender: { isDestroyed: vi.fn(() => false), send: vi.fn() } },
+        { cwd: 'C:\\repos\\restricted', cols: 80, rows: 24 }
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('cwdExists=true')
+      expect(result.error).toContain('cwdAccessible=false')
+      expect(result.error).toContain('cwdFallback=true')
+      expect(result.error).toContain('effectiveCwdExists=true')
+      expect(result.error).toContain('effectiveCwdAccessible=true')
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      restore()
+    }
+  })
+
+  it('terminal:spawn resolves pwsh.exe to an accessible file instead of a PATH directory', async () => {
     const ptyHarness = createTrackedPtyHarness()
     const { freshHandlers, restore } = await registerFreshTerminalHandlers(
       ptyHarness.createRequireImpl
@@ -401,7 +471,47 @@ describe('terminalHandlers', () => {
     const originalPath = process.env.PATH
     const originalPlatform = process.platform
     try {
-      process.env.PATH = `C:\\missing-pwsh-${Date.now()}`
+      process.env.PATH = 'C:\\blocked;C:\\Program Files\\PowerShell\\7'
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
+
+      const { statSync } = await import('node:fs')
+      vi.mocked(statSync).mockImplementation(
+        candidate =>
+          ({
+            isDirectory: () => String(candidate) === 'C:\\blocked\\pwsh.exe',
+            isFile: () => String(candidate) !== 'C:\\blocked\\pwsh.exe',
+          }) as ReturnType<typeof statSync>
+      )
+
+      const spawnHandler = freshHandlers.get('terminal:spawn')!
+      const result = await spawnHandler(
+        { sender: { isDestroyed: vi.fn(() => false), send: vi.fn() } },
+        { cols: 80, rows: 24 }
+      )
+
+      expect(result.success).toBe(true)
+      expect(ptyHarness.spawn).toHaveBeenCalledWith(
+        'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+        expect.any(Array),
+        expect.any(Object)
+      )
+    } finally {
+      process.env.PATH = originalPath
+      Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true })
+      restore()
+    }
+  })
+
+  it('terminal:spawn resolves powershell.exe when pwsh.exe is unavailable', async () => {
+    const ptyHarness = createTrackedPtyHarness()
+    const { freshHandlers, restore } = await registerFreshTerminalHandlers(
+      ptyHarness.createRequireImpl
+    )
+
+    const originalPath = process.env.PATH
+    const originalPlatform = process.platform
+    try {
+      process.env.PATH = 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0'
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true })
 
       const { existsSync } = await import('node:fs')
@@ -415,7 +525,7 @@ describe('terminalHandlers', () => {
 
       expect(result.success).toBe(true)
       expect(ptyHarness.spawn).toHaveBeenCalledWith(
-        'powershell.exe',
+        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
         expect.any(Array),
         expect.any(Object)
       )
@@ -486,7 +596,9 @@ describe('terminalHandlers', () => {
         { cols: 80, rows: 24 }
       )
 
-      expect(result).toEqual({ success: false, error: 'Failed to spawn terminal' })
+      expect(result.success).toBe(false)
+      expect(result.error).toContain('node-pty unavailable')
+      expect(result.error).toContain('stage=native-pty-load')
     } finally {
       restore()
     }
@@ -554,6 +666,37 @@ describe('terminalHandlers', () => {
       vi.advanceTimersByTime(500)
 
       expect(ptyHarness.ptyProcesses[0].write).toHaveBeenCalledWith('echo hello\r')
+    } finally {
+      restore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('terminal:spawn sends PowerShell setup after launch instead of in process args', async () => {
+    vi.useFakeTimers()
+    const terminalPathUtils = await import('../../src/utils/terminalPathUtils')
+    vi.mocked(terminalPathUtils.buildTerminalStartupCommand).mockReturnValueOnce('setup-prompt')
+    const ptyHarness = createTrackedPtyHarness()
+    const { freshHandlers, restore } = await registerFreshTerminalHandlers(
+      ptyHarness.createRequireImpl
+    )
+
+    try {
+      const spawnHandler = freshHandlers.get('terminal:spawn')!
+      const mockSender = { isDestroyed: vi.fn(() => false), send: vi.fn() }
+      await spawnHandler(
+        { sender: mockSender },
+        { cols: 80, rows: 24, startupCommand: 'echo hello' }
+      )
+
+      vi.advanceTimersByTime(500)
+
+      expect(ptyHarness.spawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.not.arrayContaining(['-EncodedCommand']),
+        expect.any(Object)
+      )
+      expect(ptyHarness.ptyProcesses[0].write).toHaveBeenCalledWith('setup-prompt;echo hello\r')
     } finally {
       restore()
       vi.useRealTimers()

--- a/electron/ipc/terminalHandlers.ts
+++ b/electron/ipc/terminalHandlers.ts
@@ -84,7 +84,8 @@ function resolveExecutableOnPath(executable: string): string | null {
     return null
   }
 
-  for (const rawDirectory of pathValue.split(path.delimiter)) {
+  const delimiter = process.platform === 'win32' ? path.win32.delimiter : path.posix.delimiter
+  for (const rawDirectory of pathValue.split(delimiter)) {
     const directory = rawDirectory.trim().replace(/^"(.*)"$/, '$1')
     if (!directory) continue
 

--- a/electron/ipc/terminalHandlers.ts
+++ b/electron/ipc/terminalHandlers.ts
@@ -1,6 +1,6 @@
 import { ipcMain, app, type WebContents } from 'electron'
 import { randomUUID } from 'node:crypto'
-import { existsSync, statSync } from 'node:fs'
+import { accessSync, constants, existsSync, statSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import {
@@ -9,6 +9,7 @@ import {
   getOrgCandidates,
   processOsc7Buffer,
   buildTerminalShellArgs,
+  buildTerminalStartupCommand,
   buildPtySpawnOptions,
   findRepoPath,
 } from '../../src/utils/terminalPathUtils'
@@ -70,32 +71,52 @@ function getPty(): typeof import('node-pty') {
 
 const MAX_SCROLLBACK_BUFFER = 100_000
 
-const executablePathCache = new Map<string, boolean>()
+const executablePathCache = new Map<string, string | null>()
 
-function executableExistsOnPath(executable: string): boolean {
+function resolveExecutableOnPath(executable: string): string | null {
   const pathValue = process.env.PATH ?? ''
   const cacheKey = `${executable}\0${pathValue}`
   const cached = executablePathCache.get(cacheKey)
   if (cached !== undefined) return cached
 
   if (!pathValue) {
-    executablePathCache.set(cacheKey, false)
-    return false
+    executablePathCache.set(cacheKey, null)
+    return null
   }
 
-  const exists = pathValue
-    .split(path.delimiter)
-    .filter(Boolean)
-    .some(directory => existsSync(path.join(directory, executable)))
+  for (const rawDirectory of pathValue.split(path.delimiter)) {
+    const directory = rawDirectory.trim().replace(/^"(.*)"$/, '$1')
+    if (!directory) continue
 
-  executablePathCache.set(cacheKey, exists)
-  return exists
+    const candidate = path.win32.resolve(directory, executable)
+    try {
+      if (!existsSync(candidate) || !statSync(candidate).isFile()) continue
+      accessSync(candidate, constants.X_OK)
+      executablePathCache.set(cacheKey, candidate)
+      return candidate
+    } catch (_: unknown) {
+      // Keep searching: a PATH entry can exist but be inaccessible or not executable.
+    }
+  }
+
+  executablePathCache.set(cacheKey, null)
+  return null
 }
 
 /** Resolve the best available PowerShell executable on Windows.
  *  Prefers pwsh.exe (PowerShell 7+), falls back to powershell.exe (Windows PowerShell 5.x). */
 function resolveWindowsShell(): string {
-  return executableExistsOnPath('pwsh.exe') ? 'pwsh.exe' : 'powershell.exe'
+  return (
+    resolveExecutableOnPath('pwsh.exe') ??
+    resolveExecutableOnPath('powershell.exe') ??
+    path.win32.join(
+      process.env.SystemRoot || process.env.WINDIR || 'C:\\Windows',
+      'System32',
+      'WindowsPowerShell',
+      'v1.0',
+      'powershell.exe'
+    )
+  )
 }
 
 interface PtyDisposable {
@@ -124,13 +145,29 @@ interface TerminalSession {
 
 const sessions = new Map<string, TerminalSession>()
 
-function isValidCwd(dir: string): boolean {
+interface CwdAccess {
+  exists: boolean
+  accessible: boolean
+}
+
+function inspectCwdAccess(dir: string): CwdAccess {
+  let exists = false
   try {
     const resolved = path.resolve(dir)
-    return existsSync(resolved) && statSync(resolved).isDirectory()
+    exists = existsSync(resolved)
+    if (!exists || !statSync(resolved).isDirectory()) {
+      return { exists, accessible: false }
+    }
+    accessSync(resolved, constants.R_OK)
+    return { exists: true, accessible: true }
   } catch (_: unknown) {
-    return false
+    return { exists, accessible: false }
   }
+}
+
+function isValidCwd(dir: string): boolean {
+  const access = inspectCwdAccess(dir)
+  return access.exists && access.accessible
 }
 
 /** Safely send IPC to the renderer — guards against destroyed webContents */
@@ -281,6 +318,8 @@ function handleResolveRepoPath(_event: unknown, opts: unknown) {
 
 interface ParsedSpawnOpts {
   cwd: string
+  cwdAccess: CwdAccess
+  cwdFallback: boolean
   cols: number | undefined
   rows: number | undefined
   startupCommand: string | undefined
@@ -290,9 +329,18 @@ function asObject(raw: unknown): Record<string, unknown> {
   return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
 }
 
-function parseValidCwd(cwdField: unknown): string {
-  if (typeof cwdField !== 'string') return resolveDefaultCwd()
-  return isValidCwd(cwdField) ? path.resolve(cwdField) : resolveDefaultCwd()
+function parseValidCwd(
+  cwdField: unknown
+): Pick<ParsedSpawnOpts, 'cwd' | 'cwdAccess' | 'cwdFallback'> {
+  if (typeof cwdField !== 'string') {
+    const cwd = resolveDefaultCwd()
+    return { cwd, cwdAccess: inspectCwdAccess(cwd), cwdFallback: false }
+  }
+
+  const cwdAccess = inspectCwdAccess(cwdField)
+  return cwdAccess.exists && cwdAccess.accessible
+    ? { cwd: path.resolve(cwdField), cwdAccess, cwdFallback: false }
+    : { cwd: resolveDefaultCwd(), cwdAccess, cwdFallback: true }
 }
 
 function parseNonEmptyString(value: unknown): string | undefined {
@@ -301,34 +349,48 @@ function parseNonEmptyString(value: unknown): string | undefined {
 
 function parseSpawnOpts(rawOpts: unknown): ParsedSpawnOpts {
   const opts = asObject(rawOpts)
-  const cwd = parseValidCwd(opts.cwd)
+  const { cwd, cwdAccess, cwdFallback } = parseValidCwd(opts.cwd)
   const cols = typeof opts.cols === 'number' ? opts.cols : undefined
   const rows = typeof opts.rows === 'number' ? opts.rows : undefined
   const startupCommand = parseNonEmptyString(opts.startupCommand)
-  return { cwd, cols, rows, startupCommand }
+  return { cwd, cwdAccess, cwdFallback, cols, rows, startupCommand }
 }
 
 async function handleSpawn(event: { sender: WebContents }, rawOpts: unknown) {
-  const { cwd, cols, rows, startupCommand } = parseSpawnOpts(rawOpts)
+  const { cwd, cwdAccess, cwdFallback, cols, rows, startupCommand } = parseSpawnOpts(rawOpts)
   const sessionId = randomUUID()
 
   const { shell, shellArgs } = resolveSpawnShell()
+  const shellStartupCommand = buildTerminalStartupCommand(shell, process.platform)
   const spawnOptions = buildSpawnOptions({ cols, rows }, cwd)
 
   let ptyProcess
+  let launchStage = 'native-pty-load'
   try {
-    ptyProcess = getPty().spawn(shell, shellArgs, spawnOptions)
+    const pty = getPty()
+    launchStage = 'native-pty-spawn'
+    ptyProcess = pty.spawn(shell, shellArgs, spawnOptions)
   } catch (error: unknown) {
+    const effectiveCwdAccess = inspectCwdAccess(cwd)
+    const message = getErrorMessageWithFallback(error, 'Failed to spawn terminal')
     return {
       success: false,
-      error: getErrorMessageWithFallback(error, 'Failed to spawn terminal'),
+      error:
+        `${message} ` +
+        `[stage=${launchStage}; shell=${shell}; ` +
+        `cwdExists=${cwdAccess.exists}; cwdAccessible=${cwdAccess.accessible}; ` +
+        `cwdFallback=${cwdFallback}; effectiveCwdExists=${effectiveCwdAccess.exists}; ` +
+        `effectiveCwdAccessible=${effectiveCwdAccess.accessible}]`,
     }
   }
 
   createTerminalSession(sessionId, ptyProcess, cwd, event.sender)
 
-  if (startupCommand) {
-    scheduleStartupCommand(sessionId, startupCommand)
+  const startupCommands = [shellStartupCommand, startupCommand].filter(
+    (command): command is string => command !== undefined
+  )
+  if (startupCommands.length > 0) {
+    scheduleStartupCommand(sessionId, startupCommands.join(';'))
   }
 
   return { success: true, sessionId, cwd }

--- a/src/utils/terminalPathUtils.test.ts
+++ b/src/utils/terminalPathUtils.test.ts
@@ -6,6 +6,7 @@ import {
   getCloneRoots,
   processOsc7Buffer,
   buildTerminalShellArgs,
+  buildTerminalStartupCommand,
   buildPtySpawnOptions,
   findRepoPath,
 } from './terminalPathUtils'
@@ -177,17 +178,20 @@ describe('processOsc7Buffer', () => {
 // ─── buildTerminalShellArgs ─────────────────────────────
 
 describe('buildTerminalShellArgs', () => {
-  it('returns encoded command args for pwsh.exe on win32', () => {
+  it('returns interactive args for pwsh.exe on win32', () => {
     const args = buildTerminalShellArgs('pwsh.exe', 'win32')
-    expect(args).toContain('-NoLogo')
-    expect(args).toContain('-NoExit')
-    expect(args).toContain('-EncodedCommand')
-    expect(args.length).toBe(4)
+    expect(args).toEqual(['-NoLogo', '-NoExit'])
   })
 
-  it('returns encoded command args for powershell.exe on win32', () => {
+  it('returns interactive args for powershell.exe on win32', () => {
     const args = buildTerminalShellArgs('powershell.exe', 'win32')
-    expect(args).toContain('-EncodedCommand')
+    expect(args).toEqual(['-NoLogo', '-NoExit'])
+  })
+
+  it('returns encoded command args for an absolute PowerShell path on win32', () => {
+    const args = buildTerminalShellArgs('C:\\Program Files\\PowerShell\\7\\pwsh.exe', 'win32')
+    expect(args).toEqual(['-NoLogo', '-NoExit'])
+    expect(args).not.toContain('-EncodedCommand')
   })
 
   it('returns empty array for non-Windows platform', () => {
@@ -198,6 +202,22 @@ describe('buildTerminalShellArgs', () => {
   it('returns empty array for non-PowerShell shell on Windows', () => {
     expect(buildTerminalShellArgs('bash', 'win32')).toEqual([])
     expect(buildTerminalShellArgs('cmd.exe', 'win32')).toEqual([])
+  })
+})
+
+describe('buildTerminalStartupCommand', () => {
+  it('returns OSC 7 prompt setup for an absolute PowerShell path on win32', () => {
+    const command = buildTerminalStartupCommand(
+      'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      'win32'
+    )
+
+    expect(command).toContain('function global:prompt')
+    expect(command).toContain('file:///')
+  })
+
+  it('returns undefined for non-PowerShell shells', () => {
+    expect(buildTerminalStartupCommand('/bin/bash', 'linux')).toBeUndefined()
   })
 })
 

--- a/src/utils/terminalPathUtils.ts
+++ b/src/utils/terminalPathUtils.ts
@@ -186,15 +186,25 @@ function buildPowerShellOsc7Setup(): string {
   ].join(';')
 }
 
+function isWindowsPowerShell(shell: string, platform: string): boolean {
+  if (platform !== 'win32') return false
+  const shellExecutable = path.win32.basename(shell).toLowerCase()
+  return shellExecutable === 'pwsh.exe' || shellExecutable === 'powershell.exe'
+}
+
 /**
- * Build shell args for the terminal. For Windows PowerShell, generates
- * an encoded command that injects OSC 7 CWD reporting into the prompt.
+ * Build shell args for the terminal.
+ *
+ * PowerShell startup customization is intentionally not passed on the process
+ * command line because Windows application-control policies can reject the
+ * encoded command with error code 5. It is sent after spawn instead.
  */
 export function buildTerminalShellArgs(shell: string, platform: string): string[] {
-  if (platform === 'win32' && (shell === 'pwsh.exe' || shell === 'powershell.exe')) {
-    const osc7Setup = buildPowerShellOsc7Setup()
-    const encoded = Buffer.from(osc7Setup, 'utf16le').toString('base64')
-    return ['-NoLogo', '-NoExit', '-EncodedCommand', encoded]
-  }
+  if (isWindowsPowerShell(shell, platform)) return ['-NoLogo', '-NoExit']
   return []
+}
+
+/** Build the PowerShell prompt customization that is sent after the PTY launches. */
+export function buildTerminalStartupCommand(shell: string, platform: string): string | undefined {
+  return isWindowsPowerShell(shell, platform) ? buildPowerShellOsc7Setup() : undefined
 }


### PR DESCRIPTION
Closes #292

## Root cause

The packaged Windows app passed an OSC 7 prompt-initialization script on PowerShell's process command line. Windows process policy denied that command line before PowerShell started, and node-pty surfaced `Cannot create process, error code: 5`. The same packaged executable successfully launched `pwsh.exe` with plain interactive arguments.

## Fix

- Resolve `pwsh.exe` and `powershell.exe` to the first accessible regular file on PATH, not a bare executable name.
- Launch PowerShell with plain interactive arguments and send OSC 7 setup through the PTY after process creation.
- Validate cwd readability and report safe requested/effective cwd booleans plus native launch stage on failure; no environment values are included.
- Cover error code 5 diagnostics, inaccessible cwd fallback context, absolute `pwsh.exe`, and `powershell.exe` fallback.

## Verification

- `bun run test:electron` — 44 files, 861 tests passed.
- `bunx vitest run src/components/terminal src/components/terminal-workspace src/hooks/useTerminalPanel.test.ts src/utils/terminalPathUtils.test.ts` — 9 files, 215 tests passed.
- `bun run test:coverage` — 291 files, 6536 tests passed; 99.83% statements / 99.62% branches / 100% functions / 99.91% lines.
- `bun run typecheck` — passed all five TypeScript projects.
- `bun run lint` — passed.
- `bun run knip` — passed.
- `bun run format:check` — passed.
- `bunx vite build` — passed.
- `bunx electron-builder --win --dir --config electron-builder.json5 --config.npmRebuild=false` — produced the Windows x64 unpacked package.
- Packaged CDP smoke — `terminal.spawn` used the exact repository cwd; attach showed an alive session; startup output, a subsequent interactive write, and OSC 7 output all matched; kill succeeded.

## Residual risk

The local packaging command disabled dependency rebuild because the locked `node-abi@4.29.0` does not yet identify Electron 43.0.0. The packaged node-pty prebuild loaded and passed the real terminal smoke, but CI's normal packaging path remains the authority for rebuild behavior. Post-spawn shell integration is intentionally written after a 500 ms delay to avoid process-policy denial; the packaged smoke verified it on this Windows host.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Windows terminal startup by improving shell resolution and PTY error diagnostics
> - `resolveExecutableOnPath` now scans PATH entries and returns the first accessible executable file path (skipping directories and inaccessible entries) for `pwsh.exe` then `powershell.exe`, falling back to the standard `WindowsPowerShell` path.
> - `inspectCwdAccess` distinguishes between non-existent and inaccessible working directories; spawn failures now include a diagnostic context with launch stage, shell path, and cwd accessibility flags.
> - PowerShell startup customization (OSC 7 prompt setup) is no longer passed via `-EncodedCommand` args; it is written to the PTY after spawn, joined with any user `startupCommand` via `;`.
> - Behavioral Change: `buildTerminalShellArgs` for Windows PowerShell now returns only `['-NoLogo', '-NoExit']` instead of an `-EncodedCommand` argument.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c8d0a6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->