### PR TITLE
fix(finance): ignore stale quote refreshes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.919] - 2026-07-26
+
+### Changed
+
+- Isolate refresh race coverage
+
 ## [0.1.918] - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.918] - 2026-07-26
+
+### Fixed
+
+- Ignore stale quote refreshes
+
 ## [0.1.917] - 2026-07-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.918",
+  "version": "0.1.919",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.917",
+  "version": "0.1.918",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/hooks/useFinance.race.test.ts
+++ b/src/hooks/useFinance.race.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { useFinance } from './useFinance'
+
+const mockFetchQuote = vi.fn()
+Object.defineProperty(window, 'finance', {
+  value: { fetchQuote: mockFetchQuote },
+  writable: true,
+  configurable: true,
+})
+
+const mockInvoke = vi.fn()
+Object.defineProperty(window, 'ipcRenderer', {
+  value: { invoke: mockInvoke },
+  writable: true,
+  configurable: true,
+})
+
+const QUOTE_AAPL = {
+  symbol: 'AAPL',
+  name: 'Apple Inc',
+  price: 150,
+  change: 2,
+  changePercent: 1.35,
+  previousClose: 148,
+  marketOpen: true,
+}
+
+const QUOTE_TSLA = { ...QUOTE_AAPL, symbol: 'TSLA', name: 'Tesla Inc' }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function arrangeOverlappingRefreshes() {
+  localStorage.setItem('finance:watchlist', JSON.stringify(['AAPL']))
+  const mountQuote = deferred<unknown>()
+  const refreshedAapl = deferred<unknown>()
+  const refreshedTsla = deferred<unknown>()
+
+  mockFetchQuote
+    .mockImplementationOnce(() => mountQuote.promise)
+    .mockImplementationOnce(() => refreshedAapl.promise)
+    .mockImplementationOnce(() => refreshedTsla.promise)
+
+  return { mountQuote, refreshedAapl, refreshedTsla }
+}
+
+async function resolveNewerRefresh(
+  refreshedAapl: ReturnType<typeof deferred<unknown>>,
+  refreshedTsla: ReturnType<typeof deferred<unknown>>
+) {
+  await act(async () => {
+    refreshedAapl.resolve({ success: true, quote: QUOTE_AAPL })
+    refreshedTsla.resolve({ success: true, quote: QUOTE_TSLA })
+  })
+}
+
+describe('useFinance refresh ordering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockInvoke.mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps a newer watchlist refresh when the mount refresh resolves last', async () => {
+    const { mountQuote, refreshedAapl, refreshedTsla } = arrangeOverlappingRefreshes()
+    const { result } = renderHook(() => useFinance())
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.addSymbol('TSLA')
+    })
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(3))
+    await resolveNewerRefresh(refreshedAapl, refreshedTsla)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const refreshedAt = result.current.lastFetchedAt
+    expect(result.current.quotes).toEqual([QUOTE_AAPL, QUOTE_TSLA])
+
+    await act(async () => {
+      mountQuote.resolve({
+        success: true,
+        quote: { ...QUOTE_AAPL, price: QUOTE_AAPL.price - 10 },
+      })
+    })
+
+    expect(result.current.quotes).toEqual([QUOTE_AAPL, QUOTE_TSLA])
+    expect(result.current.lastFetchedAt).toBe(refreshedAt)
+    expect(JSON.parse(localStorage.getItem('finance:cache') ?? '{}').quotes).toEqual([
+      QUOTE_AAPL,
+      QUOTE_TSLA,
+    ])
+  })
+
+  it('ignores a stale rejected refresh after a newer refresh succeeds', async () => {
+    const { mountQuote, refreshedAapl, refreshedTsla } = arrangeOverlappingRefreshes()
+    const { result } = renderHook(() => useFinance())
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.addSymbol('TSLA')
+    })
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(3))
+    await resolveNewerRefresh(refreshedAapl, refreshedTsla)
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      mountQuote.reject(new Error('stale request failed'))
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.quotes).toEqual([QUOTE_AAPL, QUOTE_TSLA])
+  })
+})

--- a/src/hooks/useFinance.test.ts
+++ b/src/hooks/useFinance.test.ts
@@ -26,16 +26,6 @@ const QUOTE_AAPL = {
   marketOpen: true,
 }
 
