### PR TITLE
fix(weather): ignore stale pollen responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.923] - 2026-07-26
+
+### Changed
+
+- Assert stale requests clear loading
+
 ## [0.1.922] - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.922] - 2026-07-26
+
+### Fixed
+
+- Invalidate stale pollen requests earlier
+
 ## [0.1.921] - 2026-07-26
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.921] - 2026-07-26
+
+### Fixed
+
+- Ignore stale pollen responses
+
 ## [0.1.920] - 2026-07-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.921",
+  "version": "0.1.922",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.920",
+  "version": "0.1.921",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hemsoft/buddy",
   "private": true,
-  "version": "0.1.922",
+  "version": "0.1.923",
   "description": "Your universal productivity companion - manage skills, tasks, and workflows",
   "type": "module",
   "main": "dist-electron/main.js",

--- a/src/hooks/usePollen.test.ts
+++ b/src/hooks/usePollen.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act, waitFor } from '@testing-library/react'
+import { useLayoutEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   usePollen,
@@ -315,6 +316,57 @@ describe('usePollen', () => {
 
     await act(async () => {
       resolveOldRequest({ success: true, data: MOCK_POLLEN })
+    })
+    expect(result.current.data).toEqual(newPollen)
+  })
+
+  it('invalidates the previous location request before passive effects run', async () => {
+    const newLocation = { latitude: 40.7128, longitude: -74.006 }
+    const newPollen: PollenData = {
+      tree: 2,
+      grass: 3,
+      weed: 4,
+      species: [],
+      healthRecommendations: [],
+    }
+    let resolveOldRequest!: (value: unknown) => void
+    let resolveNewRequest!: (value: unknown) => void
+    mockInvoke
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveOldRequest = resolve
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveNewRequest = resolve
+        })
+      )
+
+    const { result, rerender } = renderHook(
+      ({ location }) => {
+        const pollen = usePollen(location)
+        useLayoutEffect(() => {
+          if (location === newLocation) {
+            resolveOldRequest({ success: true, data: MOCK_POLLEN })
+          }
+        }, [location])
+        return pollen
+      },
+      { initialProps: { location: MOCK_LOCATION } }
+    )
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(1)
+    })
+
+    rerender({ location: newLocation })
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2)
+    })
+
+    expect(result.current.data).toBeNull()
+    await act(async () => {
+      resolveNewRequest({ success: true, data: newPollen })
     })
     expect(result.current.data).toEqual(newPollen)
   })

--- a/src/hooks/usePollen.test.ts
+++ b/src/hooks/usePollen.test.ts
@@ -411,12 +411,14 @@ describe('usePollen', () => {
     })
     expect(result.current.data).toEqual(newPollen)
     expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
 
     await act(async () => {
       rejectOldRequest(new Error('Previous location failed'))
     })
     expect(result.current.data).toEqual(newPollen)
     expect(result.current.error).toBeNull()
