### PR TITLE
test: cover Ralph launch validation errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.914] - 2026-07-25
+
+### Changed
+
+- Cover Ralph launch validation errors
+
 ## [0.1.913] - 2026-07-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.915] - 2026-07-25
+
+### Changed
+
+- Satisfy Ralph coverage quality gate
+
 ## [0.1.914] - 2026-07-25
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.914",
+  "version": "0.1.915",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.913",
+  "version": "0.1.914",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/components/ralph-loops/RalphLaunchForm.test.tsx
+++ b/src/components/ralph-loops/RalphLaunchForm.test.tsx
@@ -1744,4 +1744,139 @@ describe('RalphLaunchForm', () => {
       )
     })
   })
+
+  describe('Launch validation and error coverage', () => {
+    beforeEach(() => {
+      vi.mocked(useRalphModels).mockReturnValue({
+        data: mockModelsConfig,
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+      vi.mocked(useRalphProviders).mockReturnValue({
+        data: mockProvidersConfig,
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+      vi.mocked(useRalphAgents).mockReturnValue({
+        data: mockAgentsConfig,
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+    })
+
+    it('rejects an invalid optional issue number before launch', async () => {
+      const mockOnLaunch = vi.fn().mockResolvedValue({ success: true })
+      render(
+        <RalphLaunchForm
+          initialIssue={{
+            issueNumber: 0,
+            issueTitle: 'Invalid issue number',
+            issueBody: 'Test validation',
+            repository: 'repo',
+            org: 'org',
+            repoPath: '/repo',
+          }}
+          onLaunch={mockOnLaunch}
+        />
+      )
+
+      await waitFor(() => {
+        expect((screen.getByLabelText(/repository/i) as HTMLInputElement).value).toBe('/repo')
+      })
+      fireEvent.submit(screen.getByRole('button', { name: /launch/i }).closest('form')!)
+
+      expect(await screen.findByText('Issue number must be a positive integer')).toBeInTheDocument()
+      expect(mockOnLaunch).not.toHaveBeenCalled()
+    })
+
+    it('shows the message from a rejected launch Error', async () => {
+      const mockOnLaunch = vi.fn().mockRejectedValue(new Error('Launch service unavailable'))
+      render(<RalphLaunchForm onLaunch={mockOnLaunch} />)
+
+      await userEvent.type(screen.getByLabelText(/repository/i), '/repo')
+      await userEvent.click(screen.getByRole('button', { name: /launch/i }))
+
+      expect(await screen.findByText('Launch service unavailable')).toBeInTheDocument()
+    })
+
+    it('shows the fallback message for a non-Error launch rejection', async () => {
+      const mockOnLaunch = vi.fn().mockRejectedValue('launch failed')
+      render(<RalphLaunchForm onLaunch={mockOnLaunch} />)
+
+      await userEvent.type(screen.getByLabelText(/repository/i), '/repo')
+      await userEvent.click(screen.getByRole('button', { name: /launch/i }))
+
+      expect(await screen.findByText('Failed to launch Ralph run')).toBeInTheDocument()
+    })
+
+    it('keeps model options available when provider data disappears', async () => {
+      const { rerender } = render(
+        <RalphLaunchForm onLaunch={vi.fn().mockResolvedValue({ success: true })} />
+      )
+      await userEvent.selectOptions(screen.getByLabelText(/provider/i), 'openai')
+
+      vi.mocked(useRalphProviders).mockReturnValue({
+        data: null,
+        loading: true,
+        error: null,
+        refresh: vi.fn(),
+      })
+      rerender(<RalphLaunchForm onLaunch={vi.fn().mockResolvedValue({ success: true })} />)
+
+      const modelValues = Array.from(
+        (screen.getByLabelText(/model/i) as HTMLSelectElement).options
+      ).map(option => option.value)
+      expect(modelValues).toContain('gpt-4')
+      expect(modelValues).toContain('claude-3')
+    })
+
+    it('keeps model options available when the selected provider disappears', async () => {
+      const { rerender } = render(
+        <RalphLaunchForm onLaunch={vi.fn().mockResolvedValue({ success: true })} />
+      )
+      await userEvent.selectOptions(screen.getByLabelText(/provider/i), 'openai')
+
+      vi.mocked(useRalphProviders).mockReturnValue({
+        data: {
+          version: '1.0.0',
+          default: 'anthropic',
+          providers: {
+            anthropic: {
+              description: 'Anthropic',
+              supportedModelProviders: ['anthropic'],
+            },
+          },
+        } as unknown as RalphProvidersConfig,
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+      rerender(<RalphLaunchForm onLaunch={vi.fn().mockResolvedValue({ success: true })} />)
+
+      const modelValues = Array.from(
+        (screen.getByLabelText(/model/i) as HTMLSelectElement).options
+      ).map(option => option.value)
+      expect(modelValues).toContain('gpt-4')
+      expect(modelValues).toContain('claude-3')
+    })
+
+    it('omits an alias whose target model is missing', () => {
+      vi.mocked(useRalphModels).mockReturnValue({
+        data: { ...mockModelsConfig, aliases: { missing: 'not-a-model' } },
+        loading: false,
+        error: null,
+        refresh: vi.fn(),
+      })
+
+      render(<RalphLaunchForm onLaunch={vi.fn().mockResolvedValue({ success: true })} />)
+
+      const modelValues = Array.from(
+        (screen.getByLabelText(/model/i) as HTMLSelectElement).options
+      ).map(option => option.value)
+      expect(modelValues).not.toContain('missing')
+    })
+  })
 })

--- a/src/components/ralph-loops/RalphLaunchForm.test.tsx
+++ b/src/components/ralph-loops/RalphLaunchForm.test.tsx
@@ -99,6 +99,27 @@ vi.mock('../../utils/storage', () => ({
 // Import hooks after mocking
 import { useRalphModels, useRalphProviders, useRalphAgents } from '../../hooks/useRalphConfig'
 
+function restoreDefaultConfigMocks() {
+  vi.mocked(useRalphModels).mockReturnValue({
+    data: mockModelsConfig,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  })
+  vi.mocked(useRalphProviders).mockReturnValue({
+    data: mockProvidersConfig,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  })
+  vi.mocked(useRalphAgents).mockReturnValue({
+    data: mockAgentsConfig,
+    loading: false,
+    error: null,
+    refresh: vi.fn(),
+  })
+}
+
 describe('RalphLaunchForm', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -1746,26 +1767,7 @@ describe('RalphLaunchForm', () => {
   })
 
   describe('Launch validation and error coverage', () => {
-    beforeEach(() => {
-      vi.mocked(useRalphModels).mockReturnValue({
-        data: mockModelsConfig,
-        loading: false,
-        error: null,
-        refresh: vi.fn(),
-      })
-      vi.mocked(useRalphProviders).mockReturnValue({
-        data: mockProvidersConfig,
-        loading: false,
-        error: null,
-        refresh: vi.fn(),
-      })
-      vi.mocked(useRalphAgents).mockReturnValue({
-        data: mockAgentsConfig,
-        loading: false,
-        error: null,
-        refresh: vi.fn(),
-      })
-    })
+    beforeEach(restoreDefaultConfigMocks)
 
     it('rejects an invalid optional issue number before launch', async () => {
       const mockOnLaunch = vi.fn().mockResolvedValue({ success: true })
@@ -1811,6 +1813,10 @@ describe('RalphLaunchForm', () => {
 
       expect(await screen.findByText('Failed to launch Ralph run')).toBeInTheDocument()
     })
+  })
+
+  describe('Provider and alias fallback coverage', () => {
+    beforeEach(restoreDefaultConfigMocks)
 
     it('keeps model options available when provider data disappears', async () => {
       const { rerender } = render(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineConfig({
         statements: 99,
         branches: 99,
         functions: 100,
-        lines: 99,
+        lines: 100,
       },
     },
   },


### PR DESCRIPTION
Closes #311

## Summary
- cover invalid optional issue-number validation without invoking the launch callback
- cover rejected launches for both `Error` and non-`Error` values
- cover provider refresh and missing-alias branch outcomes
- raise `RalphLaunchForm.tsx` to 100% statements, branches, functions, and lines

## Verification
- `bun run test:coverage` - 6,573 tests passed
- `bun run typecheck`
- `bunx eslint src/components/ralph-loops/RalphLaunchForm.test.tsx --max-warnings 0`
- `bunx prettier --check src/components/ralph-loops/RalphLaunchForm.test.tsx`
- targeted coverage: 100% statements, branches, functions, and lines for `RalphLaunchForm.tsx`

## Risk
Low. Test-only behavioral coverage plus repository-generated version and coverage-threshold updates.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add tests covering Ralph launch validation errors and provider/model fallback behavior
> - Adds tests in [RalphLaunchForm.test.tsx](https://github.com/HemSoft/hs-buddy/pull/320/files#diff-555174b7c54b25008e8de188fa5336359a961925199eb4099ff98750aef27009) for invalid issue number rejection, launch error message display, and non-Error rejection fallback message.
> - Adds tests verifying that model options persist when provider data becomes unavailable and that aliases with missing target models are omitted.
> - Introduces `restoreDefaultConfigMocks` helper to centralize mock resets across tests.
> - Raises line coverage threshold in [vitest.config.ts](https://github.com/HemSoft/hs-buddy/pull/320/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) from 99% to 100%.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 943c50d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->