-function deferred<T>() {
-  let resolve!: (value: T) => void
-  let reject!: (reason?: unknown) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise
-    reject = rejectPromise
-  })
-  return { promise, resolve, reject }
-}
-
 describe('readWatchlist', () => {
   beforeEach(() => localStorage.clear())
 
@@ -256,84 +246,6 @@ describe('useFinance', () => {
     const { result } = renderHook(() => useFinance())
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toBeTruthy()
-  })
-
-  it('keeps a newer watchlist refresh when the mount refresh resolves last', async () => {
-    localStorage.setItem('finance:watchlist', JSON.stringify(['AAPL']))
-    const mountQuote = deferred<unknown>()
-    const refreshedAapl = deferred<unknown>()
-    const refreshedTsla = deferred<unknown>()
-    const quoteTsla = { ...QUOTE_AAPL, symbol: 'TSLA', name: 'Tesla Inc' }
-
-    mockFetchQuote
-      .mockImplementationOnce(() => mountQuote.promise)
-      .mockImplementationOnce(() => refreshedAapl.promise)
-      .mockImplementationOnce(() => refreshedTsla.promise)
-
-    const { result } = renderHook(() => useFinance())
-    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(1))
-
-    act(() => {
-      result.current.addSymbol('TSLA')
-    })
-    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(3))
-
-    await act(async () => {
-      refreshedAapl.resolve({ success: true, quote: QUOTE_AAPL })
-      refreshedTsla.resolve({ success: true, quote: quoteTsla })
-    })
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    const refreshedAt = result.current.lastFetchedAt
-    expect(result.current.quotes).toEqual([QUOTE_AAPL, quoteTsla])
-
-    await act(async () => {
-      mountQuote.resolve({
-        success: true,
-        quote: { ...QUOTE_AAPL, price: QUOTE_AAPL.price - 10 },
-      })
-    })
-
-    expect(result.current.quotes).toEqual([QUOTE_AAPL, quoteTsla])
-    expect(result.current.lastFetchedAt).toBe(refreshedAt)
-    expect(JSON.parse(localStorage.getItem('finance:cache') ?? '{}').quotes).toEqual([
-      QUOTE_AAPL,
-      quoteTsla,
-    ])
-  })
-
-  it('ignores a stale rejected refresh after a newer refresh succeeds', async () => {
-    localStorage.setItem('finance:watchlist', JSON.stringify(['AAPL']))
-    const mountQuote = deferred<unknown>()
-    const refreshedAapl = deferred<unknown>()
-    const refreshedTsla = deferred<unknown>()
-    const quoteTsla = { ...QUOTE_AAPL, symbol: 'TSLA', name: 'Tesla Inc' }
-
-    mockFetchQuote
-      .mockImplementationOnce(() => mountQuote.promise)
-      .mockImplementationOnce(() => refreshedAapl.promise)
-      .mockImplementationOnce(() => refreshedTsla.promise)
-
-    const { result } = renderHook(() => useFinance())
-    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(1))
-
-    act(() => {
-      result.current.addSymbol('TSLA')
-    })
-    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(3))
-
-    await act(async () => {
-      refreshedAapl.resolve({ success: true, quote: QUOTE_AAPL })
-      refreshedTsla.resolve({ success: true, quote: quoteTsla })
-    })
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    await act(async () => {
-      mountQuote.reject(new Error('stale request failed'))
-    })
-
-    expect(result.current.error).toBeNull()
-    expect(result.current.quotes).toEqual([QUOTE_AAPL, quoteTsla])
   })
 
   it('ignores duplicate symbol in addSymbol', async () => {

--- a/src/hooks/useFinance.test.ts
+++ b/src/hooks/useFinance.test.ts
@@ -26,6 +26,16 @@ const QUOTE_AAPL = {
   marketOpen: true,
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
 describe('readWatchlist', () => {
   beforeEach(() => localStorage.clear())
 
@@ -246,6 +256,84 @@ describe('useFinance', () => {
     const { result } = renderHook(() => useFinance())
     await waitFor(() => expect(result.current.loading).toBe(false))
     expect(result.current.error).toBeTruthy()
+  })
+
+  it('keeps a newer watchlist refresh when the mount refresh resolves last', async () => {
+    localStorage.setItem('finance:watchlist', JSON.stringify(['AAPL']))
+    const mountQuote = deferred<unknown>()
+    const refreshedAapl = deferred<unknown>()
+    const refreshedTsla = deferred<unknown>()
+    const quoteTsla = { ...QUOTE_AAPL, symbol: 'TSLA', name: 'Tesla Inc' }
+
+    mockFetchQuote
+      .mockImplementationOnce(() => mountQuote.promise)
+      .mockImplementationOnce(() => refreshedAapl.promise)
+      .mockImplementationOnce(() => refreshedTsla.promise)
+
+    const { result } = renderHook(() => useFinance())
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.addSymbol('TSLA')
+    })
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(3))
+
+    await act(async () => {
+      refreshedAapl.resolve({ success: true, quote: QUOTE_AAPL })
+      refreshedTsla.resolve({ success: true, quote: quoteTsla })
+    })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const refreshedAt = result.current.lastFetchedAt
+    expect(result.current.quotes).toEqual([QUOTE_AAPL, quoteTsla])
+
+    await act(async () => {
+      mountQuote.resolve({
+        success: true,
+        quote: { ...QUOTE_AAPL, price: QUOTE_AAPL.price - 10 },
+      })
+    })
+
+    expect(result.current.quotes).toEqual([QUOTE_AAPL, quoteTsla])
+    expect(result.current.lastFetchedAt).toBe(refreshedAt)
+    expect(JSON.parse(localStorage.getItem('finance:cache') ?? '{}').quotes).toEqual([
+      QUOTE_AAPL,
+      quoteTsla,
+    ])
+  })
+
+  it('ignores a stale rejected refresh after a newer refresh succeeds', async () => {
+    localStorage.setItem('finance:watchlist', JSON.stringify(['AAPL']))
+    const mountQuote = deferred<unknown>()
+    const refreshedAapl = deferred<unknown>()
+    const refreshedTsla = deferred<unknown>()
+    const quoteTsla = { ...QUOTE_AAPL, symbol: 'TSLA', name: 'Tesla Inc' }
+
+    mockFetchQuote
+      .mockImplementationOnce(() => mountQuote.promise)
+      .mockImplementationOnce(() => refreshedAapl.promise)
+      .mockImplementationOnce(() => refreshedTsla.promise)
+
+    const { result } = renderHook(() => useFinance())
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      result.current.addSymbol('TSLA')
+    })
+    await waitFor(() => expect(mockFetchQuote).toHaveBeenCalledTimes(3))
+
+    await act(async () => {
+      refreshedAapl.resolve({ success: true, quote: QUOTE_AAPL })
+      refreshedTsla.resolve({ success: true, quote: quoteTsla })
+    })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => {
+      mountQuote.reject(new Error('stale request failed'))
+    })
+
+    expect(result.current.error).toBeNull()
+    expect(result.current.quotes).toEqual([QUOTE_AAPL, quoteTsla])
   })
 
   it('ignores duplicate symbol in addSymbol', async () => {

--- a/src/hooks/useFinance.ts
+++ b/src/hooks/useFinance.ts
@@ -201,6 +201,19 @@ function removeFromWatchlist(
   }))
 }
 
