### PR TITLE
fix(sfl): make stalled PR warnings idempotent

### DIFF
--- a/.github/workflows/sfl-auditor.yml
+++ b/.github/workflows/sfl-auditor.yml
@@ -321,8 +321,9 @@ jobs:
 
             # Recognize both the stable marker and warnings emitted before the marker existed.
             COMMENTS=$(echo "$ROW" | jq -r '.comments[].body // ""')
+            LEGACY_WARNING_REGEX='⏰ \*\*(SFL Auditor|PR Promoter)\*\*:.*missing (one or more )?analyzer markers'
             ALREADY_FLAGGED=$(echo "$COMMENTS" \
-              | grep -Ec '<!-- sfl-auditor:stalled-pr-missing-analyzers -->|missing (one or more )?analyzer markers' \
+              | grep -Ec "<!-- sfl-auditor:stalled-pr-missing-analyzers -->|$LEGACY_WARNING_REGEX" \
               || true)
             if [ "$ALREADY_FLAGGED" -gt 0 ]; then
               continue

--- a/.github/workflows/sfl-auditor.yml
+++ b/.github/workflows/sfl-auditor.yml
@@ -319,9 +319,11 @@ jobs:
               continue
             fi
 
-            # Check if already flagged (in comments)
+            # Recognize both the stable marker and warnings emitted before the marker existed.
             COMMENTS=$(echo "$ROW" | jq -r '.comments[].body // ""')
-            ALREADY_FLAGGED=$(echo "$COMMENTS" | grep -c 'missing analyzer markers' || echo 0)
+            ALREADY_FLAGGED=$(echo "$COMMENTS" \
+              | grep -Ec '<!-- sfl-auditor:stalled-pr-missing-analyzers -->|missing (one or more )?analyzer markers' \
+              || true)
             if [ "$ALREADY_FLAGGED" -gt 0 ]; then
               continue
             fi
@@ -329,7 +331,8 @@ jobs:
             echo "Draft PR #$PR_NUM is older than 2 hours and missing analyzer markers"
 
             gh pr comment "$PR_NUM" --repo "$REPO" \
-              --body "⏰ **SFL Auditor**: Draft PR #$PR_NUM has been open for over 2 hours and is missing one or more analyzer markers. The PR Analyzers may not be dispatching for this PR. A human should investigate."
+              --body "<!-- sfl-auditor:stalled-pr-missing-analyzers -->
+            ⏰ **SFL Auditor**: Draft PR #$PR_NUM has been open for over 2 hours and is missing one or more analyzer markers. The PR Analyzers may not be dispatching for this PR. A human should investigate."
 
             FOUND=$((FOUND + 1))
           done < <(jq -c '[.[] | select(.headRefName | startswith("agent-fix/issue-"))] | .[]' \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.907] - 2026-07-25
+
+### Changed
+
+- Satisfy quality gate
+
 ## [0.1.906] - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.905] - 2026-07-25
+
+### Fixed
+
+- Make stalled PR warnings idempotent
+
 ## [0.1.904] - 2026-07-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.906] - 2026-07-25
+
+### Fixed
+
+- Scope legacy warning detection
+
 ## [0.1.905] - 2026-07-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.905",
+  "version": "0.1.906",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.904",
+  "version": "0.1.905",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.906",
+  "version": "0.1.907",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/sfl-auditor-stalled-prs.test.ts
+++ b/scripts/sfl-auditor-stalled-prs.test.ts
@@ -146,4 +146,42 @@ describe('SFL Auditor stalled draft PR counter', () => {
     expect(result.output).toContain('stalled_prs_found=0')
     expect(result.comments).toBe('')
   })
