### PR TITLE
ci: publish SFL Auditor results to job summary

### DIFF
--- a/.github/workflows/sfl-auditor.yml
+++ b/.github/workflows/sfl-auditor.yml
@@ -382,22 +382,24 @@ jobs:
 
           TOTAL=$((ORPHANED_LABELS + PR_FALLBACKS + DUPLICATES + CONFLICTING + ORPHANED_PRS + STALE_UNCLAIMED + STALLED_PRS + PAUSED))
 
-          echo "## SFL Auditor Summary"
-          echo ""
-          echo "| Check | Count |"
-          echo "|-------|-------|"
-          echo "| Orphaned in-progress labels fixed | $ORPHANED_LABELS |"
-          echo "| PR fallback issues closed | $PR_FALLBACKS |"
-          echo "| Duplicate action-item issues closed | $DUPLICATES |"
-          echo "| Conflicting labels fixed | $CONFLICTING |"
-          echo "| Orphaned agent PRs flagged | $ORPHANED_PRS |"
-          echo "| Stale unclaimed issues flagged | $STALE_UNCLAIMED |"
-          echo "| Stalled draft PRs flagged | $STALLED_PRS |"
-          echo "| Unexplained pauses flagged | $PAUSED |"
-          echo ""
+          {
+            echo "## SFL Auditor Summary"
+            echo ""
+            echo "| Check | Count |"
+            echo "|-------|-------|"
+            echo "| Orphaned in-progress labels fixed | $ORPHANED_LABELS |"
+            echo "| PR fallback issues closed | $PR_FALLBACKS |"
+            echo "| Duplicate action-item issues closed | $DUPLICATES |"
+            echo "| Conflicting labels fixed | $CONFLICTING |"
+            echo "| Orphaned agent PRs flagged | $ORPHANED_PRS |"
+            echo "| Stale unclaimed issues flagged | $STALE_UNCLAIMED |"
+            echo "| Stalled draft PRs flagged | $STALLED_PRS |"
+            echo "| Unexplained pauses flagged | $PAUSED |"
+            echo ""
 
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "All checks passed — no discrepancies found."
-          else
-            echo "Found and addressed $TOTAL discrepancies."
-          fi
+            if [ "$TOTAL" -eq 0 ]; then
+              echo "All checks passed — no discrepancies found."
+            else
+              echo "Found and addressed $TOTAL discrepancies."
+            fi
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.909] - 2026-07-25
+
+### Changed
+
+- Assert complete auditor summary
+
 ## [0.1.908] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.908] - 2026-07-25
+
+### Changed
+
+- Publish SFL auditor summary
+
 ## [0.1.907] - 2026-07-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.908",
+  "version": "0.1.909",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.907",
+  "version": "0.1.908",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/scripts/sfl-auditor-summary.test.ts
+++ b/scripts/sfl-auditor-summary.test.ts
@@ -93,8 +93,21 @@ describe('SFL Auditor summary', () => {
     })
 
     expect(result.summary).toBe(result.log)
-    expect(result.summary).toContain('| Unexplained pauses flagged | 0 |')
-    expect(result.summary).toContain('All checks passed — no discrepancies found.')
+    expect(result.summary).toBe(`## SFL Auditor Summary
+
+| Check | Count |
+|-------|-------|
+| Orphaned in-progress labels fixed | 0 |
+| PR fallback issues closed | 0 |
+| Duplicate action-item issues closed | 0 |
+| Conflicting labels fixed | 0 |
+| Orphaned agent PRs flagged | 0 |
+| Stale unclaimed issues flagged | 0 |
+| Stalled draft PRs flagged | 0 |
+| Unexplained pauses flagged | 0 |
+
+All checks passed — no discrepancies found.
+`)
   })
 
   it('publishes a valid nonzero-discrepancy table while retaining the step log', () => {
@@ -110,9 +123,20 @@ describe('SFL Auditor summary', () => {
     })
 
     expect(result.summary).toBe(result.log)
-    expect(result.summary).toContain('| Orphaned in-progress labels fixed | 1 |')
-    expect(result.summary).toContain('| Duplicate action-item issues closed | 2 |')
-    expect(result.summary).toContain('| Stalled draft PRs flagged | 1 |')
-    expect(result.summary).toContain('Found and addressed 4 discrepancies.')
+    expect(result.summary).toBe(`## SFL Auditor Summary
+
+| Check | Count |
+|-------|-------|
+| Orphaned in-progress labels fixed | 1 |
+| PR fallback issues closed | 0 |
+| Duplicate action-item issues closed | 2 |
+| Conflicting labels fixed | 0 |
+| Orphaned agent PRs flagged | 0 |
+| Stale unclaimed issues flagged | 0 |
+| Stalled draft PRs flagged | 1 |
+| Unexplained pauses flagged | 0 |
+
+Found and addressed 4 discrepancies.
+`)
   })
 })