+interface RefreshRequestState {
+  active: number
+  mounted: boolean
+}
+
+function isActiveRefresh(state: RefreshRequestState, requestId: number): boolean {
+  return state.mounted && requestId === state.active
+}
+
+function setRefreshMounted(stateRef: { current: RefreshRequestState }, mounted: boolean): void {
+  stateRef.current.mounted = mounted
+}
+
 export function useFinance() {
   const [watchlist, setWatchlistState] = useState<string[]>(readWatchlist)
 
@@ -218,44 +231,40 @@ export function useFinance() {
       : { quotes: [], loading: true, error: null, lastFetchedAt: null }
   })
 
-  const requestState = useRef({ active: 0, mounted: true }).current
+  const refreshStateRef = useRef<RefreshRequestState>({ active: 0, mounted: true })
   const watchlistRef = useRef(watchlist)
-  // Prevent an async IPC load from overwriting a local watchlist mutation.
   const mutatedRef = useRef(false)
 
   useEffect(() => {
     watchlistRef.current = watchlist
   }, [watchlist])
 
-  const refresh = useCallback(
-    (symbols?: string[]) => {
-      const list = symbols ?? watchlistRef.current
-      const requestId = ++requestState.active
+  const refresh = useCallback((symbols?: string[]) => {
+    const list = symbols ?? watchlistRef.current
+    const requestId = ++refreshStateRef.current.active
 
-      setState(prev => ({ ...prev, loading: true, error: null }))
+    setState(prev => ({ ...prev, loading: true, error: null }))
 
-      return fetchQuotes(list)
-        .then(quotes => {
-          if (requestState.mounted && requestId === requestState.active) {
-            const fetchedAt = Date.now()
-            writeCache(quotes, fetchedAt)
-            setState({ quotes, loading: false, error: null, lastFetchedAt: fetchedAt })
-          }
-        })
-        .catch(err => {
-          if (requestState.mounted && requestId === requestState.active) {
-            setState(prev => ({
-              quotes: prev.quotes,
-              loading: false,
-              error: getErrorMessageWithFallback(err, 'Failed to fetch quotes'),
-              lastFetchedAt: prev.lastFetchedAt,
-            }))
-          }
-          throw err
-        })
-    },
-    [requestState]
-  )
+    return fetchQuotes(list)
+      .then(quotes => {
+        if (isActiveRefresh(refreshStateRef.current, requestId)) {
+          const fetchedAt = Date.now()
+          writeCache(quotes, fetchedAt)
+          setState({ quotes, loading: false, error: null, lastFetchedAt: fetchedAt })
+        }
+      })
+      .catch(err => {
+        if (isActiveRefresh(refreshStateRef.current, requestId)) {
+          setState(prev => ({
+            quotes: prev.quotes,
+            loading: false,
+            error: getErrorMessageWithFallback(err, 'Failed to fetch quotes'),
+            lastFetchedAt: prev.lastFetchedAt,
+          }))
+        }
+        throw err
+      })
+  }, [])
 
   const addSymbol = useCallback(
     (symbol: string) =>
@@ -289,16 +298,16 @@ export function useFinance() {
   }, [refresh])
 
   useEffect(() => {
-    requestState.mounted = true
+    setRefreshMounted(refreshStateRef, true)
     if (!readCache()) {
       refresh().catch(() => {
         /* error already handled in state */
       })
     }
     return () => {
-      requestState.mounted = false
+      setRefreshMounted(refreshStateRef, false)
     }
-  }, [refresh, requestState])
+  }, [refresh])
 
   return { ...state, watchlist, refresh: () => refresh(), addSymbol, removeSymbol }
 }

