### PR TITLE
fix(sfl): preserve stalled PR count

### DIFF
--- a/.github/workflows/sfl-auditor.yml
+++ b/.github/workflows/sfl-auditor.yml
@@ -300,8 +300,7 @@ jobs:
           gh pr list --repo "$REPO" --state open --draft \
             --json number,headRefName,createdAt,body,comments --limit 100 > /tmp/draft_prs.json
 
-          jq -c '[.[] | select(.headRefName | startswith("agent-fix/issue-"))] | .[]' \
-            /tmp/draft_prs.json | while IFS= read -r ROW; do
+          while IFS= read -r ROW; do
             PR_NUM=$(echo "$ROW" | jq '.number')
             CREATED=$(echo "$ROW" | jq -r '.createdAt')
 
@@ -333,7 +332,8 @@ jobs:
               --body "⏰ **SFL Auditor**: Draft PR #$PR_NUM has been open for over 2 hours and is missing one or more analyzer markers. The PR Analyzers may not be dispatching for this PR. A human should investigate."
 
             FOUND=$((FOUND + 1))
-          done
+          done < <(jq -c '[.[] | select(.headRefName | startswith("agent-fix/issue-"))] | .[]' \
+            /tmp/draft_prs.json)
 
           echo "stalled_prs_found=$FOUND" >> "$GITHUB_OUTPUT"
           echo "Found $FOUND stalled draft PRs"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.904] - 2026-07-25
+
+### Fixed
+
+- Preserve stalled PR count
+
 ## [0.1.902] - 2026-07-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.902",
+  "version": "0.1.904",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/sfl-auditor-stalled-prs.test.ts
+++ b/scripts/sfl-auditor-stalled-prs.test.ts
@@ -1,0 +1,91 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const workflowPath = join(import.meta.dirname, '..', '.github', 'workflows', 'sfl-auditor.yml')
+const temporaryDirectories: string[] = []
+
+function stalledPrScript(): string {
+  const workflow = readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n')
+  const marker = '        id: stalled-prs\n        run: |\n'
+  const start = workflow.indexOf(marker)
+  const nextStep = workflow.indexOf('\n      - name:', start + marker.length)
+
+  expect(start).toBeGreaterThanOrEqual(0)
+  expect(nextStep).toBeGreaterThan(start)
+
+  return workflow
+    .slice(start + marker.length, nextStep)
+    .split('\n')
+    .map(line => line.slice(10))
+    .join('\n')
+}
+
+function bashExecutable(): string {
+  const gitBash = String.raw`C:\Program Files\Git\bin\bash.exe`
+  return process.platform === 'win32' && existsSync(gitBash) ? gitBash : 'bash'
+}
+
+function runStalledPrCheck(draftPrs: unknown[]): string {
+  const directory = mkdtempSync(join(tmpdir(), 'sfl-auditor-'))
+  temporaryDirectories.push(directory)
+
+  const fixturePath = join(directory, 'draft-prs.json')
+  const outputPath = join(directory, 'github-output')
+  const commentsPath = join(directory, 'comments')
+  writeFileSync(fixturePath, JSON.stringify(draftPrs))
+
+  const mockGh = `
+gh() {
+  if [ "$1 $2" = "pr list" ]; then
+    cat "$DRAFT_PRS_FIXTURE"
+    return
+  fi
+  if [ "$1 $2" = "pr comment" ]; then
+    echo "$3" >> "$COMMENTS_LOG"
+    return
+  fi
+  return 1
+}
+`
+  const result = spawnSync(bashExecutable(), ['-s'], {
+    input: `${mockGh}\n${stalledPrScript()}`,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      COMMENTS_LOG: commentsPath,
+      DRAFT_PRS_FIXTURE: fixturePath,
+      GITHUB_OUTPUT: outputPath,
+      REPO: 'HemSoft/hs-buddy',
+    },
+  })
+
+  expect(result.status).toBe(0)
+  return readFileSync(outputPath, 'utf8')
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('SFL Auditor stalled draft PR counter', () => {
+  it('writes zero when no draft PR qualifies', () => {
+    expect(runStalledPrCheck([])).toContain('stalled_prs_found=0')
+  })
+
+  it('writes one when a stalled draft PR lacks analyzer markers', () => {
+    const draftPr = {
+      body: '',
+      comments: [],
+      createdAt: '2020-01-01T00:00:00Z',
+      headRefName: 'agent-fix/issue-305',
+      number: 42,
+    }
+
+    expect(runStalledPrCheck([draftPr])).toContain('stalled_prs_found=1')
+  })
+})


### PR DESCRIPTION
Closes #305

## Summary
- keep the stalled draft PR loop in the parent shell so FOUND persists
- execute the workflow block against zero-result and one-result fixtures

## Verification
- bun run test (6,554 passed)
- bun run lint
- bun run typecheck
- actionlint .github/workflows/sfl-auditor.yml

## Risk
Medium: changes SFL Auditor control flow; fixture coverage verifies zero and nonzero counts.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `stalled_prs_found` counter loss in SFL auditor stalled PR detection
> The `stalled-prs` step in [sfl-auditor.yml](https://github.com/HemSoft/hs-buddy/pull/314/files#diff-871c9c437b0ae7a3987de479721d38de0539c8e3436f281c2a43a4defb321233) ran `jq ... | while read` in a pipeline, causing the `FOUND` counter to be incremented in a subshell and lost before being written to `GITHUB_OUTPUT`. Fixes this by switching to process substitution (`while read ... < <(jq ...)`), so the counter updates in the parent shell. A Vitest test in [sfl-auditor-stalled-prs.test.ts](https://github.com/HemSoft/hs-buddy/pull/314/files#diff-2eebec5cbdcba351a408ff0f00819b55417bba6783f2d07c58ce693d9fb3feb7) is added to cover zero and one qualifying stalled draft PR cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e283140.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->