### PR TITLE
chore: ratchet lint quality baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.894] - 2026-07-24
+
+### Changed
+
+- Ratchet lint quality baseline
+
 ## [0.1.893] - 2026-07-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.893",
+  "version": "0.1.894",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/lint-quality-baseline.json
+++ b/scripts/lint-quality-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "totalWarnings": 1225,
+  "totalWarnings": 1222,
   "entries": {
     "convex/__tests__/bookmarks.test.ts::max-lines-per-function": 1,
     "convex/__tests__/buddyStats.test.ts::max-lines-per-function": 1,
@@ -152,7 +152,6 @@
     "src/components/automation/run-list/RunCard.tsx::@typescript-eslint/no-confusing-void-expression": 2,
     "src/components/automation/run-list/RunFilterBar.tsx::@typescript-eslint/no-confusing-void-expression": 1,
     "src/components/automation/RunList.test.tsx::max-lines-per-function": 1,
-    "src/components/automation/RunList.tsx::@typescript-eslint/no-confusing-void-expression": 1,
     "src/components/automation/RunList.tsx::max-lines-per-function": 1,
     "src/components/automation/RunList.tsx::unicorn/no-negated-condition": 1,
     "src/components/automation/ScheduleDetailPanel.test.tsx::max-lines-per-function": 1,
@@ -451,7 +450,7 @@
     "src/components/tempo/TempoTimelineView.tsx::@typescript-eslint/no-confusing-void-expression": 2,
     "src/components/tempo/TempoTimesheetGrid.test.tsx::max-lines": 1,
     "src/components/tempo/TempoTimesheetGrid.test.tsx::max-lines-per-function": 1,
-    "src/components/tempo/TempoTimesheetGrid.tsx::@typescript-eslint/no-confusing-void-expression": 8,
+    "src/components/tempo/TempoTimesheetGrid.tsx::@typescript-eslint/no-confusing-void-expression": 6,
     "src/components/tempo/TempoTimesheetGrid.tsx::max-lines-per-function": 1,
     "src/components/tempo/tempoUtils.ts::unicorn/prefer-number-properties": 2,
     "src/components/tempo/TempoWorklogEditor.test.tsx::max-lines-per-function": 1,


### PR DESCRIPTION
Closes #296

## Summary
- ratchet the lint-quality warning baseline from 1,225 to 1,222
- remove the eliminated RunList warning bucket and reduce the TempoTimesheetGrid bucket by two
- preserve the baseline guard against any increased warning bucket

## Verification
- `bun run lint:quality` (1,222/1,222 warnings, 623/623 buckets)
- `bun run lint`
- `bun run format:check`
- pre-commit suite: 291 test files and 6,536 tests passed with coverage
- `bun run typecheck`

## Risk
Low. This updates generated quality-debt metadata only; runtime behavior is unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ratchet lint quality baseline from 1225 to 1222 warnings
> Reduces the lint warning baseline in [scripts/lint-quality-baseline.json](https://github.com/HemSoft/hs-buddy/pull/300/files#diff-93993650bde29cb80894ec790479b2882a8f5e5111e7cf18c666a7834689678c) by 3, removing one `@typescript-eslint/no-confusing-void-expression` violation from `RunList.tsx` and reducing the count in `TempoTimesheetGrid.tsx` from 8 to 6.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0acc22b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->