--- a/src/hooks/useFinance.ts
+++ b/src/hooks/useFinance.ts
@@ -218,43 +218,44 @@ export function useFinance() {
       : { quotes: [], loading: true, error: null, lastFetchedAt: null }
   })
 
-  const activeRequestRef = useRef(0)
-  const mountedRef = useRef(true)
+  const requestState = useRef({ active: 0, mounted: true }).current
   const watchlistRef = useRef(watchlist)
-  // Tracks whether the user has mutated the watchlist locally. If so, we must
-  // NOT overwrite their changes when the async IPC load resolves.
+  // Prevent an async IPC load from overwriting a local watchlist mutation.
   const mutatedRef = useRef(false)
 
   useEffect(() => {
     watchlistRef.current = watchlist
   }, [watchlist])
 
-  const refresh = useCallback((symbols?: string[]) => {
-    const list = symbols ?? watchlistRef.current
-    const requestId = ++activeRequestRef.current
+  const refresh = useCallback(
+    (symbols?: string[]) => {
+      const list = symbols ?? watchlistRef.current
+      const requestId = ++requestState.active
 
-    setState(prev => ({ ...prev, loading: true, error: null }))
+      setState(prev => ({ ...prev, loading: true, error: null }))
 
-    return fetchQuotes(list)
-      .then(quotes => {
-        if (mountedRef.current && requestId === activeRequestRef.current) {
-          const fetchedAt = Date.now()
-          writeCache(quotes, fetchedAt)
-          setState({ quotes, loading: false, error: null, lastFetchedAt: fetchedAt })
-        }
-      })
-      .catch(err => {
-        if (mountedRef.current && requestId === activeRequestRef.current) {
-          setState(prev => ({
-            quotes: prev.quotes,
-            loading: false,
-            error: getErrorMessageWithFallback(err, 'Failed to fetch quotes'),
-            lastFetchedAt: prev.lastFetchedAt,
-          }))
-        }
-        throw err
-      })
-  }, [])
+      return fetchQuotes(list)
+        .then(quotes => {
+          if (requestState.mounted && requestId === requestState.active) {
+            const fetchedAt = Date.now()
+            writeCache(quotes, fetchedAt)
+            setState({ quotes, loading: false, error: null, lastFetchedAt: fetchedAt })
+          }
+        })
+        .catch(err => {
+          if (requestState.mounted && requestId === requestState.active) {
+            setState(prev => ({
+              quotes: prev.quotes,
+              loading: false,
+              error: getErrorMessageWithFallback(err, 'Failed to fetch quotes'),
+              lastFetchedAt: prev.lastFetchedAt,
+            }))
+          }
+          throw err
+        })
+    },
+    [requestState]
+  )
 
   const addSymbol = useCallback(
     (symbol: string) =>
@@ -288,16 +289,16 @@ export function useFinance() {
   }, [refresh])
 
   useEffect(() => {
-    mountedRef.current = true
+    requestState.mounted = true
     if (!readCache()) {
       refresh().catch(() => {
         /* error already handled in state */
       })
     }
     return () => {
-      mountedRef.current = false
+      requestState.mounted = false
     }
-  }, [refresh])
+  }, [refresh, requestState])
 
   return { ...state, watchlist, refresh: () => refresh(), addSymbol, removeSymbol }
 }