+
+  it('recognizes the documented legacy warning wording', () => {
+    const result = runStalledPrCheck([
+      {
+        body: '',
+        comments: [
+          {
+            body: '⏰ **SFL Auditor**: Draft PR #42 is missing analyzer markers.',
+          },
+        ],
+        createdAt: '2020-01-01T00:00:00Z',
+        headRefName: 'agent-fix/issue-306',
+        number: 42,
+      },
+    ])
+
+    expect(result.output).toContain('stalled_prs_found=0')
+    expect(result.comments).toBe('')
+  })
+
+  it('does not treat unrelated reviewer text as an auditor warning', () => {
+    const result = runStalledPrCheck([
+      {
+        body: '',
+        comments: [
+          {
+            body: 'Review note: this test discusses missing analyzer markers.',
+          },
+        ],
+        createdAt: '2020-01-01T00:00:00Z',
+        headRefName: 'agent-fix/issue-306',
+        number: 42,
+      },
+    ])
+
+    expect(result.output).toContain('stalled_prs_found=1')
+    expect(result.comments).toContain('<!-- sfl-auditor:stalled-pr-missing-analyzers -->')
+  })
 })

--- a/scripts/sfl-auditor-stalled-prs.test.ts
+++ b/scripts/sfl-auditor-stalled-prs.test.ts
@@ -28,7 +28,12 @@ function bashExecutable(): string {
   return process.platform === 'win32' && existsSync(gitBash) ? gitBash : 'bash'
 }
 
