### PR TITLE
Ratchet Electron coverage thresholds to current floors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.895] - 2026-07-24
+
+### Changed
+
+- Ratchet Electron coverage floors
+
 ## [0.1.894] - 2026-07-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.894",
+  "version": "0.1.895",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/vitest.electron.config.ts
+++ b/vitest.electron.config.ts
@@ -17,10 +17,10 @@ export default defineConfig({
         'electron/__mocks__/**',
       ],
       thresholds: {
-        statements: 90,
+        statements: 97,
         branches: 89,
-        functions: 89,
-        lines: 90,
+        functions: 97,
+        lines: 98,
       },
     },
   },


### PR DESCRIPTION
Closes #297

## Summary
- raise Electron coverage floors to the current measured baseline
- preserve 89% branch coverage while ratcheting statements, functions, and lines

## Verification
- `bun run test:electron:coverage` (44 files, 861 tests; 97.29% statements, 89.99% branches, 97.1% functions, 98.15% lines)
- `bun run coverage:ratchet:electron` (`no threshold increase needed`)
- `bun run typecheck`
- `bun run lint`

## Risk
Low: configuration-only coverage threshold changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Raise Electron coverage thresholds for statements, functions, and lines
> Updates [`vitest.electron.config.ts`](https://github.com/HemSoft/hs-buddy/pull/301/files#diff-7bbe23ddd8f05d55a4a2cf9eec9a83044e74425abf3c0162f3081825ba013dc5) to tighten coverage gates: statements and functions rise from 89–90% to 97%, and lines from 90% to 98%. Branches remain at 89%.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d8e47a5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->