### PR TITLE
test: cover OrgDetailPanel cache branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.910] - 2026-07-25
+
+### Changed
+
+- Cover OrgDetailPanel cache branches
+
 ## [0.1.909] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.912] - 2026-07-25
+
+### Changed
+
+- Isolate OrgDetailPanel copilot fetch
+
 ## [0.1.911] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.911] - 2026-07-25
+
+### Changed
+
+- Isolate OrgDetailPanel GitHub bridge
+
 ## [0.1.910] - 2026-07-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.911",
+  "version": "0.1.912",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.909",
+  "version": "0.1.910",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.910",
+  "version": "0.1.911",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/OrgDetailPanel.test.tsx
+++ b/src/components/OrgDetailPanel.test.tsx
@@ -448,6 +448,35 @@ describe('OrgDetailPanel', () => {
       expect(screen.getByText('Business Seats')).toBeInTheDocument()
     })
 
+    it('hydrates copilot usage when cache data becomes available before the fetch', async () => {
+      const cachedCopilot = {
+        org: 'test-org',
+        premiumRequests: 1234,
+        grossCost: 88,
+        discount: 8,
+        netCost: 80,
+        businessSeats: 12,
+        fetchedAt: Date.now(),
+      }
+      let copilotCacheReads = 0
+      orgMocks.dataCacheGet.mockImplementation((key: string) => {
+        if (key !== 'org-copilot:test-org') return null
+        copilotCacheReads += 1
+        return copilotCacheReads === 2 ? { data: cachedCopilot, fetchedAt: Date.now() } : null
+      })
+      orgMocks.dataCacheIsFresh.mockReturnValue(false)
+      window.github = {
+        getCopilotUsage: vi.fn(),
+      } as unknown as typeof window.github
+
+      render(<OrgDetailPanel org="test-org" />)
+
+      await waitFor(() => {
+        expect(screen.getByText('1,234')).toBeInTheDocument()
+      })
+      expect(window.github.getCopilotUsage).not.toHaveBeenCalled()
+    })
+
     it('renders budget band for org', async () => {
       render(<OrgDetailPanel org="test-org" />)
       await waitFor(() => {
@@ -719,6 +748,39 @@ describe('OrgDetailPanel', () => {
       expect(names[0]).toContain('alice')
       expect(names[1]).toContain('bob')
       expect(names[2]).toContain('charlie')
+    })
+
+    it('uses login and zero-commit fallbacks when sorting an unnamed member first', async () => {
+      const overview = makeOverview({ topContributorsToday: [] })
+      const members = {
+        members: [
+          { login: 'charlie', name: null, url: 'https://github.com/charlie', type: 'User' },
+          { login: 'alice', name: 'Alice Smith', url: 'https://github.com/alice', type: 'User' },
+          { login: 'bob', name: 'Bob Jones', url: 'https://github.com/bob', type: 'User' },
+        ],
+      }
+      orgMocks.dataCacheGet.mockImplementation((key: string) => {
+        if (key === 'org-overview:test-org') return { data: overview, fetchedAt: Date.now() }
+        if (key === 'org-members:test-org') return { data: members, fetchedAt: Date.now() }
+        return null
+      })
+      orgMocks.mockClient.fetchOrgOverview.mockResolvedValue(overview)
+      orgMocks.mockClient.fetchOrgMembers.mockResolvedValue(members)
+
+      render(<OrgDetailPanel org="test-org" />)
+      await waitFor(() => {
+        expect(screen.getByText('Name')).toBeInTheDocument()
+      })
+
+      fireEvent.click(screen.getByText('Name'))
+      await waitFor(() => {
+        expect(screen.getByTitle('Sort by name')).toBeInTheDocument()
+      })
+
+      const names = [...document.querySelectorAll('.org-detail-roster-name')].map(
+        element => element.textContent
+      )
+      expect(names).toEqual(['charlie', 'Alice Smith (alice)', 'Bob Jones (bob)'])
     })
 
     it('shows "configured" tag for members with configured accounts', async () => {

--- a/src/components/OrgDetailPanel.test.tsx
+++ b/src/components/OrgDetailPanel.test.tsx
@@ -127,9 +127,22 @@ function makeMembers() {
   }
 }
 
+function makeMembersWithUnnamedFirst() {
+  return {
+    members: [
+      { login: 'charlie', name: null, url: 'https://github.com/charlie', type: 'User' },
+      { login: 'alice', name: 'Alice Smith', url: 'https://github.com/alice', type: 'User' },
+      { login: 'bob', name: 'Bob Jones', url: 'https://github.com/bob', type: 'User' },
+    ],
+  }
+}
+
 /* ── setup / teardown ─────────────────────────────────────────────── */
 
+let originalGitHub: typeof window.github
+
 beforeEach(() => {
+  originalGitHub = window.github
   vi.clearAllMocks()
   vi.useFakeTimers({ shouldAdvanceTime: true })
 
@@ -188,6 +201,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  window.github = originalGitHub
   vi.useRealTimers()
   vi.restoreAllMocks()
 })
@@ -487,6 +501,19 @@ describe('OrgDetailPanel', () => {
     })
   })
 
+  describe('copilot fetch results', () => {
+    it('handles a completed response without Copilot usage data', async () => {
+      const getCopilotUsage = vi.fn().mockResolvedValue({ success: false })
+      window.github = { getCopilotUsage } as unknown as typeof window.github
+
+      render(<OrgDetailPanel org="test-org" />)
+
+      await waitFor(() => {
+        expect(getCopilotUsage).toHaveBeenCalledWith('test-org', 'alice')
+      })
+    })
+  })
+
   describe('leaders section', () => {
     it('renders top contributors', async () => {
       render(<OrgDetailPanel org="test-org" />)
@@ -750,15 +777,23 @@ describe('OrgDetailPanel', () => {
       expect(names[2]).toContain('charlie')
     })
 
+    it('shows "configured" tag for members with configured accounts', async () => {
+      orgMocks.useGitHubAccounts.mockReturnValue({
+        accounts: [{ username: 'alice', org: 'test-org', token: 'ghp_test' }],
+        loading: false,
+      })
+
+      render(<OrgDetailPanel org="test-org" />)
+      await waitFor(() => {
+        expect(screen.getByText(/configured/)).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe('roster sort fallbacks', () => {
     it('uses login and zero-commit fallbacks when sorting an unnamed member first', async () => {
       const overview = makeOverview({ topContributorsToday: [] })
-      const members = {
-        members: [
-          { login: 'charlie', name: null, url: 'https://github.com/charlie', type: 'User' },
-          { login: 'alice', name: 'Alice Smith', url: 'https://github.com/alice', type: 'User' },
-          { login: 'bob', name: 'Bob Jones', url: 'https://github.com/bob', type: 'User' },
-        ],
-      }
+      const members = makeMembersWithUnnamedFirst()
       orgMocks.dataCacheGet.mockImplementation((key: string) => {
         if (key === 'org-overview:test-org') return { data: overview, fetchedAt: Date.now() }
         if (key === 'org-members:test-org') return { data: members, fetchedAt: Date.now() }
@@ -781,18 +816,6 @@ describe('OrgDetailPanel', () => {
         element => element.textContent
       )
       expect(names).toEqual(['charlie', 'Alice Smith (alice)', 'Bob Jones (bob)'])
-    })
-
-    it('shows "configured" tag for members with configured accounts', async () => {
-      orgMocks.useGitHubAccounts.mockReturnValue({
-        accounts: [{ username: 'alice', org: 'test-org', token: 'ghp_test' }],
-        loading: false,
-      })
-
-      render(<OrgDetailPanel org="test-org" />)
-      await waitFor(() => {
-        expect(screen.getByText(/configured/)).toBeInTheDocument()
-      })
     })
   })
 

--- a/src/components/OrgDetailPanel.test.tsx
+++ b/src/components/OrgDetailPanel.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { OrgDetailPanel } from './OrgDetailPanel'
+import { runCopilotFetch } from './orgCopilotFetch'
 
 /* ── hoisted mocks ─────────────────────────────────────────────────── */
 
@@ -502,6 +503,24 @@ describe('OrgDetailPanel', () => {
   })
 
   describe('copilot fetch results', () => {
+    it('skips the fetch for a user namespace', async () => {
+      const enqueue = orgMocks.useTaskQueue().enqueue
+
+      await runCopilotFetch({
+        org: 'test-org',
+        preferredAccount: 'alice',
+        forceRefresh: false,
+        isUserNamespace: true,
+        copilotCacheKey: 'org-copilot:test-org',
+        copilotTaskName: 'org-detail-copilot-test-org',
+        enqueue,
+        hasUsage: false,
+        dispatchCopilot: vi.fn(),
+      })
+
+      expect(enqueue).not.toHaveBeenCalled()
+    })
+
     it('handles a completed response without Copilot usage data', async () => {
       const getCopilotUsage = vi.fn().mockResolvedValue({ success: false })
       window.github = { getCopilotUsage } as unknown as typeof window.github

--- a/src/components/OrgDetailPanel.tsx
+++ b/src/components/OrgDetailPanel.tsx
@@ -817,7 +817,6 @@ async function runCopilotFetch({
   org,
   preferredAccount,
   forceRefresh,
-  isUserNamespace,
   copilotCacheKey,
   copilotTaskName,
   enqueue,
@@ -827,14 +826,12 @@ async function runCopilotFetch({
   org: string
   preferredAccount?: string
   forceRefresh: boolean
-  isUserNamespace: boolean
   copilotCacheKey: string
   copilotTaskName: string
   enqueue: ReturnType<typeof useTaskQueue>['enqueue']
   hasUsage: boolean
   dispatchCopilot: React.Dispatch<Parameters<typeof orgCopilotReducer>[1]>
 }): Promise<void> {
-  if (isUserNamespace) return
   if (hydrateCachedCopilot(copilotCacheKey, forceRefresh, dispatchCopilot)) return
   const queue = getTaskQueue('github')
   if (queue.hasTaskWithName(copilotTaskName)) return
@@ -899,7 +896,6 @@ function useOrgCopilotData({
         org,
         preferredAccount,
         forceRefresh,
-        isUserNamespace,
         copilotCacheKey,
         copilotTaskName,
         enqueue: enqueueRef.current,
@@ -907,7 +903,7 @@ function useOrgCopilotData({
         dispatchCopilot,
       })
     },
-    [copilotCacheKey, copilotTaskName, isUserNamespace, org, preferredAccount]
+    [copilotCacheKey, copilotTaskName, org, preferredAccount]
   )
 
   return {

--- a/src/components/OrgDetailPanel.tsx
+++ b/src/components/OrgDetailPanel.tsx
@@ -1,12 +1,4 @@
-import {
-  startTransition,
-  useCallback,
-  useEffect,
-  useMemo,
-  useReducer,
-  useRef,
-  useState,
-} from 'react'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import {
   AlertCircle,
   ArrowUpDown,
@@ -35,10 +27,10 @@ import type { GitHubAccount } from '../types/config'
 import { AccountQuotaCard } from './copilot-usage/AccountQuotaCard'
 import { OVERAGE_COST_PER_CREDIT, formatCurrency } from './copilot-usage/quotaUtils'
 import { formatDistanceToNow, formatTime } from '../utils/dateUtils'
-import { getErrorMessage, isAbortError, throwIfAborted } from '../utils/errorUtils'
 import { sumBy } from '../utils/arrayUtils'
 import { RateLimitGauge } from './RateLimitGauge'
 import { useOrgCachedFetch } from '../hooks/useOrgCachedFetch'
+import { getCachedCopilotData, runCopilotFetch } from './orgCopilotFetch'
 import './CopilotUsagePanel.css'
 import './OrgDetailPanel.css'
 
@@ -744,112 +736,6 @@ function useOrgMembersData({
   }
 }
 
-/* v8 ignore start */
-function handleCopilotSuccess(
-  data: {
-    org: string
-    premiumRequests: number
-    grossCost: number
-    discount: number
-    netCost: number
-    businessSeats: number
-    fetchedAt: number
-  },
-  dispatch: React.Dispatch<Parameters<typeof orgCopilotReducer>[1]>,
-  cacheKey: string
-) {
-  const metrics: OrgCopilotUsageData = {
-    org: data.org,
-    premiumRequests: data.premiumRequests,
-    grossCost: data.grossCost,
-    discount: data.discount,
-    netCost: data.netCost,
-    businessSeats: data.businessSeats,
-    fetchedAt: data.fetchedAt,
-  }
-  startTransition(() => {
-    dispatch({ type: 'success', usage: metrics })
-  })
-  dataCache.set(cacheKey, metrics)
-  /* v8 ignore stop */
-}
-
-function getCachedCopilotData(cacheKey: string): OrgCopilotUsageData | null {
-  return dataCache.get<OrgCopilotUsageData>(cacheKey)?.data ?? null
-}
-
-/** Handle copilot fetch result: dispatch success or error. */
-/* v8 ignore start */
-function handleCopilotFetchResult(
-  result: { success: boolean; data?: Parameters<typeof handleCopilotSuccess>[0] },
-  dispatch: React.Dispatch<Parameters<typeof orgCopilotReducer>[1]>,
-  cacheKey: string
-) {
-  if (result.success && result.data) {
-    handleCopilotSuccess(result.data, dispatch, cacheKey)
-  } else {
-    dispatch({ type: 'error', error: null })
-  }
-}
-
-/** Handle copilot fetch error: ignore aborts, otherwise dispatch error. */
-function handleCopilotCatchError(
-  error: unknown,
-  dispatch: React.Dispatch<Parameters<typeof orgCopilotReducer>[1]>
-) {
-  if (isAbortError(error)) return
-  dispatch({ type: 'error', error: getErrorMessage(error) })
-}
-/* v8 ignore stop */
-
-function hydrateCachedCopilot(
-  cacheKey: string,
-  forceRefresh: boolean,
-  dispatchCopilot: React.Dispatch<Parameters<typeof orgCopilotReducer>[1]>
-): boolean {
-  const cached = getCachedCopilotData(cacheKey)
-  if (!cached || forceRefresh) return false
-  dispatchCopilot({ type: 'hydrate-cache', usage: cached })
-  return true
-}
-
-async function runCopilotFetch({
-  org,
-  preferredAccount,
-  forceRefresh,
-  copilotCacheKey,
-  copilotTaskName,
-  enqueue,
-  hasUsage,
-  dispatchCopilot,
-}: {
-  org: string
-  preferredAccount?: string
-  forceRefresh: boolean
-  copilotCacheKey: string
-  copilotTaskName: string
-  enqueue: ReturnType<typeof useTaskQueue>['enqueue']
-  hasUsage: boolean
-  dispatchCopilot: React.Dispatch<Parameters<typeof orgCopilotReducer>[1]>
-}): Promise<void> {
-  if (hydrateCachedCopilot(copilotCacheKey, forceRefresh, dispatchCopilot)) return
-  const queue = getTaskQueue('github')
-  if (queue.hasTaskWithName(copilotTaskName)) return
-  dispatchCopilot({ type: 'start-loading', hasUsage })
-  try {
-    const result = await enqueue(
-      async signal => {
-        throwIfAborted(signal)
-        return await window.github.getCopilotUsage(org, preferredAccount)
-      },
-      { name: copilotTaskName, priority: -1 }
-    )
-    handleCopilotFetchResult(result, dispatchCopilot, copilotCacheKey)
-  } catch (fetchError: unknown) {
-    handleCopilotCatchError(fetchError, dispatchCopilot)
-  }
-}
-
 function useOrgCopilotData({
   org,
   enqueue,
@@ -896,6 +782,7 @@ function useOrgCopilotData({
         org,
         preferredAccount,
         forceRefresh,
+        isUserNamespace,
         copilotCacheKey,
         copilotTaskName,
         enqueue: enqueueRef.current,
@@ -903,7 +790,7 @@ function useOrgCopilotData({
         dispatchCopilot,
       })
     },
-    [copilotCacheKey, copilotTaskName, org, preferredAccount]
+    [copilotCacheKey, copilotTaskName, isUserNamespace, org, preferredAccount]
   )
 
   return {

--- a/src/components/orgCopilotFetch.ts
+++ b/src/components/orgCopilotFetch.ts
@@ -1,0 +1,112 @@
+import { startTransition, type Dispatch } from 'react'
+import type { useTaskQueue } from '../hooks/useTaskQueue'
+import { dataCache } from '../services/dataCache'
+import { getTaskQueue } from '../services/taskQueue'
+import { getErrorMessage, isAbortError, throwIfAborted } from '../utils/errorUtils'
+import { orgCopilotReducer, type OrgCopilotUsageData } from './orgDetailReducer'
+
+type CopilotDispatch = Dispatch<Parameters<typeof orgCopilotReducer>[1]>
+
+/* v8 ignore start */
+function handleCopilotSuccess(
+  data: {
+    org: string
+    premiumRequests: number
+    grossCost: number
+    discount: number
+    netCost: number
+    businessSeats: number
+    fetchedAt: number
+  },
+  dispatch: CopilotDispatch,
+  cacheKey: string
+) {
+  const metrics: OrgCopilotUsageData = {
+    org: data.org,
+    premiumRequests: data.premiumRequests,
+    grossCost: data.grossCost,
+    discount: data.discount,
+    netCost: data.netCost,
+    businessSeats: data.businessSeats,
+    fetchedAt: data.fetchedAt,
+  }
+  startTransition(() => {
+    dispatch({ type: 'success', usage: metrics })
+  })
+  dataCache.set(cacheKey, metrics)
+}
+/* v8 ignore stop */
+
+export function getCachedCopilotData(cacheKey: string): OrgCopilotUsageData | null {
+  return dataCache.get<OrgCopilotUsageData>(cacheKey)?.data ?? null
+}
+
+/* v8 ignore start */
+function handleCopilotFetchResult(
+  result: { success: boolean; data?: Parameters<typeof handleCopilotSuccess>[0] },
+  dispatch: CopilotDispatch,
+  cacheKey: string
+) {
+  if (result.success && result.data) {
+    handleCopilotSuccess(result.data, dispatch, cacheKey)
+  } else {
+    dispatch({ type: 'error', error: null })
+  }
+}
+
+function handleCopilotCatchError(error: unknown, dispatch: CopilotDispatch) {
+  if (isAbortError(error)) return
+  dispatch({ type: 'error', error: getErrorMessage(error) })
+}
+/* v8 ignore stop */
+
+function hydrateCachedCopilot(
+  cacheKey: string,
+  forceRefresh: boolean,
+  dispatchCopilot: CopilotDispatch
+): boolean {
+  const cached = getCachedCopilotData(cacheKey)
+  if (!cached || forceRefresh) return false
+  dispatchCopilot({ type: 'hydrate-cache', usage: cached })
+  return true
+}
+
+export async function runCopilotFetch({
+  org,
+  preferredAccount,
+  forceRefresh,
+  isUserNamespace,
+  copilotCacheKey,
+  copilotTaskName,
+  enqueue,
+  hasUsage,
+  dispatchCopilot,
+}: {
+  org: string
+  preferredAccount?: string
+  forceRefresh: boolean
+  isUserNamespace: boolean
+  copilotCacheKey: string
+  copilotTaskName: string
+  enqueue: ReturnType<typeof useTaskQueue>['enqueue']
+  hasUsage: boolean
+  dispatchCopilot: CopilotDispatch
+}): Promise<void> {
+  if (isUserNamespace) return
+  if (hydrateCachedCopilot(copilotCacheKey, forceRefresh, dispatchCopilot)) return
+  const queue = getTaskQueue('github')
+  if (queue.hasTaskWithName(copilotTaskName)) return
+  dispatchCopilot({ type: 'start-loading', hasUsage })
+  try {
+    const result = await enqueue(
+      async signal => {
+        throwIfAborted(signal)
+        return await window.github.getCopilotUsage(org, preferredAccount)
+      },
+      { name: copilotTaskName, priority: -1 }
+    )
+    handleCopilotFetchResult(result, dispatchCopilot, copilotCacheKey)
+  } catch (fetchError: unknown) {
+    handleCopilotCatchError(fetchError, dispatchCopilot)
+  }
+}


### PR DESCRIPTION
Closes #309

## Summary
- cover cached Copilot hydration before a network fetch
- cover user-namespace, login, and zero-commit fallback branches
- extract the Copilot fetch helper for direct testing without changing runtime behavior
- restore `window.github` after each test so coverage is order-independent

## Verification
- `bun run test:coverage` (294 files, 6,564 tests)
- `bun run lint`
- `bun run lint:quality`
- `bun run typecheck`
- `bun run knip`
- `OrgDetailPanel.tsx` and `orgCopilotFetch.ts`: 100% statements, branches, functions, and lines

## Risk
Low. The fetch logic is moved unchanged into a focused module and exercised through both component and direct tests.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract Copilot fetch logic from `OrgDetailPanel` and add cache branch tests
> - Moves Copilot usage fetch functions (`runCopilotFetch`, `getCachedCopilotData`, etc.) out of `OrgDetailPanel.tsx` into a new [`orgCopilotFetch.ts`](https://github.com/HemSoft/hs-buddy/pull/318/files#diff-ce479fa67c0d14dbf001fc36cc98c7d4c512024dd143c89dbb9d8cdaafa11f07) module to enable direct unit testing.
> - Adds tests in [`OrgDetailPanel.test.tsx`](https://github.com/HemSoft/hs-buddy/pull/318/files#diff-75d71839d068c6f41540946277a0ed26bd894af1b95696a9de91581f7b8385dc) covering cache hydration before fetch, user-namespace fetch suppression, empty copilot response handling, and roster sort fallbacks for unnamed members.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 79cc349.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->