+    expect(result.current.loading).toBe(false)
   })
 
   it('handles IPC unavailable gracefully (test environment)', async () => {

--- a/src/hooks/usePollen.test.ts
+++ b/src/hooks/usePollen.test.ts
@@ -23,6 +23,7 @@ const mockInvoke = vi.fn()
 
 beforeEach(() => {
   vi.useFakeTimers({ shouldAdvanceTime: true })
+  mockInvoke.mockReset()
   localStorage.clear()
   clearPollenCache()
   window.ipcRenderer = { invoke: mockInvoke } as never
@@ -270,6 +271,100 @@ describe('usePollen', () => {
     await waitFor(() => {
       expect(result2.current.data).toEqual(newPollen)
     })
+  })
+
+  it('ignores a previous location response that resolves after the active location', async () => {
+    const newLocation = { latitude: 40.7128, longitude: -74.006 }
+    const newPollen: PollenData = {
+      tree: 5,
+      grass: 4,
+      weed: 3,
+      species: [],
+      healthRecommendations: [],
+    }
+    let resolveOldRequest!: (value: unknown) => void
+    let resolveNewRequest!: (value: unknown) => void
+    mockInvoke
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveOldRequest = resolve
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveNewRequest = resolve
+        })
+      )
+
+    const { result, rerender } = renderHook(({ location }) => usePollen(location), {
+      initialProps: { location: MOCK_LOCATION },
+    })
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(1)
+    })
+
+    rerender({ location: newLocation })
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      resolveNewRequest({ success: true, data: newPollen })
+    })
+    expect(result.current.data).toEqual(newPollen)
+
+    await act(async () => {
+      resolveOldRequest({ success: true, data: MOCK_POLLEN })
+    })
+    expect(result.current.data).toEqual(newPollen)
+  })
+
+  it('ignores a previous location error after the active location succeeds', async () => {
+    const newLocation = { latitude: 40.7128, longitude: -74.006 }
+    const newPollen: PollenData = {
+      tree: 4,
+      grass: 3,
+      weed: 2,
+      species: [],
+      healthRecommendations: [],
+    }
+    let rejectOldRequest!: (reason: Error) => void
+    let resolveNewRequest!: (value: unknown) => void
+    mockInvoke
+      .mockReturnValueOnce(
+        new Promise((_, reject) => {
+          rejectOldRequest = reject
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveNewRequest = resolve
+        })
+      )
+
+    const { result, rerender } = renderHook(({ location }) => usePollen(location), {
+      initialProps: { location: MOCK_LOCATION },
+    })
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(1)
+    })
+
+    rerender({ location: newLocation })
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      resolveNewRequest({ success: true, data: newPollen })
+    })
+    expect(result.current.data).toEqual(newPollen)
+    expect(result.current.error).toBeNull()
+
+    await act(async () => {
+      rejectOldRequest(new Error('Previous location failed'))
+    })
+    expect(result.current.data).toEqual(newPollen)
+    expect(result.current.error).toBeNull()
   })
 
   it('handles IPC unavailable gracefully (test environment)', async () => {

--- a/src/hooks/usePollen.ts
+++ b/src/hooks/usePollen.ts
@@ -155,6 +155,7 @@ function applyPollenFetchError(
 export function usePollen(location: { latitude: number; longitude: number } | null) {
   const [state, setState] = useState<PollenState>({ data: null, loading: false, error: null })
   const mountedRef = useRef(true)
+  const requestIdRef = useRef(0)
 
   useEffect(() => {
     mountedRef.current = true
@@ -166,6 +167,7 @@ export function usePollen(location: { latitude: number; longitude: number } | nu
   const refresh = useCallback(async () => {
     if (!location) return
 
+    const requestId = ++requestIdRef.current
     const { latitude, longitude } = location
 
     const cachedState = readCachedPollenState(latitude, longitude)
@@ -178,15 +180,17 @@ export function usePollen(location: { latitude: number; longitude: number } | nu
 
     try {
       const result = await fetchPollen(latitude, longitude)
-      if (!mountedRef.current) return
+      if (!mountedRef.current || requestId !== requestIdRef.current) return
       setState(prev => resolvePollenState(result, prev, latitude, longitude))
     } catch (err: unknown) {
+      if (requestId !== requestIdRef.current) return
       applyPollenFetchError(mountedRef, setState, err)
     }
   }, [location])
 
   // Fetch on mount and when location changes
   useEffect(() => {
+    requestIdRef.current += 1
     if (location) {
       refresh()
     }

--- a/src/hooks/usePollen.ts
+++ b/src/hooks/usePollen.ts
@@ -1,6 +1,7 @@
 import {
   useState,
   useEffect,
+  useLayoutEffect,
   useCallback,
   useRef,
   type Dispatch,
@@ -156,6 +157,15 @@ export function usePollen(location: { latitude: number; longitude: number } | nu
   const [state, setState] = useState<PollenState>({ data: null, loading: false, error: null })
   const mountedRef = useRef(true)
   const requestIdRef = useRef(0)
+  const locationKey = location ? `${location.latitude}:${location.longitude}` : null
+  const previousLocationKeyRef = useRef(locationKey)
+
+  useLayoutEffect(() => {
+    if (previousLocationKeyRef.current !== locationKey) {
+      previousLocationKeyRef.current = locationKey
+      requestIdRef.current += 1
+    }
+  }, [locationKey])
 
   useEffect(() => {
     mountedRef.current = true
@@ -190,7 +200,6 @@ export function usePollen(location: { latitude: number; longitude: number } | nu
 
   // Fetch on mount and when location changes
   useEffect(() => {
-    requestIdRef.current += 1
     if (location) {
       refresh()
     }


### PR DESCRIPTION
## Summary
- track pollen request generations so superseded locations cannot update state or cache
- ignore stale success and rejection results after the active location succeeds
- cover same-hook location rerenders while preserving cache and manual refresh behavior

## Verification
- `bun x vitest run src/hooks/usePollen.test.ts`
- `bun run lint`
- `bun run test`
- `bun run test:coverage`
- `bun run typecheck`
- `bun run knip`
- `bun x vite build`

## Risk
Low: the change is isolated to pollen request result application and adds regression coverage for both response paths.

Closes #325

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `usePollen` hook to ignore stale pollen responses from previous locations
> - Introduces a `requestIdRef` counter in [`usePollen.ts`](https://github.com/HemSoft/hs-buddy/pull/330/files#diff-e58ec5da98d544096bd55e8d9191661171bd1ee0dbb2ede5626d19c97dd7f558) to track the active request; state updates from older requests are discarded.
> - Uses `useLayoutEffect` to increment the request ID when the location changes, invalidating in-flight requests before passive effects run.
> - Both success and error paths now check that the captured request ID still matches the current one before applying any state changes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1be432e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->