-function runStalledPrCheck(draftPrs: unknown[]): string {
+interface StalledPrCheckResult {
+  comments: string
+  output: string
+}
+
+function runStalledPrCheck(draftPrs: unknown[]): StalledPrCheckResult {
   const directory = mkdtempSync(join(tmpdir(), 'sfl-auditor-'))
   temporaryDirectories.push(directory)
 
@@ -44,8 +49,15 @@ gh() {
     return
   fi
   if [ "$1 $2" = "pr comment" ]; then
-    echo "$3" >> "$COMMENTS_LOG"
-    return
+    shift 2
+    while [ "$#" -gt 0 ]; do
+      if [ "$1" = "--body" ]; then
+        printf '%s\n' "$2" >> "$COMMENTS_LOG"
+        return
+      fi
+      shift
+    done
+    return 1
   fi
   return 1
 }
@@ -63,7 +75,10 @@ gh() {
   })
 
   expect(result.status).toBe(0)
-  return readFileSync(outputPath, 'utf8')
+  return {
+    comments: existsSync(commentsPath) ? readFileSync(commentsPath, 'utf8') : '',
+    output: readFileSync(outputPath, 'utf8'),
+  }
 }
 
 afterEach(() => {
@@ -74,7 +89,7 @@ afterEach(() => {
 
 describe('SFL Auditor stalled draft PR counter', () => {
   it('writes zero when no draft PR qualifies', () => {
-    expect(runStalledPrCheck([])).toContain('stalled_prs_found=0')
+    expect(runStalledPrCheck([]).output).toContain('stalled_prs_found=0')
   })
 
   it('writes one when a stalled draft PR lacks analyzer markers', () => {
@@ -86,6 +101,49 @@ describe('SFL Auditor stalled draft PR counter', () => {
       number: 42,
     }
 
-    expect(runStalledPrCheck([draftPr])).toContain('stalled_prs_found=1')
+    const result = runStalledPrCheck([draftPr])
+
+    expect(result.output).toContain('stalled_prs_found=1')
+    expect(result.comments).toContain('<!-- sfl-auditor:stalled-pr-missing-analyzers -->')
+  })
+
+  it('does not post the emitted warning twice for the same PR', () => {
+    const draftPr = {
+      body: '',
+      comments: [],
+      createdAt: '2020-01-01T00:00:00Z',
+      headRefName: 'agent-fix/issue-306',
+      number: 42,
+    }
+    const firstRun = runStalledPrCheck([draftPr])
+    const secondRun = runStalledPrCheck([
+      {
+        ...draftPr,
+        comments: [{ body: firstRun.comments }],
+      },
+    ])
+
+    expect(firstRun.output).toContain('stalled_prs_found=1')
+    expect(secondRun.output).toContain('stalled_prs_found=0')
+    expect(secondRun.comments).toBe('')
+  })
+
+  it('recognizes warning text emitted before the stable marker existed', () => {
+    const result = runStalledPrCheck([
+      {
+        body: '',
+        comments: [
+          {
+            body: '⏰ **SFL Auditor**: Draft PR #42 has been open for over 2 hours and is missing one or more analyzer markers.',
+          },
+        ],
+        createdAt: '2020-01-01T00:00:00Z',
+        headRefName: 'agent-fix/issue-306',
+        number: 42,
+      },
+    ])
+
+    expect(result.output).toContain('stalled_prs_found=0')
+    expect(result.comments).toBe('')
   })
 })

--- a/scripts/sfl-auditor-stalled-prs.test.ts
+++ b/scripts/sfl-auditor-stalled-prs.test.ts
@@ -33,16 +33,7 @@ interface StalledPrCheckResult {
   output: string
 }
 
-function runStalledPrCheck(draftPrs: unknown[]): StalledPrCheckResult {
-  const directory = mkdtempSync(join(tmpdir(), 'sfl-auditor-'))
-  temporaryDirectories.push(directory)
-
-  const fixturePath = join(directory, 'draft-prs.json')
-  const outputPath = join(directory, 'github-output')
-  const commentsPath = join(directory, 'comments')
-  writeFileSync(fixturePath, JSON.stringify(draftPrs))
-
-  const mockGh = `
+const mockGh = `
 gh() {
   if [ "$1 $2" = "pr list" ]; then
     cat "$DRAFT_PRS_FIXTURE"
@@ -62,6 +53,16 @@ gh() {
   return 1
 }
 `
+
+function runStalledPrCheck(draftPrs: unknown[]): StalledPrCheckResult {
+  const directory = mkdtempSync(join(tmpdir(), 'sfl-auditor-'))
+  temporaryDirectories.push(directory)
+
+  const fixturePath = join(directory, 'draft-prs.json')
+  const outputPath = join(directory, 'github-output')
+  const commentsPath = join(directory, 'comments')
+  writeFileSync(fixturePath, JSON.stringify(draftPrs))
+
   const result = spawnSync(bashExecutable(), ['-s'], {
     input: `${mockGh}\n${stalledPrScript()}`,
     encoding: 'utf8',
@@ -127,7 +128,9 @@ describe('SFL Auditor stalled draft PR counter', () => {
     expect(secondRun.output).toContain('stalled_prs_found=0')
     expect(secondRun.comments).toBe('')
   })
+})
 
+describe('SFL Auditor stalled draft PR warning detection', () => {
   it('recognizes warning text emitted before the stable marker existed', () => {
     const result = runStalledPrCheck([
       {


### PR DESCRIPTION
Closes #306

## Summary
- add a stable machine-readable marker to stalled-PR warnings
- recognize scoped legacy warning text before commenting
- cover duplicate suppression, legacy wording, and unrelated reviewer text

## Verification
- `bun run test` (293 files, 6,558 tests)
- `bun run test:coverage` (99.83% statements, 99.62% branches, 100% functions, 99.91% lines)
- `bun run lint`
- `bun run lint:quality`
- `bun run typecheck`
- `bun run knip`
- `bunx prettier --check scripts/sfl-auditor-stalled-prs.test.ts`

## Risk
Medium: this changes SFL Auditor comment-detection behavior. Regression tests cover fresh warnings, repeated runs, legacy warning text, and false-positive avoidance.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make stalled PR warnings idempotent in the SFL auditor workflow
> - The stalled PR auditor in [sfl-auditor.yml](.github/workflows/sfl-auditor.yml) now embeds a stable HTML marker (`<!-- sfl-auditor:stalled-pr-missing-analyzers -->`) at the top of each warning comment.
> - Before posting, the auditor checks for this marker or a legacy warning phrasing (from either 'SFL Auditor' or 'PR Promoter') using an extended regex, preventing duplicate comments on subsequent runs.
> - Tests in [sfl-auditor-stalled-prs.test.ts](https://github.com/HemSoft/hs-buddy/pull/315/files#diff-2eebec5cbdcba351a408ff0f00819b55417bba6783f2d07c58ce693d9fb3feb7) are updated to assert marker presence and idempotency, and a new suite covers legacy warning detection edge cases.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e73cb1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->