### PR TITLE
test: cover PR list fetch concurrency guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.913] - 2026-07-25
+
+### Changed
+
+- Cover PR list fetch concurrency guards
+
 ## [0.1.912] - 2026-07-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.912",
+  "version": "0.1.913",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/pull-request-list/usePRListData.test.ts
+++ b/src/components/pull-request-list/usePRListData.test.ts
@@ -16,6 +16,7 @@ const {
   mockUseRepoBookmarks,
   mockUseRepoBookmarkMutations,
   mockUseTaskQueue,
+  mockUseRef,
 } = vi.hoisted(() => ({
   mockGitHubClient: vi.fn(),
   mockFetchMyPRs: vi.fn(),
@@ -28,7 +29,14 @@ const {
   mockUseRepoBookmarks: vi.fn(),
   mockUseRepoBookmarkMutations: vi.fn(),
   mockUseTaskQueue: vi.fn(),
+  mockUseRef: vi.fn(),
 }))
+
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof import('react')>()
+  mockUseRef.mockImplementation(actual.useRef)
+  return { ...actual, useRef: mockUseRef }
+})
 
 vi.mock('../../api/github', () => ({
   GitHubClient: mockGitHubClient.mockImplementation(function MockGitHubClient() {
@@ -174,6 +182,88 @@ describe('usePRListData', () => {
     expect(onCountChange).toHaveBeenCalledWith(3)
     expect(mockGitHubClient).toHaveBeenCalledWith({ accounts: [account] }, 14)
     expect(dataCache.get<PullRequest[]>('my-prs')?.data).toHaveLength(3)
+  })
+
+  it('uses data that becomes fresh while the fetch is queued', async () => {
+    const cachedPr = makePR({ id: 11, repository: 'queued-cache' })
+    let runQueuedTask: (() => Promise<void>) | undefined
+
+    mockUseTaskQueue.mockReturnValue({
+      enqueue: vi.fn(
+        (task: (signal: AbortSignal) => Promise<PullRequest[]>) =>
+          new Promise<PullRequest[]>((resolve, reject) => {
+            runQueuedTask = async () => {
+              try {
+                resolve(await task(new AbortController().signal))
+              } catch (error: unknown) {
+                reject(error)
+              }
+            }
+          })
+      ),
+      cancelAll: vi.fn(),
+    })
+
+    const { result } = renderHook(() => usePRListData('my-prs'))
+    await waitFor(() => expect(runQueuedTask).toBeDefined())
+
+    dataCache.set('my-prs', [cachedPr], Date.now())
+    await act(async () => {
+      await runQueuedTask?.()
+    })
+
+    await waitFor(() => expect(result.current.prs).toEqual([cachedPr]))
+    expect(mockFetchMyPRs).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale fetch result after the mode changes', async () => {
+    const stalePr = makePR({ id: 12, repository: 'stale-result' })
+    const currentPr = makePR({ id: 13, repository: 'current-result' })
+    let resolveStaleFetch: ((prs: PullRequest[]) => void) | undefined
+
+    mockFetchMyPRs.mockReturnValue(
+      new Promise<PullRequest[]>(resolve => {
+        resolveStaleFetch = resolve
+      })
+    )
+    mockFetchNeedsReview.mockResolvedValue([currentPr])
+
+    const { result, rerender } = renderHook(
+      ({ mode }: { mode: 'my-prs' | 'needs-review' }) => usePRListData(mode),
+      { initialProps: { mode: 'my-prs' } as { mode: 'my-prs' | 'needs-review' } }
+    )
+    await waitFor(() => expect(mockFetchMyPRs).toHaveBeenCalledOnce())
+
+    rerender({ mode: 'needs-review' })
+    await waitFor(() => expect(result.current.prs).toEqual([currentPr]))
+
+    await act(async () => {
+      resolveStaleFetch?.([stalePr])
+    })
+
+    expect(result.current.prs).toEqual([currentPr])
+    expect(dataCache.get<PullRequest[]>('my-prs')).toBeNull()
+  })
+
+  it('does not start a duplicate fetch while one is in progress', () => {
+    const actualUseRef = mockUseRef.getMockImplementation()
+    if (!actualUseRef) throw new Error('React useRef mock is not initialized')
+    let injectedInProgressRef = false
+    mockUseRef.mockImplementation(initialValue => {
+      const ref = actualUseRef(initialValue)
+      if (!injectedInProgressRef && initialValue === false) {
+        injectedInProgressRef = true
+        ref.current = true
+      }
+      return ref
+    })
+
+    try {
+      renderHook(() => usePRListData('my-prs'))
+      expect(mockFetchMyPRs).not.toHaveBeenCalled()
+    } finally {
+      mockUseRef.mockImplementation(actualUseRef)
+    }
   })
 
   it('surfaces an account configuration error before fetching', async () => {


### PR DESCRIPTION
Closes #310

## Summary
- cover queued PR-list fetches that reuse newly fresh cache data
- verify stale fetch results cannot overwrite current mode state or cache
- verify an in-progress fetch suppresses duplicate work

## Verification
- `bun run test:coverage` (294 files, 6,567 tests)
- `bun run typecheck`
- `bunx eslint src/components/pull-request-list/usePRListData.test.ts --max-warnings 0`
- targeted `usePRListData.ts` coverage: 100% statements, branches, functions, and lines

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests for concurrency guards in `usePRListData`
> Adds three new tests to [usePRListData.test.ts](https://github.com/HemSoft/hs-buddy/pull/319/files#diff-1b53c9a7eca3859c82928e3642063b0c7b887da91db0b81b6fd1db6df5f02ecc) covering edge cases in concurrent fetch handling:
> - Verifies the hook uses fresh cached data when it becomes available before a queued fetch task runs
> - Verifies stale fetch results are ignored and the cache is cleared when the mode changes before the fetch resolves
> - Verifies no duplicate fetch is started when one is already in progress, using a `useRef` override to simulate the in-progress flag
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 04b299a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->