### PR TITLE
Fix run finalization after schedule deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.916] - 2026-07-25
+
+### Fixed
+
+- Finalize runs after schedule deletion
+
 ## [0.1.915] - 2026-07-25
 
 ### Changed

--- a/convex/__tests__/runs.test.ts
+++ b/convex/__tests__/runs.test.ts
@@ -123,6 +123,89 @@ describe('runs', () => {
 
     const sched = await t.query(api.schedules.get, { id: schedId })
     expect(sched?.lastRunStatus).toBe('completed')
+    expect(sched?.lastRunAt).toBeGreaterThan(0)
+  })
+
+  test('fail updates schedule lastRunStatus when run has a scheduleId', async () => {
+    const t = convexTest(schema, modules)
+    const jobId = await t.mutation(api.jobs.create, baseJob)
+    const schedId = await t.mutation(api.schedules.create, {
+      jobId,
+      name: 'my-sched',
+      cron: '* * * * *',
+      enabled: false,
+      missedPolicy: 'skip',
+    })
+    const runId = await t.mutation(api.runs.create, {
+      jobId,
+      scheduleId: schedId,
+      triggeredBy: 'schedule',
+    })
+    await t.mutation(api.runs.fail, { id: runId, error: 'worker failed' })
+
+    const sched = await t.query(api.schedules.get, { id: schedId })
+    expect(sched?.lastRunStatus).toBe('failed')
+    expect(sched?.lastRunAt).toBeGreaterThan(0)
+  })
+
+  test('complete finalizes a scheduled run after its job and schedule are deleted', async () => {
+    const t = convexTest(schema, modules)
+    const jobId = await t.mutation(api.jobs.create, baseJob)
+    const scheduleId = await t.mutation(api.schedules.create, {
+      jobId,
+      name: 'deleted-schedule',
+      cron: '* * * * *',
+      enabled: false,
+      missedPolicy: 'skip',
+    })
+    const runId = await t.mutation(api.runs.create, {
+      jobId,
+      scheduleId,
+      triggeredBy: 'schedule',
+    })
+    await t.mutation(api.runs.markRunning, { id: runId })
+    await t.mutation(api.jobs.remove, { id: jobId })
+
+    await t.mutation(api.runs.complete, { id: runId, output: { result: 'ok' } })
+
+    const run = await t.query(api.runs.get, { id: runId })
+    expect(run).toMatchObject({
+      status: 'completed',
+      output: { result: 'ok' },
+    })
+    expect(run?.completedAt).toBeGreaterThan(0)
+    expect(run?.duration).toBeGreaterThanOrEqual(0)
+    expect((await t.query(api.buddyStats.get)).runsCompleted).toBe(1)
+  })
+
+  test('fail finalizes a scheduled run after its job and schedule are deleted', async () => {
+    const t = convexTest(schema, modules)
+    const jobId = await t.mutation(api.jobs.create, baseJob)
+    const scheduleId = await t.mutation(api.schedules.create, {
+      jobId,
+      name: 'deleted-schedule',
+      cron: '* * * * *',
+      enabled: false,
+      missedPolicy: 'skip',
+    })
+    const runId = await t.mutation(api.runs.create, {
+      jobId,
+      scheduleId,
+      triggeredBy: 'schedule',
+    })
+    await t.mutation(api.runs.markRunning, { id: runId })
+    await t.mutation(api.jobs.remove, { id: jobId })
+
+    await t.mutation(api.runs.fail, { id: runId, error: 'worker failed' })
+
+    const run = await t.query(api.runs.get, { id: runId })
+    expect(run).toMatchObject({
+      status: 'failed',
+      error: 'worker failed',
+    })
+    expect(run?.completedAt).toBeGreaterThan(0)
+    expect(run?.duration).toBeGreaterThanOrEqual(0)
+    expect((await t.query(api.buddyStats.get)).runsFailed).toBe(1)
   })
 
   test('cancel stops a pending run', async () => {

--- a/convex/runs.ts
+++ b/convex/runs.ts
@@ -152,10 +152,13 @@ async function finalizeRun(
   })
   await incrementStat(db, statKey)
   if (run.scheduleId) {
-    await db.patch(run.scheduleId, {
-      lastRunAt: completedAt,
-      lastRunStatus: status,
-    })
+    const schedule = await db.get('schedules', run.scheduleId)
+    if (schedule) {
+      await db.patch('schedules', schedule._id, {
+        lastRunAt: completedAt,
+        lastRunStatus: status,
+      })
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.915",
+  "version": "0.1.916",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #321

## Summary
- finalize completed and failed runs even when their originating schedule was deleted
- retain schedule `lastRunAt` and `lastRunStatus` updates when the schedule still exists
- cover completion, failure, persisted output/error, duration, and buddy stats after job deletion

## Verification
- `bun run test:convex`
- `bun run typecheck`
- `bunx eslint convex/runs.ts convex/__tests__/runs.test.ts --max-warnings 0`
- repository pre-commit suite: 6,573 tests with coverage

## Risk
Medium: run lifecycle persistence changed, with regression coverage for both deleted and existing schedules.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix run finalization when associated schedule has been deleted
> In [`finalizeRun`](https://github.com/HemSoft/hs-buddy/pull/326/files#diff-9a786cccc3c22a779d22f59e64859da59dd118014bc161db0e2dce4025f7f5a1), the schedule patch now fetches the schedule first and skips the update if it no longer exists. Previously, completing or failing a run after its schedule was deleted would throw an error, leaving the run in a broken state. Tests cover both complete and fail paths for deleted schedules.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73eef46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->