### PR TITLE
fix(security): prevent GitHub IPC shell injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.902] - 2026-07-25
+
+### Fixed
+
+- Stop retrying non-retryable model errors
+
 ## [0.1.898] - 2026-07-25
 
 ### Fixed

--- a/electron/ipc/githubHandlers.test.ts
+++ b/electron/ipc/githubHandlers.test.ts
@@ -29,6 +29,14 @@ const mockExecFileAsync = vi.fn((file: string, args: string[], options: unknown)
   mockExecAsync(`${file} ${args.join(' ')}`, options)
 )
 
+function expectGhApiCall(expectedEndpoint: unknown, timeout: number): void {
+  expect(mockExecFileAsync).toHaveBeenCalledWith(
+    'gh',
+    ['api', expectedEndpoint, '-H', 'X-GitHub-Api-Version: 2022-11-28'],
+    expect.objectContaining({ encoding: 'utf8', timeout })
+  )
+}
+
 vi.mock('../utils', () => ({
   execAsync: (...args: unknown[]) => mockExecAsync(...args),
   execFileAsync: (file: string, args: string[], options: unknown) =>
@@ -570,11 +578,12 @@ describe('githubHandlers', () => {
     })
   })
 
-  describe('github:get-user-premium-requests', () => {
-    it.each([
-      ['bad-org; echo injected', 'testmember'],
-      ['test-org', 'badmember; echo injected'],
-    ])('rejects invalid org/member %s/%s before invoking gh', async (org, memberLogin) => {
+  it.each([
+    ['bad-org; echo injected', 'testmember'],
+    ['test-org', 'badmember; echo injected'],
+  ])(
+    'github:get-user-premium-requests rejects invalid org/member %s/%s before invoking gh',
+    async (org, memberLogin) => {
       const handler = handlers.get('github:get-user-premium-requests')!
       const result = await handler({}, org, memberLogin, 'testuser')
 
@@ -584,8 +593,10 @@ describe('githubHandlers', () => {
       })
       expect(mockExecAsync).not.toHaveBeenCalled()
       expect(mockExecFileAsync).not.toHaveBeenCalled()
-    })
+    }
+  )
 
+  describe('github:get-user-premium-requests', () => {
     it('returns premium request data on success', async () => {
       // tryGetCliToken
       mockExecAsync.mockResolvedValueOnce({ stdout: 'ghp_token123\n', stderr: '' })
@@ -593,22 +604,12 @@ describe('githubHandlers', () => {
       mockExecAsync.mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
       mockExecAsync.mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
       mockExecAsync.mockResolvedValueOnce({ stdout: '{"usageItems":[]}', stderr: '' })
-
       const handler = handlers.get('github:get-user-premium-requests')!
       const result = await handler({}, 'test-org', 'testmember', 'testuser')
       expect(result.success).toBe(true)
       expect(result.data.memberLogin).toBe('testmember')
       expect(result.data.org).toBe('test-org')
-      expect(mockExecFileAsync).toHaveBeenCalledWith(
-        'gh',
-        [
-          'api',
-          expect.stringContaining('user=testmember'),
-          '-H',
-          'X-GitHub-Api-Version: 2022-11-28',
-        ],
-        expect.objectContaining({ encoding: 'utf8', timeout: 15000 })
-      )
+      expectGhApiCall(expect.stringContaining('user=testmember'), 15000)
     })
 
     it('returns premium request data with model breakdown when items have grossQuantity > 0', async () => {
@@ -1334,19 +1335,19 @@ describe('githubHandlers', () => {
     })
   })
 
-  describe('github:get-copilot-seats', () => {
-    it('rejects an invalid org before invoking gh', async () => {
-      const handler = handlers.get('github:get-copilot-seats')!
-      const result = await handler({}, 'bad-org; echo injected')
+  it('github:get-copilot-seats rejects an invalid org before invoking gh', async () => {
+    const handler = handlers.get('github:get-copilot-seats')!
+    const result = await handler({}, 'bad-org; echo injected')
 
-      expect(result).toEqual({
-        success: false,
-        error: "Invalid GitHub account slug: 'bad-org; echo injected'",
-      })
-      expect(mockExecAsync).not.toHaveBeenCalled()
-      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      success: false,
+      error: "Invalid GitHub account slug: 'bad-org; echo injected'",
     })
+    expect(mockExecAsync).not.toHaveBeenCalled()
+    expect(mockExecFileAsync).not.toHaveBeenCalled()
+  })
 
+  describe('github:get-copilot-seats', () => {
     it('returns paginated seat data', async () => {
       const seatPayload = {
         total_seats: 2,
@@ -1368,24 +1369,13 @@ describe('githubHandlers', () => {
         ],
       }
       mockExecAsync.mockResolvedValueOnce({ stdout: JSON.stringify(seatPayload), stderr: '' })
-
       const handler = handlers.get('github:get-copilot-seats')!
       const result = await handler({}, 'test-org')
-
       expect(result.success).toBe(true)
       expect(result.data.totalSeats).toBe(2)
       expect(result.data.fetchedSeats).toBe(2)
       expect(result.data.seats).toHaveLength(2)
-      expect(mockExecFileAsync).toHaveBeenCalledWith(
-        'gh',
-        [
-          'api',
-          '/orgs/test-org/copilot/billing/seats?per_page=100&page=1',
-          '-H',
-          'X-GitHub-Api-Version: 2022-11-28',
-        ],
-        expect.objectContaining({ encoding: 'utf8', timeout: 20000 })
-      )
+      expectGhApiCall('/orgs/test-org/copilot/billing/seats?per_page=100&page=1', 20000)
     })
 
     it('paginates when first page has 100 seats and more remain', async () => {

--- a/electron/ipc/githubHandlers.test.ts
+++ b/electron/ipc/githubHandlers.test.ts
@@ -46,11 +46,15 @@ vi.mock('../../src/utils/budgetUtils', () => ({
 const mockParseActiveGitHubAccount = vi.fn().mockReturnValue(null)
 const mockBuildGhAuthTokenArgs = vi.fn().mockReturnValue(['auth', 'token'])
 const mockValidateCliToken = vi.fn().mockReturnValue({ valid: true, token: 'ghp_test' })
+const mockAssertValidGitHubAccountSlug = vi.fn((slug: string) => {
+  if (slug.includes(';')) throw new Error(`Invalid GitHub account slug: '${slug}'`)
+})
 
 vi.mock('../../src/utils/githubAuthUtils', () => ({
   parseActiveGitHubAccount: (...args: unknown[]) => mockParseActiveGitHubAccount(...args),
   buildGhAuthTokenArgs: (...args: unknown[]) => mockBuildGhAuthTokenArgs(...args),
   validateCliToken: (...args: unknown[]) => mockValidateCliToken(...args),
+  assertValidGitHubAccountSlug: (...args: [string]) => mockAssertValidGitHubAccountSlug(...args),
 }))
 
 const mockClassifyCliTokenError = vi.fn().mockReturnValue('unknown')
@@ -156,6 +160,16 @@ describe('githubHandlers', () => {
       const handler = handlers.get('github:get-cli-token')!
       await expect(handler({}, 'testuser')).rejects.toBe('cli-not-installed')
     })
+
+    it('rejects a metacharacter-bearing username before invoking gh', async () => {
+      const handler = handlers.get('github:get-cli-token')!
+
+      await expect(handler({}, 'testuser; echo injected')).rejects.toThrow(
+        "Invalid GitHub account slug: 'testuser; echo injected'"
+      )
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
   })
 
   describe('github:get-active-account', () => {
@@ -194,8 +208,9 @@ describe('githubHandlers', () => {
       const handler = handlers.get('github:switch-account')!
       const result = await handler({}, 'otheruser')
 
-      expect(mockExecAsync).toHaveBeenCalledWith(
-        'gh auth switch --user otheruser',
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['auth', 'switch', '--user', 'otheruser'],
         expect.objectContaining({ encoding: 'utf8', timeout: 5000 })
       )
       expect(result).toEqual({ success: true })
@@ -208,9 +223,33 @@ describe('githubHandlers', () => {
       const result = await handler({}, 'baduser')
       expect(result).toEqual({ success: false, error: 'account not found' })
     })
+
+    it('rejects a metacharacter-bearing username before invoking gh', async () => {
+      const handler = handlers.get('github:switch-account')!
+      const result = await handler({}, 'baduser; echo injected')
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'baduser; echo injected'",
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
   })
 
   describe('github:get-copilot-quota', () => {
+    it('rejects a metacharacter-bearing username before invoking gh', async () => {
+      const handler = handlers.get('github:get-copilot-quota')!
+      const result = await handler({}, 'baduser; echo injected')
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'baduser; echo injected'",
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns error when no token available', async () => {
       // tryGetCliToken returns null when execAsync fails
       mockExecAsync.mockRejectedValueOnce(new Error('no token'))
@@ -237,6 +276,21 @@ describe('githubHandlers', () => {
   })
 
   describe('github:get-copilot-usage', () => {
+    it('rejects invalid org and account slugs before invoking gh', async () => {
+      const handler = handlers.get('github:get-copilot-usage')!
+
+      await expect(handler({}, 'bad-org; echo injected', 'testuser')).resolves.toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'bad-org; echo injected'",
+      })
+      await expect(handler({}, 'test-org', 'baduser; echo injected')).resolves.toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'baduser; echo injected'",
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns parsed usage data on success', async () => {
       // tryGetCliToken
       mockExecAsync.mockResolvedValueOnce({ stdout: 'ghp_token123\n', stderr: '' })
@@ -401,6 +455,18 @@ describe('githubHandlers', () => {
   })
 
   describe('github:get-copilot-budget', () => {
+    it('rejects an invalid org before invoking gh', async () => {
+      const handler = handlers.get('github:get-copilot-budget')!
+      const result = await handler({}, 'bad-org; echo injected', 'testuser')
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'bad-org; echo injected'",
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns budget data on success', async () => {
       // tryGetCliToken
       mockExecAsync.mockResolvedValueOnce({ stdout: 'ghp_token123\n', stderr: '' })
@@ -433,6 +499,21 @@ describe('githubHandlers', () => {
   })
 
   describe('github:get-copilot-member-usage', () => {
+    it.each([
+      ['bad-org; echo injected', 'testmember'],
+      ['test-org', 'badmember; echo injected'],
+    ])('rejects invalid org/member %s/%s before invoking gh', async (org, memberLogin) => {
+      const handler = handlers.get('github:get-copilot-member-usage')!
+      const result = await handler({}, org, memberLogin, 'testuser')
+
+      expect(result).toEqual({
+        success: false,
+        error: `Invalid GitHub account slug: '${org.includes(';') ? org : memberLogin}'`,
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns member seat data on success', async () => {
       // tryGetCliToken
       mockExecAsync.mockResolvedValueOnce({ stdout: 'ghp_token123\n', stderr: '' })
@@ -452,6 +533,11 @@ describe('githubHandlers', () => {
       expect(result.success).toBe(true)
       expect(result.data.login).toBe('testmember')
       expect(result.data.planType).toBe('business')
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['api', '/orgs/test-org/members/testmember/copilot'],
+        expect.objectContaining({ encoding: 'utf8', timeout: 15000 })
+      )
     })
 
     it('returns null data for 404 (no Copilot seat)', async () => {
@@ -485,6 +571,21 @@ describe('githubHandlers', () => {
   })
 
   describe('github:get-user-premium-requests', () => {
+    it.each([
+      ['bad-org; echo injected', 'testmember'],
+      ['test-org', 'badmember; echo injected'],
+    ])('rejects invalid org/member %s/%s before invoking gh', async (org, memberLogin) => {
+      const handler = handlers.get('github:get-user-premium-requests')!
+      const result = await handler({}, org, memberLogin, 'testuser')
+
+      expect(result).toEqual({
+        success: false,
+        error: `Invalid GitHub account slug: '${org.includes(';') ? org : memberLogin}'`,
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns premium request data on success', async () => {
       // tryGetCliToken
       mockExecAsync.mockResolvedValueOnce({ stdout: 'ghp_token123\n', stderr: '' })
@@ -498,6 +599,16 @@ describe('githubHandlers', () => {
       expect(result.success).toBe(true)
       expect(result.data.memberLogin).toBe('testmember')
       expect(result.data.org).toBe('test-org')
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        [
+          'api',
+          expect.stringContaining('user=testmember'),
+          '-H',
+          'X-GitHub-Api-Version: 2022-11-28',
+        ],
+        expect.objectContaining({ encoding: 'utf8', timeout: 15000 })
+      )
     })
 
     it('returns premium request data with model breakdown when items have grossQuantity > 0', async () => {
@@ -578,6 +689,22 @@ describe('githubHandlers', () => {
   })
 
   describe('github:collect-copilot-snapshots', () => {
+    it('rejects an invalid account before invoking gh', async () => {
+      const handler = handlers.get('github:collect-copilot-snapshots')!
+      const result = await handler({}, [{ username: 'baduser; echo injected', org: 'test-org' }])
+
+      expect(result.results).toEqual([
+        {
+          success: false,
+          username: 'baduser; echo injected',
+          org: 'test-org',
+          error: "Invalid GitHub account slug: 'baduser; echo injected'",
+        },
+      ])
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('processes multiple accounts and returns per-account results', async () => {
       const { assembleCopilotMetrics } = await import('../../src/utils/billingParsers')
       vi.mocked(assembleCopilotMetrics).mockReturnValue({
@@ -1208,6 +1335,18 @@ describe('githubHandlers', () => {
   })
 
   describe('github:get-copilot-seats', () => {
+    it('rejects an invalid org before invoking gh', async () => {
+      const handler = handlers.get('github:get-copilot-seats')!
+      const result = await handler({}, 'bad-org; echo injected')
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'bad-org; echo injected'",
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns paginated seat data', async () => {
       const seatPayload = {
         total_seats: 2,
@@ -1237,6 +1376,16 @@ describe('githubHandlers', () => {
       expect(result.data.totalSeats).toBe(2)
       expect(result.data.fetchedSeats).toBe(2)
       expect(result.data.seats).toHaveLength(2)
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        [
+          'api',
+          '/orgs/test-org/copilot/billing/seats?per_page=100&page=1',
+          '-H',
+          'X-GitHub-Api-Version: 2022-11-28',
+        ],
+        expect.objectContaining({ encoding: 'utf8', timeout: 20000 })
+      )
     })
 
     it('paginates when first page has 100 seats and more remain', async () => {
@@ -1294,6 +1443,18 @@ describe('githubHandlers', () => {
   })
 
   describe('github:get-batch-monthly-requests', () => {
+    it('rejects an invalid member login before invoking gh', async () => {
+      const handler = handlers.get('github:get-batch-monthly-requests')!
+      const result = await handler({}, ['baduser; echo injected'], undefined, true)
+
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid GitHub account slug: 'baduser; echo injected'",
+      })
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
     it('returns monthly totals with skipDayProbing', async () => {
       const { sumGrossRequests } = await import('../../src/utils/billingParsers')
       vi.mocked(sumGrossRequests).mockReturnValue(10)
@@ -1309,6 +1470,11 @@ describe('githubHandlers', () => {
       expect(result.success).toBe(true)
       expect(result.data.alice).toEqual({ requests: 10, lastActiveDate: null })
       expect(result.data.bob).toEqual({ requests: 10, lastActiveDate: null })
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['api', expect.stringContaining('user=alice'), '-H', 'X-GitHub-Api-Version: 2022-11-28'],
+        expect.objectContaining({ encoding: 'utf8', timeout: 15000 })
+      )
     })
 
     it('probes backwards for last active date when not skipping', async () => {

--- a/electron/ipc/githubHandlers.ts
+++ b/electron/ipc/githubHandlers.ts
@@ -8,6 +8,7 @@ import { findBudgetAcrossPages } from '../../src/utils/budgetUtils'
 import { IPC_INVOKE } from '../../src/ipc/contracts'
 import {
   parseActiveGitHubAccount,
+  assertValidGitHubAccountSlug,
   buildGhAuthTokenArgs,
   validateCliToken,
 } from '../../src/utils/githubAuthUtils'
@@ -49,14 +50,6 @@ export const PERSONAL_BUDGETS: Record<string, number> = {}
 type ExecAsyncSettledResult = PromiseSettledResult<Awaited<ReturnType<typeof execAsync>>>
 type CliStdoutSettledResult = PromiseSettledResult<{ stdout: string }>
 
-const GITHUB_ACCOUNT_SLUG_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
-
-function assertValidGitHubAccountSlug(org: string): void {
-  if (!GITHUB_ACCOUNT_SLUG_PATTERN.test(org)) {
-    throw new Error(`Invalid GitHub account slug: '${org}'`)
-  }
-}
-
 async function runGhApi(
   endpoint: string,
   execEnv: NodeJS.ProcessEnv,
@@ -79,8 +72,9 @@ async function tryGetCliToken(username?: string): Promise<string | null> {
     return null
   }
 
+  assertValidGitHubAccountSlug(username)
   try {
-    const { stdout } = await execAsync(`gh auth token --user ${username}`, {
+    const { stdout } = await execFileAsync('gh', buildGhAuthTokenArgs(username), {
       encoding: 'utf8',
       timeout: CLI_TIMEOUT_MS,
     })
@@ -161,7 +155,13 @@ export async function fetchCopilotMetrics(
   org: string,
   username?: string
 ): Promise<ReturnType<typeof assembleCopilotMetrics>> {
-  const execEnv = await getTokenEnv(username)
+  let execEnv: NodeJS.ProcessEnv
+  try {
+    assertValidGitHubAccountSlug(org)
+    execEnv = await getTokenEnv(username)
+  } catch (error: unknown) {
+    return { success: false, error: getErrorMessage(error) }
+  }
 
   const now = new Date()
   const year = now.getUTCFullYear()
@@ -462,9 +462,11 @@ async function fetchMonthlyTotals(
     const settled = await Promise.allSettled(
       batch.map(async login => {
         const encoded = encodeURIComponent(login)
-        const { stdout } = await execAsync(
-          `gh api "/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&user=${encoded}&product=Copilot" -H "X-GitHub-Api-Version: 2022-11-28"`,
-          { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+        const { stdout } = await runGhApi(
+          `/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&user=${encoded}&product=Copilot`,
+          execEnv,
+          API_TIMEOUT_MS,
+          ['X-GitHub-Api-Version: 2022-11-28']
         )
         const data = JSON.parse(stdout.trim()) as { usageItems?: PremiumUsageItem[] }
         return { login, requests: sumGrossRequests(data.usageItems ?? []) }
@@ -509,9 +511,11 @@ async function probeBatchDayActivity(
   const settled = await Promise.allSettled(
     batch.map(async login => {
       const encoded = encodeURIComponent(login)
-      const { stdout } = await execAsync(
-        `gh api "/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&day=${day}&user=${encoded}&product=Copilot" -H "X-GitHub-Api-Version: 2022-11-28"`,
-        { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+      const { stdout } = await runGhApi(
+        `/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&day=${day}&user=${encoded}&product=Copilot`,
+        execEnv,
+        API_TIMEOUT_MS,
+        ['X-GitHub-Api-Version: 2022-11-28']
       )
       const data = JSON.parse(stdout.trim()) as { usageItems?: PremiumUsageItem[] }
       return { login, dayRequests: sumGrossRequests(data.usageItems ?? []) }
@@ -589,6 +593,7 @@ async function fetchCopilotSeats(
   fetchedSeats: number
   seats: ReturnType<typeof mapCopilotSeatData>[]
 }> {
+  assertValidGitHubAccountSlug(org)
   const seats: ReturnType<typeof mapCopilotSeatData>[] = []
   let page = 1
   const maxPages = 10
@@ -596,9 +601,11 @@ async function fetchCopilotSeats(
 
   while (page <= maxPages) {
     // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Copilot seats are paginated until the API reports all seats loaded.
-    const { stdout } = await execAsync(
-      `gh api "/orgs/${org}/copilot/billing/seats?per_page=100&page=${page}" -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_LONG_MS, env: execEnv }
+    const { stdout } = await runGhApi(
+      `/orgs/${org}/copilot/billing/seats?per_page=100&page=${page}`,
+      execEnv,
+      API_TIMEOUT_LONG_MS,
+      ['X-GitHub-Api-Version: 2022-11-28']
     )
     const data = JSON.parse(stdout.trim()) as CopilotSeatResponse
 
@@ -614,6 +621,7 @@ async function fetchCopilotSeats(
 
 function registerGitHubAuthHandlers(): void {
   ipcMain.handle(IPC_INVOKE.GITHUB_GET_CLI_TOKEN, async (_event, username?: string) => {
+    if (username) assertValidGitHubAccountSlug(username)
     try {
       const args = buildGhAuthTokenArgs(username)
       const { stdout, stderr } = await execFileAsync('gh', args, {
@@ -644,7 +652,8 @@ function registerGitHubAuthHandlers(): void {
 
   ipcMain.handle(IPC_INVOKE.GITHUB_SWITCH_ACCOUNT, async (_event, username: string) => {
     try {
-      await execAsync(`gh auth switch --user ${username}`, {
+      assertValidGitHubAccountSlug(username)
+      await execFileAsync('gh', ['auth', 'switch', '--user', username], {
         encoding: 'utf8',
         timeout: CLI_TIMEOUT_MS,
       })
@@ -663,11 +672,11 @@ function registerGitHubAuthHandlers(): void {
  * accounts or missing access) so callers can fall back to billing-usage seats.
  */
 async function fetchSeatCount(org: string, execEnv: NodeJS.ProcessEnv): Promise<number | null> {
+  assertValidGitHubAccountSlug(org)
   try {
-    const { stdout } = await execAsync(
-      `gh api /orgs/${org}/copilot/billing -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
-    )
+    const { stdout } = await runGhApi(`/orgs/${org}/copilot/billing`, execEnv, API_TIMEOUT_MS, [
+      'X-GitHub-Api-Version: 2022-11-28',
+    ])
     const data = JSON.parse(stdout.trim()) as { seat_breakdown?: { total?: number } }
     const total = data.seat_breakdown?.total
     return typeof total === 'number' ? total : null
@@ -681,6 +690,7 @@ function registerCopilotUsageHandlers(): void {
     IPC_INVOKE.GITHUB_GET_COPILOT_USAGE,
     async (_event, org: string, username?: string) => {
       try {
+        assertValidGitHubAccountSlug(org)
         const execEnv = await getTokenEnv(username)
         const now = new Date()
         const billingYear = now.getUTCFullYear()
@@ -753,6 +763,7 @@ function registerCopilotUsageHandlers(): void {
     IPC_INVOKE.GITHUB_GET_COPILOT_BUDGET,
     async (_event, org: string, username?: string) => {
       try {
+        assertValidGitHubAccountSlug(org)
         const execEnv = await getTokenEnv(username)
 
         const now = new Date()
@@ -785,12 +796,10 @@ function registerCopilotMemberHandlers(): void {
     IPC_INVOKE.GITHUB_GET_COPILOT_MEMBER_USAGE,
     async (_event, org: string, memberLogin: string, username?: string) => {
       try {
+        assertValidGitHubAccountSlug(org)
+        assertValidGitHubAccountSlug(memberLogin)
         const execEnv = await getTokenEnv(username)
-        const { stdout } = await execAsync(`gh api "/orgs/${org}/members/${memberLogin}/copilot"`, {
-          encoding: 'utf8',
-          timeout: API_TIMEOUT_MS,
-          env: execEnv,
-        })
+        const { stdout } = await runGhApi(`/orgs/${org}/members/${memberLogin}/copilot`, execEnv)
         const seat = JSON.parse(stdout.trim()) as RawCopilotSeat
         return { success: true, data: mapCopilotSeatData(seat, memberLogin) }
       } catch (error: unknown) {
@@ -825,6 +834,8 @@ function registerCopilotMemberHandlers(): void {
 }
 
 async function fetchUserPremiumRequests(org: string, memberLogin: string, username?: string) {
+  assertValidGitHubAccountSlug(org)
+  assertValidGitHubAccountSlug(memberLogin)
   const execEnv = await getTokenEnv(username)
   const now = new Date()
   const year = now.getUTCFullYear()
@@ -833,17 +844,23 @@ async function fetchUserPremiumRequests(org: string, memberLogin: string, userna
   const encodedLogin = encodeURIComponent(memberLogin)
 
   const [userMonthResult, userTodayResult, orgMonthResult] = await Promise.allSettled([
-    execAsync(
-      `gh api "/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&user=${encodedLogin}&product=Copilot" -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    runGhApi(
+      `/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&user=${encodedLogin}&product=Copilot`,
+      execEnv,
+      API_TIMEOUT_MS,
+      ['X-GitHub-Api-Version: 2022-11-28']
     ),
-    execAsync(
-      `gh api "/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&day=${day}&user=${encodedLogin}&product=Copilot" -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    runGhApi(
+      `/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&day=${day}&user=${encodedLogin}&product=Copilot`,
+      execEnv,
+      API_TIMEOUT_MS,
+      ['X-GitHub-Api-Version: 2022-11-28']
     ),
-    execAsync(
-      `gh api "/organizations/${org}/settings/billing/premium_request/usage?year=${year}&month=${month}" -H "X-GitHub-Api-Version: 2022-11-28"`,
-      { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+    runGhApi(
+      `/organizations/${org}/settings/billing/premium_request/usage?year=${year}&month=${month}`,
+      execEnv,
+      API_TIMEOUT_MS,
+      ['X-GitHub-Api-Version: 2022-11-28']
     ),
   ])
 
@@ -887,6 +904,7 @@ async function fetchUserMonthlyCredits(
   memberLogin: string,
   execEnv: NodeJS.ProcessEnv
 ): Promise<number | null> {
+  assertValidGitHubAccountSlug(memberLogin)
   const now = new Date()
   const year = now.getUTCFullYear()
   const month = now.getUTCMonth() + 1
@@ -902,9 +920,11 @@ async function fetchUserMonthlyCredits(
     // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Batches intentionally cap concurrent per-day billing calls.
     const settled = await Promise.allSettled(
       batch.map(async day => {
-        const { stdout } = await execAsync(
-          `gh api "/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&day=${day}&user=${encoded}&product=Copilot" -H "X-GitHub-Api-Version: 2022-11-28"`,
-          { encoding: 'utf8', timeout: API_TIMEOUT_MS, env: execEnv }
+        const { stdout } = await runGhApi(
+          `/enterprises/${ENTERPRISE_SLUG}/settings/billing/premium_request/usage?year=${year}&month=${month}&day=${day}&user=${encoded}&product=Copilot`,
+          execEnv,
+          API_TIMEOUT_MS,
+          ['X-GitHub-Api-Version: 2022-11-28']
         )
         const data = JSON.parse(stdout.trim()) as { usageItems?: PremiumUsageItem[] }
         return sumGrossRequests(data.usageItems ?? [])
@@ -926,6 +946,7 @@ function registerCopilotSeatHandlers(): void {
     IPC_INVOKE.GITHUB_GET_COPILOT_SEATS,
     async (_event, org: string, username?: string) => {
       try {
+        assertValidGitHubAccountSlug(org)
         const execEnv = await getTokenEnv(username)
         return {
           success: true,
@@ -946,6 +967,7 @@ function registerCopilotSeatHandlers(): void {
     IPC_INVOKE.GITHUB_GET_BATCH_MONTHLY_REQUESTS,
     async (_event, logins: string[], username?: string, skipDayProbing?: boolean) => {
       try {
+        for (const login of logins) assertValidGitHubAccountSlug(login)
         const execEnv = await getTokenEnv(username)
         const now = new Date()
         const year = now.getUTCFullYear()

--- a/electron/services/copilotService.test.ts
+++ b/electron/services/copilotService.test.ts
@@ -40,6 +40,8 @@ vi.mock('../config', () => ({
 const mockSendPrompt = vi.fn()
 const mockEnsureClientStarted = vi.fn()
 const mockRestartSharedClient = vi.fn()
+const mockExecAsync = vi.fn().mockResolvedValue({ stdout: 'user\n' })
+const mockExecFileAsync = vi.fn().mockResolvedValue({ stdout: 'user\n', stderr: '' })
 
 vi.mock('./copilotClient', () => ({
   ensureClientStarted: (...args: unknown[]) => mockEnsureClientStarted(...args),
@@ -49,7 +51,8 @@ vi.mock('./copilotClient', () => ({
 }))
 
 vi.mock('../utils', () => ({
-  execAsync: vi.fn().mockResolvedValue({ stdout: 'user\n' }),
+  execAsync: (...args: unknown[]) => mockExecAsync(...args),
+  execFileAsync: (...args: unknown[]) => mockExecFileAsync(...args),
 }))
 
 vi.mock('../../src/utils/errorUtils', () => ({
@@ -199,10 +202,9 @@ describe('copilotService', () => {
 
   describe('switchAccount skip', () => {
     it('skips switch when already on the correct account', async () => {
-      const { execAsync } = await import('../utils')
       const service = getCopilotService()
 
-      // First call: switches to 'testacct' — execAsync is called for gh auth switch
+      // First call switches to 'testacct'.
       await service.executePrompt({
         prompt: 'Review PR',
         category: 'general',
@@ -211,7 +213,7 @@ describe('copilotService', () => {
 
       // Wait for async runPrompt to settle
       await new Promise(r => setTimeout(r, 20))
-      vi.mocked(execAsync).mockClear()
+      mockExecFileAsync.mockClear()
 
       // Second call: same account — should skip switch (lines 133-135)
       await service.executePrompt({
@@ -222,11 +224,22 @@ describe('copilotService', () => {
 
       await new Promise(r => setTimeout(r, 20))
 
-      // execAsync should NOT have been called for 'gh auth switch' again
-      const switchCalls = vi.mocked(execAsync).mock.calls.filter(
-        ([cmd]) => typeof cmd === 'string' && cmd.includes('gh auth switch')
-      )
-      expect(switchCalls).toHaveLength(0)
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
+    })
+
+    it('rejects a metacharacter-bearing account before invoking gh', async () => {
+      const service = getCopilotService()
+
+      await expect(
+        service.executePrompt({
+          prompt: 'Review PR',
+          category: 'general',
+          metadata: { ghAccount: 'testacct; echo injected' },
+        })
+      ).rejects.toThrow("Invalid GitHub account slug: 'testacct; echo injected'")
+
+      expect(mockExecAsync).not.toHaveBeenCalled()
+      expect(mockExecFileAsync).not.toHaveBeenCalled()
     })
   })
 
@@ -269,10 +282,9 @@ describe('copilotService', () => {
       const service = getCopilotService()
       await service.listModels('other-user')
 
-      // execAsync called with gh auth switch
-      const { execAsync } = await import('../utils')
-      expect(execAsync).toHaveBeenCalledWith(
-        expect.stringContaining('gh auth switch --user other-user'),
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['auth', 'switch', '--user', 'other-user'],
         expect.anything()
       )
     })
@@ -313,7 +325,6 @@ describe('copilotService', () => {
   describe('executePrompt — account auto-resolution', () => {
     it('auto-resolves account from GitHub URLs in prompt', async () => {
       const { findAccountForOrgs } = await import('../../src/utils/copilotPromptUtils')
-      const { execAsync } = await import('../utils')
 
       vi.mocked(findAccountForOrgs).mockReturnValueOnce('auto-user-from-url')
       mockQuery.mockResolvedValueOnce([])
@@ -326,8 +337,9 @@ describe('copilotService', () => {
 
       expect(mockQuery).toHaveBeenCalledWith('githubAccounts:list', {})
       expect(findAccountForOrgs).toHaveBeenCalledWith([], ['myorg'])
-      expect(execAsync).toHaveBeenCalledWith(
-        expect.stringContaining('gh auth switch --user auto-user-from-url'),
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['auth', 'switch', '--user', 'auto-user-from-url'],
         expect.anything()
       )
     })
@@ -400,8 +412,7 @@ describe('copilotService', () => {
     })
 
     it('continues when gh auth switch fails', async () => {
-      const { execAsync } = await import('../utils')
-      vi.mocked(execAsync).mockRejectedValueOnce(new Error('switch failed'))
+      mockExecFileAsync.mockRejectedValueOnce(new Error('switch failed'))
 
       const service = getCopilotService()
       const result = await service.executePrompt({
@@ -411,8 +422,9 @@ describe('copilotService', () => {
       })
 
       expect(result.success).toBe(true)
-      expect(execAsync).toHaveBeenCalledWith(
-        expect.stringContaining('gh auth switch --user failing-user-explicit'),
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['auth', 'switch', '--user', 'failing-user-explicit'],
         expect.anything()
       )
     })

--- a/electron/services/copilotService.test.ts
+++ b/electron/services/copilotService.test.ts
@@ -278,6 +278,16 @@ describe('copilotService', () => {
       await expect(service.listModels()).rejects.toThrow('not connected')
     })
 
+    it('does not retry non-retryable errors', async () => {
+      const service = getCopilotService()
+      mockEnsureClientStarted.mockRejectedValue(new Error('permission denied'))
+
+      await expect(service.listModels()).rejects.toThrow('permission denied')
+
+      expect(mockEnsureClientStarted).toHaveBeenCalledTimes(1)
+      expect(mockRestartSharedClient).not.toHaveBeenCalled()
+    })
+
     it('switches account before listing if ghAccount provided', async () => {
       const service = getCopilotService()
       await service.listModels('other-user')

--- a/electron/services/copilotService.ts
+++ b/electron/services/copilotService.ts
@@ -20,7 +20,8 @@ import {
 } from './copilotClient'
 import { CONVEX_URL } from '../config'
 import { getErrorMessage } from '../../src/utils/errorUtils'
-import { execAsync } from '../utils'
+import { assertValidGitHubAccountSlug } from '../../src/utils/githubAuthUtils'
+import { execFileAsync } from '../utils'
 import {
   hasPRReviewMetadata,
   mapModelInfo,
@@ -129,6 +130,8 @@ class CopilotService {
    * effect.  We track the current account to avoid unnecessary restarts.
    */
   private async switchAccount(ghAccount: string): Promise<void> {
+    assertValidGitHubAccountSlug(ghAccount)
+
     // Skip if already on the correct account
     if (this.currentGhAccount === ghAccount) {
       console.log(`[CopilotService] Already on account "${ghAccount}" — skipping switch`)
@@ -137,7 +140,7 @@ class CopilotService {
 
     try {
       console.log(`[CopilotService] Switching to gh CLI account: ${ghAccount}`)
-      await execAsync(`gh auth switch --user ${ghAccount}`, {
+      await execFileAsync('gh', ['auth', 'switch', '--user', ghAccount], {
         encoding: 'utf8',
         timeout: 5000,
       })

--- a/electron/services/copilotService.ts
+++ b/electron/services/copilotService.ts
@@ -345,6 +345,7 @@ IMPORTANT: Format your entire response as clean, well-structured Markdown. Use h
           await restartSharedClient()
           continue
         }
+        break
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.899",
+  "version": "0.1.900",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.900",
+  "version": "0.1.902",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.898",
+  "version": "0.1.899",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/utils/githubAuthUtils.test.ts
+++ b/src/utils/githubAuthUtils.test.ts
@@ -1,10 +1,26 @@
 import { describe, it, expect, vi } from 'vitest'
 import {
   parseActiveGitHubAccount,
+  assertValidGitHubAccountSlug,
   buildGhAuthTokenArgs,
   isNonFatalGhStderr,
   validateCliToken,
 } from './githubAuthUtils'
+
+describe('assertValidGitHubAccountSlug', () => {
+  it.each(['octocat', 'test-org', 'A1', 'a'.repeat(39)])('accepts valid slug %s', slug => {
+    expect(() => assertValidGitHubAccountSlug(slug)).not.toThrow()
+  })
+
+  it.each(['org; echo injected', 'user$(whoami)', '-leading', 'trailing-', 'a'.repeat(40)])(
+    'rejects invalid slug %s',
+    slug => {
+      expect(() => assertValidGitHubAccountSlug(slug)).toThrow(
+        `Invalid GitHub account slug: '${slug}'`
+      )
+    }
+  )
+})
 
 describe('parseActiveGitHubAccount', () => {
   it('returns the active account from gh auth status output', () => {
@@ -75,6 +91,12 @@ describe('buildGhAuthTokenArgs', () => {
 
   it('appends --user flag when username provided', () => {
     expect(buildGhAuthTokenArgs('octocat')).toEqual(['auth', 'token', '--user', 'octocat'])
+  })
+
+  it('rejects shell metacharacters instead of building arguments', () => {
+    expect(() => buildGhAuthTokenArgs('octocat; echo injected')).toThrow(
+      "Invalid GitHub account slug: 'octocat; echo injected'"
+    )
   })
 })
 

--- a/src/utils/githubAuthUtils.ts
+++ b/src/utils/githubAuthUtils.ts
@@ -5,6 +5,15 @@
  * parsing and policy logic is testable without exec calls.
  */
 
+const GITHUB_ACCOUNT_SLUG_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/
+
+/** Reject values that cannot be GitHub account, organization, or login slugs. */
+export function assertValidGitHubAccountSlug(slug: string): void {
+  if (!GITHUB_ACCOUNT_SLUG_PATTERN.test(slug)) {
+    throw new Error(`Invalid GitHub account slug: '${slug}'`)
+  }
+}
+
 /**
  * Parse `gh auth status` stderr to find the active GitHub account.
  * Returns the account name or null if none is active.
@@ -30,7 +39,10 @@ export function parseActiveGitHubAccount(stderr: string): string | null {
  */
 export function buildGhAuthTokenArgs(username?: string): string[] {
   const args = ['auth', 'token']
-  if (username) args.push('--user', username)
+  if (username) {
+    assertValidGitHubAccountSlug(username)
+    args.push('--user', username)
+  }
   return args
 }
 


### PR DESCRIPTION
## Summary
- replace renderer-controlled GitHub CLI shell interpolation with `execFileAsync('gh', argv)`
- validate account, organization, and member/login slugs before command execution
- add metacharacter regression coverage for GitHub IPC and Copilot account switching

## Verification
- `bun run typecheck` — passed
- `bun run test:electron` — 44 files, 874 tests passed
- `bun run security:electron` — 47 files scanned, 0 findings
- `bun run test:coverage` — 292 files, 6552 tests passed

## Risk acknowledgment
High risk: these paths execute operating-system commands. The change preserves valid GitHub CLI account and Copilot behavior while removing shell interpretation from renderer-controlled identifiers.

Closes #303

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent shell injection in GitHub IPC handlers by validating account slugs
> - Adds `assertValidGitHubAccountSlug` in [`src/utils/githubAuthUtils.ts`](https://github.com/HemSoft/hs-buddy/pull/312/files#diff-988eb736b027eab7bd0f2e22f6e1857500acb0b6306c0c8f603e0b75c6f634a9) that throws on slugs containing shell metacharacters (e.g. `;`).
> - Applies this validation before any `gh` invocation across all GitHub IPC handlers in [`electron/ipc/githubHandlers.ts`](https://github.com/HemSoft/hs-buddy/pull/312/files#diff-f84a9b8e1b26a344ab9375a65a775761c30264af180eb417a49006ace6a28034) and `copilotService.switchAccount`.
> - Replaces `execAsync` string-based `gh` calls with `execFileAsync` argv-array calls throughout, eliminating shell interpolation.
> - Fixes a bug in `listModels` where non-retryable errors were still retried; the loop now breaks immediately on a non-retryable error.
> - Behavioral Change: invalid usernames, org slugs, or member logins now throw/return errors immediately rather than being passed to `gh`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21b449f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->