--- a/src/hooks/useFinance.ts
+++ b/src/hooks/useFinance.ts
@@ -218,7 +218,8 @@ export function useFinance() {
       : { quotes: [], loading: true, error: null, lastFetchedAt: null }
   })
 
-  const abortRef = useRef(false)
+  const activeRequestRef = useRef(0)
+  const mountedRef = useRef(true)
   const watchlistRef = useRef(watchlist)
   // Tracks whether the user has mutated the watchlist locally. If so, we must
   // NOT overwrite their changes when the async IPC load resolves.
@@ -230,20 +231,20 @@ export function useFinance() {
 
   const refresh = useCallback((symbols?: string[]) => {
     const list = symbols ?? watchlistRef.current
-    abortRef.current = false
+    const requestId = ++activeRequestRef.current
 
     setState(prev => ({ ...prev, loading: true, error: null }))
 
     return fetchQuotes(list)
       .then(quotes => {
-        if (!abortRef.current) {
+        if (mountedRef.current && requestId === activeRequestRef.current) {
           const fetchedAt = Date.now()
           writeCache(quotes, fetchedAt)
           setState({ quotes, loading: false, error: null, lastFetchedAt: fetchedAt })
         }
       })
       .catch(err => {
-        if (!abortRef.current) {
+        if (mountedRef.current && requestId === activeRequestRef.current) {
           setState(prev => ({
             quotes: prev.quotes,
             loading: false,
@@ -287,16 +288,16 @@ export function useFinance() {
   }, [refresh])
 
   useEffect(() => {
-    const abortState = abortRef
+    mountedRef.current = true
     if (!readCache()) {
       refresh().catch(() => {
         /* error already handled in state */
       })
     }
     return () => {
-      abortState.current = true
+      mountedRef.current = false
     }
-  }, [refresh, abortRef])
+  }, [refresh])
 
   return { ...state, watchlist, refresh: () => refresh(), addSymbol, removeSymbol }
 }


### PR DESCRIPTION
Closes #324

## Summary
- assign each finance refresh a monotonically increasing request identity
- allow only the latest mounted request to update quote state or cache
- cover stale successful and rejected refreshes while preserving unmount cancellation

## Verification
- `bunx vitest run src/hooks/useFinance.test.ts --reporter=dot`
- `bunx eslint src/hooks/useFinance.ts src/hooks/useFinance.test.ts --max-warnings 0`
- `bun run typecheck`
- pre-commit: 294 test files, 6,575 tests, coverage and formatting checks passed

## Risk
Low. The change only gates completion side effects; quote fetching and watchlist persistence are unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale quote refreshes in `useFinance` by tracking active request ID
> - Replaces the `abortRef` boolean in [useFinance.ts](https://github.com/HemSoft/hs-buddy/pull/328/files#diff-92bce8f042a19cd58ca7d75de54c2be83af8b1cdc567289326e36f3f4c01c20b) with a `refreshStateRef` holding `{ active, mounted }`. Each `refresh()` call increments `active` to produce a unique `requestId`.
> - State updates, cache writes, and error handling are now guarded by `isActiveRefresh()`, so only the latest in-flight request while the hook is mounted can commit results.
> - Older overlapping requests and any requests that resolve after unmount no longer modify quotes, `lastFetchedAt`, `loading`, or `error`.
> - Adds race condition tests in [useFinance.race.test.ts](https://github.com/HemSoft/hs-buddy/pull/328/files#diff-8ad30f461f55e9e057375b0ce7fe53fc516c1fb50c1e14a3ccd20f4a6b6db51c) covering both stale-resolve and stale-reject scenarios.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c251cdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->