### PR TITLE
fix(tempo): ignore stale schedule responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.920] - 2026-07-26
+
+### Fixed
+
+- Ignore stale schedule responses
+
 ## [0.1.919] - 2026-07-26
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.919",
+  "version": "0.1.920",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/hooks/useTempo.test.ts
+++ b/src/hooks/useTempo.test.ts
@@ -194,6 +194,61 @@ describe('useUserSchedule', () => {
     expect(result.current.error).toBe('Failed to load schedule')
   })
 
+  it('keeps the newer schedule when the previous date range resolves last', async () => {
+    const aprilDays = [{ date: '2026-04-13', requiredSeconds: 28800, type: 'WORKING_DAY' }]
+    const mayDays = [{ date: '2026-05-01', requiredSeconds: 0, type: 'HOLIDAY' }]
+    let resolveApril!: (value: { success: boolean; data: typeof aprilDays }) => void
+    let resolveMay!: (value: { success: boolean; data: typeof mayDays }) => void
+    mockGetSchedule
+      .mockReturnValueOnce(new Promise(resolve => (resolveApril = resolve)))
+      .mockReturnValueOnce(new Promise(resolve => (resolveMay = resolve)))
+
+    const { result, rerender } = renderHook(({ from, to }) => useUserSchedule(from, to), {
+      initialProps: { from: '2026-04-01', to: '2026-04-30' },
+    })
+    rerender({ from: '2026-05-01', to: '2026-05-31' })
+
+    await act(async () => resolveMay({ success: true, data: mayDays }))
+    expect(result.current.schedule).toEqual(mayDays)
+    await act(async () => resolveApril({ success: true, data: aprilDays }))
+    expect(result.current.schedule).toEqual(mayDays)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('ignores a stale failure after the current date range succeeds', async () => {
+    const mayDays = [{ date: '2026-05-01', requiredSeconds: 0, type: 'HOLIDAY' }]
+    let resolveApril!: (value: { success: boolean; error: string }) => void
+    let resolveMay!: (value: { success: boolean; data: typeof mayDays }) => void
+    mockGetSchedule
+      .mockReturnValueOnce(new Promise(resolve => (resolveApril = resolve)))
+      .mockReturnValueOnce(new Promise(resolve => (resolveMay = resolve)))
+
+    const { result, rerender } = renderHook(({ from, to }) => useUserSchedule(from, to), {
+      initialProps: { from: '2026-04-01', to: '2026-04-30' },
+    })
+    rerender({ from: '2026-05-01', to: '2026-05-31' })
+
+    await act(async () => resolveMay({ success: true, data: mayDays }))
+    await act(async () => resolveApril({ success: false, error: 'April failed' }))
+    expect(result.current.schedule).toEqual(mayDays)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('refreshes the current date range', async () => {
+    const initialDays = [{ date: '2026-04-13', requiredSeconds: 28800, type: 'WORKING_DAY' }]
+    const refreshedDays = [{ date: '2026-04-14', requiredSeconds: 28800, type: 'WORKING_DAY' }]
+    mockGetSchedule
+      .mockResolvedValueOnce({ success: true, data: initialDays })
+      .mockResolvedValueOnce({ success: true, data: refreshedDays })
+    const { result } = renderHook(() => useUserSchedule('2026-04-01', '2026-04-30'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(async () => result.current.refresh())
+
+    expect(mockGetSchedule).toHaveBeenLastCalledWith('2026-04-01', '2026-04-30')
+    expect(result.current.schedule).toEqual(refreshedDays)
+  })
+
   it('skips stale schedule result after unmount', async () => {
     let resolveSchedule!: (v: unknown) => void
     mockGetSchedule.mockReturnValue(new Promise(r => (resolveSchedule = r)))

--- a/src/hooks/useTempo.ts
+++ b/src/hooks/useTempo.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import type {
   TempoDaySummary,
   TempoWorklog,
@@ -113,11 +113,17 @@ export function useUserSchedule(from: string, to: string) {
   const [schedule, setSchedule] = useState<TempoScheduleDay[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const requestIdRef = useRef(0)
+  const invalidateRequests = useCallback(() => {
+    requestIdRef.current++
+  }, [])
 
   const load = useCallback(async () => {
+    const requestId = ++requestIdRef.current
     setLoading(true)
     setError(null)
     const result = await window.tempo.getSchedule(from, to)
+    if (requestId !== requestIdRef.current) return
     if (result.success && result.data) {
       setSchedule(result.data)
     } else {
@@ -127,14 +133,9 @@ export function useUserSchedule(from: string, to: string) {
   }, [from, to])
 
   useEffect(() => {
-    let stale = false
-    load().then(() => {
-      if (stale) return
-    })
-    return () => {
-      stale = true
-    }
-  }, [load])
+    void load()
+    return invalidateRequests
+  }, [invalidateRequests, load])
 
   return { schedule, loading, error, refresh: load }
 }


### PR DESCRIPTION
Closes #323

## Summary
- guard schedule state updates with a per-request sequence
- invalidate pending schedule requests when the date range changes or the hook unmounts
- cover reversed response order, stale failures, and manual refresh

## Verification
- `bun run test` (295 files, 6578 tests)
- `bun run test:coverage` (99.94% statements, 99.83% branches, 100% functions/lines)
- `bun run lint`
- `bun run typecheck`
- `bun run knip`
- `bunx vite build`

## Risk
Low. The change is isolated to `useUserSchedule`; the newest request remains authoritative and existing refresh behavior is covered.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale schedule responses in `useUserSchedule` hook
> When `from`/`to` props change or the component unmounts, in-flight `getSchedule` requests could overwrite newer results. A ref-based request ID counter is introduced in [useTempo.ts](https://github.com/HemSoft/hs-buddy/pull/329/files#diff-2ae6eb5824426ce3c6be14b20561112dd935628c00108aebc6f715f48e7d3c99): each call to `load()` captures the current ID, and the response is discarded if the ID no longer matches by the time it resolves. Stale errors are also suppressed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df7f050.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->