--- a/scripts/sfl-auditor-summary.test.ts
+++ b/scripts/sfl-auditor-summary.test.ts
@@ -1,0 +1,118 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const workflowPath = join(import.meta.dirname, '..', '.github', 'workflows', 'sfl-auditor.yml')
+const temporaryDirectories: string[] = []
+
+interface AuditorCounts {
+  conflicting: number
+  duplicates: number
+  orphanedLabels: number
+  orphanedPrs: number
+  paused: number
+  prFallbacks: number
+  staleUnclaimed: number
+  stalledPrs: number
+}
+
+const outputExpressions: Record<keyof AuditorCounts, string> = {
+  conflicting: '${{ steps.conflicting.outputs.conflicting_fixed }}',
+  duplicates: '${{ steps.duplicate-issues.outputs.duplicate_issues_closed }}',
+  orphanedLabels: '${{ steps.orphaned-labels.outputs.orphaned_labels_fixed }}',
+  orphanedPrs: '${{ steps.orphaned-prs.outputs.orphaned_prs_found }}',
+  paused: '${{ steps.paused.outputs.unexplained_pause_found }}',
+  prFallbacks: '${{ steps.pr-fallbacks.outputs.pr_fallbacks_fixed }}',
+  staleUnclaimed: '${{ steps.stale-unclaimed.outputs.stale_unclaimed_found }}',
+  stalledPrs: '${{ steps.stalled-prs.outputs.stalled_prs_found }}',
+}
+
+function summaryScript(counts: AuditorCounts): string {
+  const workflow = readFileSync(workflowPath, 'utf8').replaceAll('\r\n', '\n')
+  const marker = '      - name: Summary\n        run: |\n'
+  const start = workflow.indexOf(marker)
+
+  expect(start).toBeGreaterThanOrEqual(0)
+
+  let script = workflow
+    .slice(start + marker.length)
+    .split('\n')
+    .map(line => line.slice(10))
+    .join('\n')
+
+  for (const [name, expression] of Object.entries(outputExpressions)) {
+    script = script.replaceAll(expression, String(counts[name as keyof AuditorCounts]))
+  }
+
+  return script
+}
+
+function bashExecutable(): string {
+  const gitBash = String.raw`C:\Program Files\Git\bin\bash.exe`
+  return process.platform === 'win32' && existsSync(gitBash) ? gitBash : 'bash'
+}
+
+function runSummary(counts: AuditorCounts): { log: string; summary: string } {
+  const directory = mkdtempSync(join(tmpdir(), 'sfl-auditor-summary-'))
+  temporaryDirectories.push(directory)
+  const summaryPath = join(directory, 'summary.md')
+  const result = spawnSync(bashExecutable(), ['-s'], {
+    input: summaryScript(counts),
+    encoding: 'utf8',
+    env: { ...process.env, GITHUB_STEP_SUMMARY: summaryPath },
+  })
+
+  expect(result.stderr).toBe('')
+  expect(result.status).toBe(0)
+
+  return {
+    log: result.stdout,
+    summary: readFileSync(summaryPath, 'utf8'),
+  }
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('SFL Auditor summary', () => {
+  it('publishes a valid zero-discrepancy table while retaining the step log', () => {
+    const result = runSummary({
+      conflicting: 0,
+      duplicates: 0,
+      orphanedLabels: 0,
+      orphanedPrs: 0,
+      paused: 0,
+      prFallbacks: 0,
+      staleUnclaimed: 0,
+      stalledPrs: 0,
+    })
+
+    expect(result.summary).toBe(result.log)
+    expect(result.summary).toContain('| Unexplained pauses flagged | 0 |')
+    expect(result.summary).toContain('All checks passed — no discrepancies found.')
+  })
+
+  it('publishes a valid nonzero-discrepancy table while retaining the step log', () => {
+    const result = runSummary({
+      conflicting: 0,
+      duplicates: 2,
+      orphanedLabels: 1,
+      orphanedPrs: 0,
+      paused: 0,
+      prFallbacks: 0,
+      staleUnclaimed: 0,
+      stalledPrs: 1,
+    })
+
+    expect(result.summary).toBe(result.log)
+    expect(result.summary).toContain('| Orphaned in-progress labels fixed | 1 |')
+    expect(result.summary).toContain('| Duplicate action-item issues closed | 2 |')
+    expect(result.summary).toContain('| Stalled draft PRs flagged | 1 |')
+    expect(result.summary).toContain('Found and addressed 4 discrepancies.')
+  })
+})


### PR DESCRIPTION
Closes #307

## Summary
- stream the complete SFL Auditor result table to both the step log and `$GITHUB_STEP_SUMMARY`
- preserve the zero- and nonzero-discrepancy final status messages
- add executable regression coverage for both outcomes

## Verification
- `bunx vitest run scripts/sfl-auditor-summary.test.ts scripts/sfl-auditor-stalled-prs.test.ts --reporter=dot`
- `bunx eslint scripts/sfl-auditor-summary.test.ts`
- `bun run typecheck`
- repository pre-commit gate: 294 test files / 6,560 tests passed with coverage

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Publish SFL Auditor results to GitHub Job Summary
> The `Summary` step in [sfl-auditor.yml](.github/workflows/sfl-auditor.yml) now pipes its markdown output through `tee -a "$GITHUB_STEP_SUMMARY"` so the report appears in the GitHub Actions job summary UI in addition to stdout. A Vitest test suite in [sfl-auditor-summary.test.ts](https://github.com/HemSoft/hs-buddy/pull/316/files#diff-4a739df4e62fe17dc7abf99e658ea990f1517db5252c6d7a0c3d1be6aff5d9ba) verifies that stdout and the summary file contents match for both zero- and nonzero-discrepancy scenarios.
>
> <!-- Macroscope's changelog starts here -->
> #### Changes since #316 opened
>
> - Replaced partial-contains assertions with exact string equality checks in SFL Auditor summary tests [eee58e6]
> - Bumped version to 0.1.909 and updated changelog [eee58e6]
> <!-- Macroscope's changelog ends here -->
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4c9dcdb.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->