### PR TITLE
fix: preserve Copilot review result integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.917] - 2026-07-25
+
+### Fixed
+
+- Preserve Copilot review result integrity
+
 ## [0.1.916] - 2026-07-25
 
 ### Fixed

--- a/convex/__tests__/copilotResults.test.ts
+++ b/convex/__tests__/copilotResults.test.ts
@@ -5,6 +5,15 @@ import { api } from '../_generated/api'
 
 const modules = import.meta.glob('../**/*.*s')
 
+const prRunArgs = {
+  owner: 'acme',
+  repo: 'frontend',
+  prNumber: 42,
+  prUrl: 'https://github.com/acme/frontend/pull/42',
+  prTitle: 'Add feature',
+  prompt: 'Review this PR',
+}
+
 describe('copilotResults', () => {
   test('listRecent returns empty array when no results exist', async () => {
     const t = convexTest(schema, modules)
@@ -149,6 +158,41 @@ describe('copilotResults', () => {
     expect(result).toBeNull()
   })
 
+  test('remove deletes linked review runs without affecting unrelated history', async () => {
+    const t = convexTest(schema, modules)
+    const deletedResultId = await t.mutation(api.copilotResults.create, {
+      prompt: 'delete linked result',
+    })
+    const retainedResultId = await t.mutation(api.copilotResults.create, {
+      prompt: 'retain linked result',
+    })
+    await t.mutation(api.prReviewRuns.create, {
+      ...prRunArgs,
+      resultId: deletedResultId,
+    })
+    await t.mutation(api.prReviewRuns.create, {
+      ...prRunArgs,
+      prNumber: 99,
+      resultId: retainedResultId,
+    })
+
+    await t.mutation(api.copilotResults.remove, { id: deletedResultId })
+
+    const deletedRuns = await t.query(api.prReviewRuns.listByPr, {
+      owner: prRunArgs.owner,
+      repo: prRunArgs.repo,
+      prNumber: prRunArgs.prNumber,
+    })
+    const retainedRuns = await t.query(api.prReviewRuns.listByPr, {
+      owner: prRunArgs.owner,
+      repo: prRunArgs.repo,
+      prNumber: 99,
+    })
+    expect(deletedRuns).toEqual([])
+    expect(retainedRuns).toHaveLength(1)
+    expect(await t.query(api.copilotResults.get, { id: retainedResultId })).not.toBeNull()
+  })
+
   test('cleanup removes old completed and failed results', async () => {
     const t = convexTest(schema, modules)
     const id1 = await t.mutation(api.copilotResults.create, { prompt: 'old1' })
@@ -159,6 +203,46 @@ describe('copilotResults', () => {
     // Use negative days to make cutoff in the future, ensuring all results are included
     const result = await t.mutation(api.copilotResults.cleanup, { olderThanDays: -1 })
     expect(result.deleted).toBe(2)
+  })
+
+  test('cleanup deletes linked review runs without affecting retained results', async () => {
+    const t = convexTest(schema, modules)
+    const deletedResultId = await t.mutation(api.copilotResults.create, {
+      prompt: 'old linked result',
+    })
+    const retainedResultId = await t.mutation(api.copilotResults.create, {
+      prompt: 'pending linked result',
+    })
+    await t.mutation(api.copilotResults.complete, {
+      id: deletedResultId,
+      result: 'done',
+    })
+    await t.mutation(api.prReviewRuns.create, {
+      ...prRunArgs,
+      resultId: deletedResultId,
+    })
+    await t.mutation(api.prReviewRuns.create, {
+      ...prRunArgs,
+      prNumber: 99,
+      resultId: retainedResultId,
+    })
+
+    const result = await t.mutation(api.copilotResults.cleanup, { olderThanDays: -1 })
+
+    const deletedRuns = await t.query(api.prReviewRuns.listByPr, {
+      owner: prRunArgs.owner,
+      repo: prRunArgs.repo,
+      prNumber: prRunArgs.prNumber,
+    })
+    const retainedRuns = await t.query(api.prReviewRuns.listByPr, {
+      owner: prRunArgs.owner,
+      repo: prRunArgs.repo,
+      prNumber: 99,
+    })
+    expect(result.deleted).toBe(1)
+    expect(deletedRuns).toEqual([])
+    expect(retainedRuns).toHaveLength(1)
+    expect(await t.query(api.copilotResults.get, { id: retainedResultId })).not.toBeNull()
   })
 
   test('cleanup stops early when encountering recent results', async () => {

--- a/convex/__tests__/prReviewRuns.test.ts
+++ b/convex/__tests__/prReviewRuns.test.ts
@@ -36,6 +36,23 @@ describe('prReviewRuns', () => {
     expect(runs[0].prTitle).toBe('Add feature')
   })
 
+  test('create rejects a deleted Copilot result', async () => {
+    const t = convexTest(schema, modules)
+    const resultId = await createCopilotResult(t)
+    await t.mutation(api.copilotResults.remove, { id: resultId })
+
+    await expect(t.mutation(api.prReviewRuns.create, { ...prRunArgs, resultId })).rejects.toThrow(
+      'CopilotResult'
+    )
+
+    const runs = await t.query(api.prReviewRuns.listByPr, {
+      owner: prRunArgs.owner,
+      repo: prRunArgs.repo,
+      prNumber: prRunArgs.prNumber,
+    })
+    expect(runs).toEqual([])
+  })
+
   test('create stores optional fields (model, ghAccount, headSha, threadStats)', async () => {
     const t = convexTest(schema, modules)
     const resultId = await createCopilotResult(t)

--- a/convex/copilotResults.ts
+++ b/convex/copilotResults.ts
@@ -1,11 +1,25 @@
 import { v } from 'convex/values'
-import { mutation, query } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+import { mutation, query, type MutationCtx } from './_generated/server'
 import { MS_PER_DAY } from './lib/constants'
 import { copilotResultStatusValidator, isPendingOrRunning, notFoundError } from './lib/domain'
 
 /**
  * Copilot SDK Results — CRUD operations for captured Copilot prompt results.
  */
+
+async function deleteResultWithReviewRuns(ctx: MutationCtx, resultId: Id<'copilotResults'>) {
+  const reviewRuns = await ctx.db
+    .query('prReviewRuns')
+    .withIndex('by_result', q => q.eq('resultId', resultId))
+    .collect()
+
+  for (const reviewRun of reviewRuns) {
+    // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Every linked row must be removed before its result.
+    await ctx.db.delete(reviewRun._id)
+  }
+  await ctx.db.delete(resultId)
+}
 
 // List recent results (newest first)
 export const listRecent = query({
@@ -153,7 +167,7 @@ export const fail = mutation({
 export const remove = mutation({
   args: { id: v.id('copilotResults') },
   handler: async (ctx, args) => {
-    await ctx.db.delete(args.id)
+    await deleteResultWithReviewRuns(ctx, args.id)
   },
 })
 
@@ -175,7 +189,7 @@ export const cleanup = mutation({
       if (result.createdAt >= cutoff) break
       if (!isPendingOrRunning(result.status)) {
         // react-doctor-disable-next-line react-doctor/async-await-in-loop -- Cleanup walks sorted rows and stops at the cutoff boundary.
-        await ctx.db.delete(result._id)
+        await deleteResultWithReviewRuns(ctx, result._id)
         deleted++
       }
     }

--- a/convex/prReviewRuns.ts
+++ b/convex/prReviewRuns.ts
@@ -1,14 +1,15 @@
-import { v } from "convex/values";
-import { mutation, query, type DatabaseReader } from "./_generated/server";
-import type { Id } from "./_generated/dataModel";
+import { v } from 'convex/values'
+import { mutation, query, type DatabaseReader } from './_generated/server'
+import type { Id } from './_generated/dataModel'
+import { notFoundError } from './lib/domain'
 
-async function getRunByResult(db: DatabaseReader, resultId: Id<"copilotResults">) {
+async function getRunByResult(db: DatabaseReader, resultId: Id<'copilotResults'>) {
   const rows = await db
-    .query("prReviewRuns")
-    .withIndex("by_result", (q) => q.eq("resultId", resultId))
-    .take(1);
+    .query('prReviewRuns')
+    .withIndex('by_result', q => q.eq('resultId', resultId))
+    .take(1)
 
-  return rows[0] ?? null;
+  return rows[0] ?? null
 }
 
 // List recent review runs for a specific PR (newest first)
@@ -20,14 +21,16 @@ export const listByPr = query({
     limit: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const limit = args.limit ?? 25;
+    const limit = args.limit ?? 25
     return await ctx.db
-      .query("prReviewRuns")
-      .withIndex("by_pr", q => q.eq("owner", args.owner).eq("repo", args.repo).eq("prNumber", args.prNumber))
-      .order("desc")
-      .take(limit);
+      .query('prReviewRuns')
+      .withIndex('by_pr', q =>
+        q.eq('owner', args.owner).eq('repo', args.repo).eq('prNumber', args.prNumber)
+      )
+      .order('desc')
+      .take(limit)
   },
-});
+})
 
 // Get latest review run for a specific PR
 export const latestByPr = query({
@@ -38,14 +41,16 @@ export const latestByPr = query({
   },
   handler: async (ctx, args) => {
     const rows = await ctx.db
-      .query("prReviewRuns")
-      .withIndex("by_pr", q => q.eq("owner", args.owner).eq("repo", args.repo).eq("prNumber", args.prNumber))
-      .order("desc")
-      .take(1);
+      .query('prReviewRuns')
+      .withIndex('by_pr', q =>
+        q.eq('owner', args.owner).eq('repo', args.repo).eq('prNumber', args.prNumber)
+      )
+      .order('desc')
+      .take(1)
 
-    return rows[0] ?? null;
+    return rows[0] ?? null
   },
-});
+})
 
 // Create a new PR review run linked to a Copilot resultId
 export const create = mutation({
@@ -55,7 +60,7 @@ export const create = mutation({
     prNumber: v.number(),
     prUrl: v.string(),
     prTitle: v.string(),
-    resultId: v.id("copilotResults"),
+    resultId: v.id('copilotResults'),
     prompt: v.string(),
     model: v.optional(v.string()),
     ghAccount: v.optional(v.string()),
@@ -69,14 +74,17 @@ export const create = mutation({
     ),
   },
   handler: async (ctx, args) => {
-    const now = Date.now();
-    return await ctx.db.insert("prReviewRuns", {
+    const result = await ctx.db.get(args.resultId)
+    if (!result) throw notFoundError('CopilotResult', args.resultId)
+
+    const now = Date.now()
+    return await ctx.db.insert('prReviewRuns', {
       owner: args.owner,
       repo: args.repo,
       prNumber: args.prNumber,
       prUrl: args.prUrl,
       prTitle: args.prTitle,
-      status: "pending",
+      status: 'pending',
       resultId: args.resultId,
       prompt: args.prompt,
       model: args.model,
@@ -85,62 +93,62 @@ export const create = mutation({
       reviewedThreadStats: args.reviewedThreadStats,
       createdAt: now,
       updatedAt: now,
-    });
+    })
   },
-});
+})
 
 export const markRunningByResult = mutation({
   args: {
-    resultId: v.id("copilotResults"),
+    resultId: v.id('copilotResults'),
     model: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const row = await getRunByResult(ctx.db, args.resultId);
-    if (!row) return;
+    const row = await getRunByResult(ctx.db, args.resultId)
+    if (!row) return
 
     await ctx.db.patch(row._id, {
-      status: "running",
+      status: 'running',
       model: args.model ?? row.model,
       updatedAt: Date.now(),
-    });
+    })
   },
-});
+})
 
 export const completeByResult = mutation({
   args: {
-    resultId: v.id("copilotResults"),
+    resultId: v.id('copilotResults'),
     model: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const row = await getRunByResult(ctx.db, args.resultId);
-    if (!row) return;
+    const row = await getRunByResult(ctx.db, args.resultId)
+    if (!row) return
 
-    const now = Date.now();
+    const now = Date.now()
     await ctx.db.patch(row._id, {
-      status: "completed",
+      status: 'completed',
       model: args.model ?? row.model,
       completedAt: now,
       updatedAt: now,
       error: undefined,
-    });
+    })
   },
-});
+})
 
 export const failByResult = mutation({
   args: {
-    resultId: v.id("copilotResults"),
+    resultId: v.id('copilotResults'),
     error: v.string(),
   },
   handler: async (ctx, args) => {
-    const row = await getRunByResult(ctx.db, args.resultId);
-    if (!row) return;
+    const row = await getRunByResult(ctx.db, args.resultId)
+    if (!row) return
 
-    const now = Date.now();
+    const now = Date.now()
     await ctx.db.patch(row._id, {
-      status: "failed",
+      status: 'failed',
       error: args.error,
       completedAt: now,
       updatedAt: now,
-    });
+    })
   },
-});
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.916",
+  "version": "0.1.917",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",


### PR DESCRIPTION
Closes #322

## Summary
- cascade Copilot result deletion to every linked PR review run
- reject delayed review-run creation when its result no longer exists
- cover explicit deletion, cleanup, and unrelated-row retention

## Verification
- `bun run test:convex` (247 tests)
- `bun run lint`
- `bun run typecheck`
- pre-commit coverage suite (6,573 tests; 99.94% statements, 99.83% branches, 100% functions/lines)

## Risk
Medium: persisted PR review history is deleted only when its required Copilot result is deleted; indexed lookups and regression tests protect unrelated rows.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix cascade deletion of `prReviewRuns` when a Copilot result is removed
> - Introduces `deleteResultWithReviewRuns` in [`copilotResults.ts`](https://github.com/HemSoft/hs-buddy/pull/327/files#diff-9571659316b51a063f95544e06f0a1aaf03e0b05f6b85eb01a9bebca3b6097a5) that queries `prReviewRuns` by the `by_result` index and deletes linked runs before deleting the result.
> - The `remove` and `cleanup` mutations now use this helper, so deleting or cleaning up a Copilot result also removes all associated PR review runs.
> - Adds a guard in `prReviewRuns.create` that throws a not-found error if the referenced Copilot result does not exist.
> - Behavioral Change: deleting a Copilot result now cascades to delete all linked `prReviewRuns`; previously those runs were left orphaned.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 665deb9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->