### PR TITLE
fix(deps): upgrade brace-expansion to 5.0.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -96,7 +96,7 @@
     "@babel/core": "^7.29.1",
     "@grpc/grpc-js": "^1.14.4",
     "body-parser": "^1.20.6",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.8",
     "electron-builder-squirrel-windows": "26.15.3",
     "fast-uri": "^3.1.4",
     "form-data": "^4.0.6",
@@ -1010,7 +1010,7 @@
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
-    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
+    "brace-expansion": ["brace-expansion@5.0.8", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 

--- a/package.json
+++ b/package.json
@@ -155,7 +155,7 @@
   "overrides": {
     "@babel/core": "^7.29.1",
     "body-parser": "^1.20.6",
-    "brace-expansion": "^5.0.7",
+    "brace-expansion": "^5.0.8",
     "electron-builder-squirrel-windows": "26.15.3",
     "@grpc/grpc-js": "^1.14.4",
     "fast-uri": "^3.1.4",


### PR DESCRIPTION
Closes #304

## Summary
- raise the `brace-expansion` override from `^5.0.7` to `^5.0.8`
- regenerate `bun.lock` so all dependency paths resolve the patched `5.0.8` release
- avoid unrelated or incompatible dependency upgrades

## Verification
- `bun install --frozen-lockfile` — passed (no changes)
- `bun audit` — passed (`No vulnerabilities found`)
- `bun run typecheck` — passed
- `bun run lint` — passed
- `bun run knip` — passed
- `bun run test` — passed (292 files, 6,552 tests)

## Risk Acknowledgment
**Medium risk.** The override affects lint, glob, Electron packaging, and test-tool dependency chains. The change is constrained to the patched release and the full requested quality gates passed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade `brace-expansion` dependency to 5.0.8
> Bumps `brace-expansion` in [package.json](https://github.com/HemSoft/hs-buddy/pull/313/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) from `^5.0.7` to `^5.0.8` and updates the lockfile accordingly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb747fc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->