### PR TITLE
refactor(tempo): break timesheet type cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.896] - 2026-07-25
+
+### Changed
+
+- Break timesheet type cycle
+
 ## [0.1.895] - 2026-07-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.895",
+  "version": "0.1.896",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/tempo/TempoTimesheetGrid.tsx
+++ b/src/components/tempo/TempoTimesheetGrid.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useEffect, useState, useCallback } from 'react'
 import { createPortal } from 'react-dom'
-import type { TempoIssueSummary, TempoWorklog } from '../../types/tempo'
+import type { DayColumn, TempoIssueSummary, TempoWorklog } from '../../types/tempo'
 import { formatDateKey } from '../../utils/dateUtils'
 import { isModKey, modLabel } from '../../utils/platform'
 import { getHoursClasses } from '../../utils/tempoUtils'
@@ -56,16 +56,6 @@ interface TempoTimesheetGridProps {
   onWorklogDelete: (worklog: TempoWorklog) => void
   onCopyToToday: (worklogs: TempoWorklog[]) => void
   onCopyFromPreviousMonth?: () => void
-}
-
-export interface DayColumn {
-  date: string // YYYY-MM-DD
-  dayNum: number
-  dayLabel: string // MON, TUE, ...
-  isWeekend: boolean
-  isToday: boolean
-  isHoliday: boolean
-  holidayName?: string
 }
 
 function buildDayHeaderClass(col: DayColumn): string {

--- a/src/components/tempo/TimesheetFooterRow.tsx
+++ b/src/components/tempo/TimesheetFooterRow.tsx
@@ -1,7 +1,6 @@
 import { Check } from 'lucide-react'
-import type { TempoWorklog } from '../../types/tempo'
+import type { DayColumn, TempoWorklog } from '../../types/tempo'
 import { isModKey, modLabel } from '../../utils/platform'
-import type { DayColumn } from './TempoTimesheetGrid'
 
 function buildTotalCellClass(col: DayColumn, isDayComplete: boolean, dayTotal: number): string {
   return [

--- a/src/types/tempo.ts
+++ b/src/types/tempo.ts
@@ -45,6 +45,17 @@ export interface TempoIssueSummary {
   hoursByDate: Record<string, number>
 }
 
+/** Calendar metadata for a column in the Tempo timesheet grid */
+export interface DayColumn {
+  date: string // YYYY-MM-DD
+  dayNum: number
+  dayLabel: string // MON, TUE, ...
+  isWeekend: boolean
+  isToday: boolean
+  isHoliday: boolean
+  holidayName?: string
+}
+
 /** Payload for creating a worklog */
 export interface CreateWorklogPayload {
   issueKey: string


### PR DESCRIPTION
Closes #298

## Summary
- move `DayColumn` to the shared Tempo type module
- remove the footer-to-grid reverse type import
- preserve component behavior and markup

## Verification
- `bun run deps:check`
- `bun run typecheck`
- `bun run lint`
- `bunx vitest run src/components/tempo/TempoTimesheetGrid.test.tsx` (29 tests)
- pre-commit suite: 291 files and 6,536 tests with coverage

## Risk
Low: type-only relocation with no runtime or rendered-markup changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move `DayColumn` interface to central tempo types to break import cycle
> Moves the `DayColumn` interface from [TempoTimesheetGrid.tsx](https://github.com/HemSoft/hs-buddy/pull/302/files#diff-bc0f7c1110ce9cc45eb35a592526260a5b76149edab136b8b0c9fadd9078fe84) into [src/types/tempo.ts](https://github.com/HemSoft/hs-buddy/pull/302/files#diff-ac90a22b428f361f2742734516b33474eaad746b8af73a3459dd9250698db789). `TimesheetFooterRow` previously imported `DayColumn` directly from the grid component, creating a type cycle; both components now import from the shared types module.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8c29991.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->